### PR TITLE
Add owned type mapping and table splitting support

### DIFF
--- a/src/nORM/Configuration/IEntityTypeConfiguration.cs
+++ b/src/nORM/Configuration/IEntityTypeConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -10,5 +11,9 @@ namespace nORM.Configuration
         string? TableName { get; }
         PropertyInfo? KeyProperty { get; }
         Dictionary<PropertyInfo, string> ColumnNames { get; }
+        Type? TableSplitWith { get; }
+        Dictionary<PropertyInfo, OwnedNavigation> OwnedNavigations { get; }
     }
+
+    public record OwnedNavigation(Type OwnedType, IEntityTypeConfiguration? Configuration);
 }

--- a/src/nORM/Mapping/OwnedAttribute.cs
+++ b/src/nORM/Mapping/OwnedAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace nORM.Mapping
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class OwnedAttribute : Attribute
+    {
+    }
+}

--- a/src/nORM/Mapping/TableSplitAttribute.cs
+++ b/src/nORM/Mapping/TableSplitAttribute.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace nORM.Mapping
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed class TableSplitAttribute : Attribute
+    {
+        public Type PrincipalType { get; }
+
+        public TableSplitAttribute(Type principalType)
+        {
+            PrincipalType = principalType;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `OwnedAttribute` and `TableSplitAttribute`
- extend configuration to configure owned navigations and shared tables
- enhance column and table mapping to handle owned types and table splitting

## Testing
- `dotnet build src/nORM.csproj`
- `dotnet test src/nORM.csproj` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ffcde244832cbfb14d629134c200