### PR TITLE
Harden LIKE pattern escaping across providers

### DIFF
--- a/src/nORM/Internal/Extensions.cs
+++ b/src/nORM/Internal/Extensions.cs
@@ -16,12 +16,5 @@ namespace nORM.Internal
             cmd.Parameters.Add(p);
         }
 
-        public static string EscapeLike(this string value)
-        {
-            return value
-                .Replace("\\", "\\\\")
-                .Replace("%", "\\%")
-                .Replace("_", "\\_");
-        }
     }
 }

--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -25,6 +25,17 @@ namespace nORM.Providers
         public abstract string GetIdentityRetrievalString(TableMapping m);
         public abstract DbParameter CreateParameter(string name, object? value);
 
+        public virtual char LikeEscapeChar => '\\';
+
+        public virtual string EscapeLikePattern(string value)
+        {
+            var esc = LikeEscapeChar.ToString();
+            return value
+                .Replace(esc, esc + esc)
+                .Replace("%", esc + "%")
+                .Replace("_", esc + "_");
+        }
+
         #region Bulk Operations (Abstract & Fallback)
         public virtual async Task<int> BulkInsertAsync<T>(DbContext ctx, TableMapping m, IEnumerable<T> entities, CancellationToken ct) where T : class
         {

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -32,11 +32,21 @@ namespace nORM.Providers
         }
         
         public override string GetIdentityRetrievalString(TableMapping m) => "; SELECT SCOPE_IDENTITY();";
-        
+
         public override System.Data.Common.DbParameter CreateParameter(string name, object? value)
         {
             var param = new SqlParameter(name, value ?? DBNull.Value);
             return param;
+        }
+
+        public override string EscapeLikePattern(string value)
+        {
+            var escaped = base.EscapeLikePattern(value);
+            var esc = LikeEscapeChar.ToString();
+            return escaped
+                .Replace("[", esc + "[")
+                .Replace("]", esc + "]")
+                .Replace("^", esc + "^");
         }
 
         #region SQL Server Bulk Operations

--- a/src/nORM/Query/ExpressionToSqlVisitor.cs
+++ b/src/nORM/Query/ExpressionToSqlVisitor.cs
@@ -8,7 +8,6 @@ using System.Text;
 using nORM.Core;
 using nORM.Mapping;
 using nORM.Providers;
-using nORM.Internal;
 
 #nullable enable
 
@@ -105,8 +104,8 @@ namespace nORM.Query
                         if (TryGetConstantValue(node.Arguments[0], out var contains) && contains is string cs)
                         {
                             var containsParam = $"{_provider.ParamPrefix}p{_paramIndex++}";
-                            _params[containsParam] = $"%{cs.EscapeLike()}%";
-                            _sql.Append(containsParam).Append(" ESCAPE '\\'");
+                            _params[containsParam] = $"%{_provider.EscapeLikePattern(cs)}%";
+                            _sql.Append(containsParam).Append($" ESCAPE '{_provider.LikeEscapeChar}'");
                         }
                         else
                         {
@@ -118,8 +117,8 @@ namespace nORM.Query
                         if (TryGetConstantValue(node.Arguments[0], out var starts) && starts is string ss)
                         {
                             var startsParam = $"{_provider.ParamPrefix}p{_paramIndex++}";
-                            _params[startsParam] = $"{ss.EscapeLike()}%";
-                            _sql.Append(startsParam).Append(" ESCAPE '\\'");
+                            _params[startsParam] = $"{_provider.EscapeLikePattern(ss)}%";
+                            _sql.Append(startsParam).Append($" ESCAPE '{_provider.LikeEscapeChar}'");
                         }
                         else
                         {
@@ -131,8 +130,8 @@ namespace nORM.Query
                         if (TryGetConstantValue(node.Arguments[0], out var ends) && ends is string es)
                         {
                             var endsParam = $"{_provider.ParamPrefix}p{_paramIndex++}";
-                            _params[endsParam] = $"%{es.EscapeLike()}";
-                            _sql.Append(endsParam).Append(" ESCAPE '\\'");
+                            _params[endsParam] = $"%{_provider.EscapeLikePattern(es)}";
+                            _sql.Append(endsParam).Append($" ESCAPE '{_provider.LikeEscapeChar}'");
                         }
                         else
                         {


### PR DESCRIPTION
## Summary
- centralize pattern escaping in DatabaseProvider with provider-specific escape char
- update ExpressionToSqlVisitor to use provider escapes for Contains/StartsWith/EndsWith
- extend SqlServerProvider to escape bracket and caret characters

## Testing
- `dotnet restore`
- `dotnet build src/nORM.csproj -p:GeneratePackageOnBuild=false`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f791ebb0832c8d54beb2aa3cbc86