### PR TITLE
Refactor Any translation to return bool

### DIFF
--- a/src/nORM/Core/NormAsyncExtensions.cs
+++ b/src/nORM/Core/NormAsyncExtensions.cs
@@ -80,12 +80,11 @@ namespace nORM.Core
             if (source.Provider is Query.NormQueryProvider normProvider)
             {
                 var anyExpression = Expression.Call(
-                    typeof(Queryable), 
-                    nameof(Queryable.Any), 
-                    new[] { typeof(T) }, 
+                    typeof(Queryable),
+                    nameof(Queryable.Any),
+                    new[] { typeof(T) },
                     source.Expression);
-                var result = await normProvider.ExecuteAsync<int>(anyExpression, ct);
-                return result > 0;
+                return await normProvider.ExecuteAsync<bool>(anyExpression, ct);
             }
             
             throw new InvalidOperationException(

--- a/src/nORM/Core/NormQueryable.cs
+++ b/src/nORM/Core/NormQueryable.cs
@@ -78,7 +78,7 @@ namespace nORM.Core
         public Task<List<T>> ToListAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<List<T>>(Expression, ct);
         public async Task<T[]> ToArrayAsync(CancellationToken ct = default) => (await ToListAsync(ct)).ToArray();
         public Task<int> CountAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<int>(Expression.Call(typeof(Queryable), nameof(Queryable.Count), new[] { typeof(T) }, Expression), ct);
-        public async Task<bool> AnyAsync(CancellationToken ct = default) => await ((NormQueryProvider)Provider).ExecuteAsync<int>(Expression.Call(typeof(Queryable), nameof(Queryable.Any), new[] { typeof(T) }, Expression), ct) > 0;
+        public async Task<bool> AnyAsync(CancellationToken ct = default) => await ((NormQueryProvider)Provider).ExecuteAsync<bool>(Expression.Call(typeof(Queryable), nameof(Queryable.Any), new[] { typeof(T) }, Expression), ct);
         public Task<T> FirstAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<T>(Expression.Call(typeof(Queryable), nameof(Queryable.First), new[] { typeof(T) }, Expression), ct);
         public Task<T?> FirstOrDefaultAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<T?>(Expression.Call(typeof(Queryable), nameof(Queryable.FirstOrDefault), new[] { typeof(T) }, Expression), ct);
         public Task<T> SingleAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<T>(Expression.Call(typeof(Queryable), nameof(Queryable.Single), new[] { typeof(T) }, Expression), ct);

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -629,14 +629,14 @@ namespace nORM.Query
             switch (node.Method.Name)
             {
                 case "Any":
-                    _sql.Append("SELECT CASE WHEN EXISTS(");
+                    _sql.Append("SELECT 1 WHERE EXISTS(");
                     _sql.Append(subPlan.Sql);
-                    _sql.Append(") THEN 1 ELSE 0 END");
+                    _sql.Append(")");
                     break;
                 case "All":
-                    _sql.Append("SELECT CASE WHEN NOT EXISTS(");
+                    _sql.Append("SELECT 1 WHERE NOT EXISTS(");
                     _sql.Append(subPlan.Sql);
-                    _sql.Append(") THEN 1 ELSE 0 END");
+                    _sql.Append(")");
                     break;
                 case "Contains":
                     return Visit(node.Arguments[0]);


### PR DESCRIPTION
## Summary
- simplify AnyAsync to execute bool instead of int comparison
- translate Any/All using EXISTS to avoid CASE wrapping

## Testing
- `dotnet build src/nORM.csproj -p:GeneratePackageOnBuild=false`


------
https://chatgpt.com/codex/tasks/task_e_68b6e796d314832caa5ea06d987c5715