### PR TITLE
Implement LRU cache for materializers

### DIFF
--- a/src/nORM/Internal/ConcurrentLruCache.cs
+++ b/src/nORM/Internal/ConcurrentLruCache.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace nORM.Internal
+{
+    public class ConcurrentLruCache<TKey, TValue> where TKey : notnull
+    {
+        private readonly ConcurrentDictionary<TKey, LinkedListNode<CacheItem>> _cache = new();
+        private readonly LinkedList<CacheItem> _lruList = new();
+        private readonly object _lock = new();
+        private readonly int _maxSize;
+
+        public ConcurrentLruCache(int maxSize)
+        {
+            _maxSize = maxSize;
+        }
+
+        public TValue GetOrAdd(TKey key, Func<TKey, TValue> factory)
+        {
+            if (_cache.TryGetValue(key, out var node))
+            {
+                lock (_lock)
+                {
+                    _lruList.Remove(node);
+                    _lruList.AddFirst(node);
+                }
+                return node.Value.Value;
+            }
+
+            var value = factory(key);
+            var newNode = new LinkedListNode<CacheItem>(new CacheItem(key, value));
+
+            lock (_lock)
+            {
+                if (_cache.TryAdd(key, newNode))
+                {
+                    _lruList.AddFirst(newNode);
+
+                    if (_lruList.Count > _maxSize)
+                    {
+                        var lastNode = _lruList.Last!;
+                        _lruList.RemoveLast();
+                        _cache.TryRemove(lastNode.Value.Key, out _);
+                    }
+                }
+            }
+
+            return value;
+        }
+
+        private record CacheItem(TKey Key, TValue Value);
+    }
+}
+

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -40,7 +39,7 @@ namespace nORM.Query
         private bool _singleResult = false;
         
         // Cache materializers to reduce memory allocations
-        private static readonly ConcurrentDictionary<(Type MappingType, Type TargetType, string? ProjectionKey), Func<DbDataReader, object>> _materializerCache = new();
+        private static readonly ConcurrentLruCache<(Type MappingType, Type TargetType, string? ProjectionKey), Func<DbDataReader, object>> _materializerCache = new(maxSize: 1000);
 
         // Initialize _groupJoinInfo in constructor to suppress warning
         // This field is used in complex join scenarios


### PR DESCRIPTION
## Summary
- prevent unbounded growth of materializer cache by replacing `ConcurrentDictionary` with bounded `ConcurrentLruCache`
- add generic `ConcurrentLruCache` implementation with eviction of least recently used entries

## Testing
- `dotnet test`
- `dotnet build` *(fails: File not found '/workspace/README.md'; ambiguous methods in benchmark project)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f63e8280832c9baccc90878c8ff1