### PR TITLE
Use GetFieldValue for scalar materialization

### DIFF
--- a/src/nORM/Internal/Methods.cs
+++ b/src/nORM/Internal/Methods.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Reflection;
 
 #nullable enable
@@ -22,6 +23,7 @@ namespace nORM.Internal
         public static readonly MethodInfo GetGuid = typeof(IDataRecord).GetMethod(nameof(IDataRecord.GetGuid))!;
         public static readonly MethodInfo GetString = typeof(IDataRecord).GetMethod(nameof(IDataRecord.GetString))!;
         public static readonly MethodInfo GetBytes = typeof(IDataRecord).GetMethod(nameof(IDataRecord.GetValue))!;
+        public static readonly MethodInfo GetFieldValue = typeof(DbDataReader).GetMethod(nameof(DbDataReader.GetFieldValue))!;
 
         internal static MethodInfo GetReaderMethod(Type type)
         {

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -145,10 +145,10 @@ namespace nORM.Query
 
             if (targetType.IsPrimitive || targetType == typeof(decimal) || targetType == typeof(string))
             {
+                var fieldValue = Methods.GetFieldValue.MakeGenericMethod(targetType);
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Callvirt, Methods.GetReaderMethod(targetType));
-                if (Methods.GetReaderMethod(targetType).Name == "GetValue") il.Emit(OpCodes.Unbox_Any, targetType);
+                il.Emit(OpCodes.Callvirt, fieldValue);
             }
             else if (projection?.Body is NewExpression newExpr)
             {
@@ -215,7 +215,7 @@ namespace nORM.Query
                     il.Emit(OpCodes.Ldc_I4, i);
                     var readerMethod = Methods.GetReaderMethod(col.Prop.PropertyType);
                     il.Emit(OpCodes.Callvirt, readerMethod);
-                    if (readerMethod.Name == "GetValue") il.Emit(OpCodes.Unbox_Any, col.Prop.PropertyType);
+                    if (readerMethod == Methods.GetValue) il.Emit(OpCodes.Unbox_Any, col.Prop.PropertyType);
                     il.Emit(OpCodes.Callvirt, col.SetterMethod);
                     il.MarkLabel(endOfBlock);
                 }
@@ -251,7 +251,7 @@ namespace nORM.Query
                 il.Emit(OpCodes.Ldc_I4, startColumnIndex + i);
                 var readerMethod = Methods.GetReaderMethod(col.Prop.PropertyType);
                 il.Emit(OpCodes.Callvirt, readerMethod);
-                if (readerMethod.Name == "GetValue") il.Emit(OpCodes.Unbox_Any, col.Prop.PropertyType);
+                if (readerMethod == Methods.GetValue) il.Emit(OpCodes.Unbox_Any, col.Prop.PropertyType);
                 il.Emit(OpCodes.Callvirt, col.SetterMethod);
                 il.MarkLabel(endOfBlock);
             }
@@ -272,7 +272,7 @@ namespace nORM.Query
             il.Emit(OpCodes.Ldc_I4, columnIndex);
             var readerMethod = Methods.GetReaderMethod(column.Prop.PropertyType);
             il.Emit(OpCodes.Callvirt, readerMethod);
-            if (readerMethod.Name == "GetValue") il.Emit(OpCodes.Unbox_Any, column.Prop.PropertyType);
+            if (readerMethod == Methods.GetValue) il.Emit(OpCodes.Unbox_Any, column.Prop.PropertyType);
             il.Emit(OpCodes.Stloc, localVar);
             il.MarkLabel(endOfBlock);
         }


### PR DESCRIPTION
## Summary
- leverage `DbDataReader.GetFieldValue<T>` for scalar materialization
- avoid repeated lookups by comparing cached reader methods

## Testing
- `dotnet test`
- `dotnet build src/nORM.csproj -p:GeneratePackageOnBuild=false`


------
https://chatgpt.com/codex/tasks/task_e_68b6edace564832c98dfca8f7f3c9fd9