### PR TITLE
Fix Postgres identity retrieval

### DIFF
--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -22,7 +22,7 @@ namespace nORM.Providers
         public string ParamPrefix { get; protected init; } = "@";
         public abstract string Escape(string id);
         public abstract void ApplyPaging(StringBuilder sb, int? limit, int? offset);
-        public abstract string GetIdentityRetrievalString();
+        public abstract string GetIdentityRetrievalString(TableMapping m);
         public abstract DbParameter CreateParameter(string name, object? value);
 
         #region Bulk Operations (Abstract & Fallback)
@@ -195,7 +195,7 @@ namespace nORM.Providers
                 var cols = m.Columns.Where(c => !c.IsDbGenerated);
                 var colNames = string.Join(", ", cols.Select(c => c.EscCol));
                 var valParams = string.Join(", ", cols.Select(c => ParamPrefix + c.PropName));
-                return $"INSERT INTO {m.EscTable} ({colNames}) VALUES ({valParams}){GetIdentityRetrievalString()}";
+                return $"INSERT INTO {m.EscTable} ({colNames}) VALUES ({valParams}){GetIdentityRetrievalString(m)}";
             });
         }
 

--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -21,7 +21,7 @@ namespace nORM.Providers
             if (limit.HasValue) sb.Append($" LIMIT {offset ?? 0}, {limit}");
         }
         
-        public override string GetIdentityRetrievalString() => "; SELECT LAST_INSERT_ID();";
+        public override string GetIdentityRetrievalString(TableMapping m) => "; SELECT LAST_INSERT_ID();";
         
         public override System.Data.Common.DbParameter CreateParameter(string name, object? value)
         {

--- a/src/nORM/Providers/PostgresProvider.cs
+++ b/src/nORM/Providers/PostgresProvider.cs
@@ -24,7 +24,11 @@ namespace nORM.Providers
             if (offset.HasValue) sb.Append($" OFFSET {offset}");
         }
         
-        public override string GetIdentityRetrievalString() => " RETURNING id";
+        public override string GetIdentityRetrievalString(TableMapping m)
+        {
+            var keyCol = m.KeyColumns.FirstOrDefault(c => c.IsDbGenerated);
+            return keyCol != null ? $" RETURNING {keyCol.EscCol}" : string.Empty;
+        }
         
         public override System.Data.Common.DbParameter CreateParameter(string name, object? value)
         {

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -28,7 +28,7 @@ namespace nORM.Providers
             }
         }
         
-        public override string GetIdentityRetrievalString() => "; SELECT SCOPE_IDENTITY();";
+        public override string GetIdentityRetrievalString(TableMapping m) => "; SELECT SCOPE_IDENTITY();";
         
         public override System.Data.Common.DbParameter CreateParameter(string name, object? value)
         {

--- a/src/nORM/Providers/SqliteProvider.cs
+++ b/src/nORM/Providers/SqliteProvider.cs
@@ -26,7 +26,7 @@ namespace nORM.Providers
             if (offset.HasValue) sb.Append($" OFFSET {offset}");
         }
         
-        public override string GetIdentityRetrievalString() => "; SELECT last_insert_rowid();";
+        public override string GetIdentityRetrievalString(TableMapping m) => "; SELECT last_insert_rowid();";
         
         public override DbParameter CreateParameter(string name, object? value)
         {


### PR DESCRIPTION
## Summary
- allow providers to determine identity retrieval using table metadata
- generate PostgreSQL RETURNING clause based on the actual db-generated key column

## Testing
- `dotnet build src/nORM.csproj -p:GeneratePackageOnBuild=false`

------
https://chatgpt.com/codex/tasks/task_e_68b6e65e41f8832c807e4443da776aad