### PR TITLE
Add entity change tracking and state management

### DIFF
--- a/src/nORM/Core/ChangeTracker.cs
+++ b/src/nORM/Core/ChangeTracker.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using nORM.Mapping;
+using RefComparer = System.Collections.Generic.ReferenceEqualityComparer;
+
+#nullable enable
+
+namespace nORM.Core
+{
+    public sealed class ChangeTracker
+    {
+        private readonly Dictionary<object, EntityEntry> _entries = new(RefComparer.Instance);
+
+        internal EntityEntry Track(object entity, EntityState state, TableMapping mapping)
+        {
+            if (!_entries.TryGetValue(entity, out var entry))
+            {
+                entry = new EntityEntry(entity, state, mapping);
+                _entries[entity] = entry;
+            }
+            else
+            {
+                entry.State = state;
+            }
+            return entry;
+        }
+
+        internal void Remove(object entity) => _entries.Remove(entity);
+
+        public IEnumerable<EntityEntry> Entries => _entries.Values;
+
+        internal void DetectChanges()
+        {
+            foreach (var entry in _entries.Values)
+            {
+                if (entry.State == EntityState.Unchanged)
+                    entry.DetectChanges();
+            }
+        }
+    }
+}

--- a/src/nORM/Core/EntityEntry.cs
+++ b/src/nORM/Core/EntityEntry.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using nORM.Mapping;
+
+#nullable enable
+
+namespace nORM.Core
+{
+    public sealed class EntityEntry
+    {
+        private readonly TableMapping _mapping;
+        private readonly Dictionary<string, object?> _originalValues = new();
+
+        public object Entity { get; }
+        public EntityState State { get; internal set; }
+        internal TableMapping Mapping => _mapping;
+
+        internal EntityEntry(object entity, EntityState state, TableMapping mapping)
+        {
+            Entity = entity;
+            State = state;
+            _mapping = mapping;
+            CaptureOriginalValues();
+        }
+
+        private void CaptureOriginalValues()
+        {
+            _originalValues.Clear();
+            foreach (var col in _mapping.Columns)
+            {
+                _originalValues[col.PropName] = col.Getter(Entity);
+            }
+        }
+
+        internal void DetectChanges()
+        {
+            if (State is EntityState.Added or EntityState.Deleted) return;
+
+            foreach (var col in _mapping.Columns.Where(c => !c.IsKey && !c.IsTimestamp))
+            {
+                var current = col.Getter(Entity);
+                var original = _originalValues.TryGetValue(col.PropName, out var o) ? o : null;
+                if (!Equals(current, original))
+                {
+                    State = EntityState.Modified;
+                    return;
+                }
+            }
+
+            if (State == EntityState.Modified)
+                State = EntityState.Unchanged;
+        }
+
+        internal void AcceptChanges()
+        {
+            CaptureOriginalValues();
+            State = EntityState.Unchanged;
+        }
+    }
+}

--- a/src/nORM/Core/EntityState.cs
+++ b/src/nORM/Core/EntityState.cs
@@ -1,0 +1,15 @@
+using System;
+
+#nullable enable
+
+namespace nORM.Core
+{
+    public enum EntityState
+    {
+        Detached,
+        Unchanged,
+        Added,
+        Modified,
+        Deleted
+    }
+}

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -353,6 +353,7 @@ namespace nORM.Navigation
                 var entity = materializer(reader);
                 // Enable lazy loading for the loaded entity
                 _navigationContexts.GetValue(entity, _ => new NavigationContext(context, entityType));
+                context.ChangeTracker.Track(entity, EntityState.Unchanged, mapping);
                 results.Add(entity);
             }
             
@@ -381,6 +382,7 @@ namespace nORM.Navigation
                 var entity = materializer(reader);
                 // Enable lazy loading for the loaded entity
                 _navigationContexts.GetValue(entity, _ => new NavigationContext(context, entityType));
+                context.ChangeTracker.Track(entity, EntityState.Unchanged, mapping);
                 return entity;
             }
             


### PR DESCRIPTION
## Summary
- Introduce `EntityState`, `EntityEntry`, and `ChangeTracker` to capture and track entity state
- Extend `DbContext` with Add/Attach/Update/Remove/Entry and SaveChanges APIs
- Track entities during query materialization and navigation loading for automatic change detection

## Testing
- `dotnet build src/nORM.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b6fdfe5e38832c8f3021b4f6039c68