### PR TITLE
Use structural expression fingerprint for plan cache key

### DIFF
--- a/src/nORM/Query/ExpressionFingerprint.cs
+++ b/src/nORM/Query/ExpressionFingerprint.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace nORM.Query
+{
+    internal static class ExpressionFingerprint
+    {
+        public static int Compute(Expression expression)
+        {
+            var visitor = new FingerprintVisitor();
+            visitor.Visit(expression);
+            return visitor.Hash;
+        }
+
+        private sealed class FingerprintVisitor : ExpressionVisitor
+        {
+            private readonly HashCode _hash = new();
+            private readonly Dictionary<ParameterExpression, int> _parameters = new();
+
+            public int Hash => _hash.ToHashCode();
+
+            public override Expression? Visit(Expression? node)
+            {
+                if (node == null)
+                    return null;
+
+                _hash.Add(node.NodeType);
+                _hash.Add(node.Type.FullName);
+
+                return base.Visit(node);
+            }
+
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                // Ignore constant value; base.VisitConstant does nothing
+                return node;
+            }
+
+            protected override Expression VisitMember(MemberExpression node)
+            {
+                _hash.Add(node.Member.Module.ModuleVersionId);
+                _hash.Add(node.Member.MetadataToken);
+                return base.VisitMember(node);
+            }
+
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                _hash.Add(node.Method.Module.ModuleVersionId);
+                _hash.Add(node.Method.MetadataToken);
+                return base.VisitMethodCall(node);
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                if (!_parameters.TryGetValue(node, out var id))
+                {
+                    id = _parameters.Count;
+                    _parameters[node] = id;
+                }
+                _hash.Add(id);
+                _hash.Add(node.Type.FullName);
+                return base.VisitParameter(node);
+            }
+
+            protected override Expression VisitLambda<T>(Expression<T> node)
+            {
+                foreach (var parameter in node.Parameters)
+                {
+                    if (!_parameters.ContainsKey(parameter))
+                    {
+                        int id = _parameters.Count;
+                        _parameters[parameter] = id;
+                    }
+                }
+                return base.VisitLambda(node);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ExpressionFingerprint` to generate structural hashes for LINQ expressions
- use fingerprint and tenant id in `QueryPlanCacheKey` instead of expression strings

## Testing
- `dotnet build src/nORM.csproj`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b6ec7c2638832c8fee0307f919db56