### PR TITLE
Implement robust connection pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,24 @@ var options = new DbContextOptions { RetryPolicy = retryPolicy };
 var context = new DbContext(connection, provider, options);
 ```
 
+### Connection Pooling
+
+```csharp
+// Create a pool that manages SQL Server connections
+var pool = new ConnectionPool(
+    () => new SqlConnection("Server=.;Database=MyApp;Trusted_Connection=true"),
+    new ConnectionPoolOptions
+    {
+        MaxPoolSize = 50,
+        MinPoolSize = 5,
+        ConnectionIdleLifetime = TimeSpan.FromMinutes(5)
+    });
+
+await using var pooledConnection = await pool.RentAsync();
+var context = new DbContext(pooledConnection, provider);
+// Disposing the connection or context returns it to the pool
+```
+
 ### Advanced Logging
 
 ```csharp

--- a/src/nORM/Core/ConnectionPool.cs
+++ b/src/nORM/Core/ConnectionPool.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Concurrent;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace nORM.Core
+{
+    /// <summary>
+    /// Thread-safe pool managing database connections.
+    /// </summary>
+    public sealed class ConnectionPool : IAsyncDisposable, IDisposable
+    {
+        private readonly Func<DbConnection> _connectionFactory;
+        private readonly ConcurrentQueue<PooledItem> _pool = new();
+        private readonly SemaphoreSlim _semaphore;
+        private readonly Timer _cleanupTimer;
+        private readonly int _minSize;
+        private readonly TimeSpan _idleLifetime;
+        private int _created;
+        private bool _disposed;
+
+        private sealed class PooledItem
+        {
+            public DbConnection Connection { get; }
+            public DateTime LastUsed { get; set; }
+
+            public PooledItem(DbConnection connection)
+            {
+                Connection = connection;
+                LastUsed = DateTime.UtcNow;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionPool"/> class.
+        /// </summary>
+        /// <param name="connectionFactory">Factory used to create new <see cref="DbConnection"/> instances.</param>
+        /// <param name="options">Optional pool configuration.</param>
+        public ConnectionPool(Func<DbConnection> connectionFactory, ConnectionPoolOptions? options = null)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+            var opts = options ?? new ConnectionPoolOptions();
+            if (opts.MaxPoolSize <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxPoolSize));
+            if (opts.MinPoolSize < 0 || opts.MinPoolSize > opts.MaxPoolSize)
+                throw new ArgumentOutOfRangeException(nameof(options.MinPoolSize));
+
+            _semaphore = new SemaphoreSlim(opts.MaxPoolSize, opts.MaxPoolSize);
+            _minSize = opts.MinPoolSize;
+            _idleLifetime = opts.ConnectionIdleLifetime;
+
+            // Pre-warm pool with minimum number of connections
+            for (int i = 0; i < _minSize; i++)
+            {
+                var cn = connectionFactory();
+                cn.Open();
+                _pool.Enqueue(new PooledItem(cn));
+                Interlocked.Increment(ref _created);
+            }
+
+            _cleanupTimer = new Timer(CleanupCallback, null, _idleLifetime, _idleLifetime);
+        }
+
+        /// <summary>
+        /// Rents a connection from the pool.
+        /// </summary>
+        public async Task<DbConnection> RentAsync(CancellationToken ct = default)
+        {
+            ThrowIfDisposed();
+            await _semaphore.WaitAsync(ct).ConfigureAwait(false);
+
+            if (_pool.TryDequeue(out var item))
+            {
+                try
+                {
+                    if (item.Connection.State != ConnectionState.Open)
+                        await item.Connection.OpenAsync(ct).ConfigureAwait(false);
+                }
+                catch
+                {
+                    item.Connection.Dispose();
+                    Interlocked.Decrement(ref _created);
+                    return await RentAsync(ct).ConfigureAwait(false);
+                }
+                item.LastUsed = DateTime.UtcNow;
+                return new PooledDbConnection(this, item.Connection);
+            }
+
+            var cn = _connectionFactory();
+            await cn.OpenAsync(ct).ConfigureAwait(false);
+            Interlocked.Increment(ref _created);
+            return new PooledDbConnection(this, cn);
+        }
+
+        private void Return(DbConnection connection)
+        {
+            if (_disposed)
+            {
+                connection.Dispose();
+                return;
+            }
+
+            if (connection.State == ConnectionState.Open)
+            {
+                _pool.Enqueue(new PooledItem(connection));
+            }
+            else
+            {
+                connection.Dispose();
+                Interlocked.Decrement(ref _created);
+            }
+            _semaphore.Release();
+        }
+
+        private void CleanupCallback(object? state)
+        {
+            if (_disposed) return;
+            var threshold = DateTime.UtcNow - _idleLifetime;
+
+            while (_created > _minSize && _pool.TryPeek(out var item) && item.LastUsed < threshold)
+            {
+                if (_pool.TryDequeue(out var old))
+                {
+                    old.Connection.Dispose();
+                    Interlocked.Decrement(ref _created);
+                }
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(ConnectionPool));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _cleanupTimer.Dispose();
+            while (_pool.TryDequeue(out var item))
+            {
+                item.Connection.Dispose();
+            }
+            _semaphore.Dispose();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Dispose();
+            await Task.CompletedTask;
+        }
+
+        private sealed class PooledDbConnection : DbConnection
+        {
+            private readonly ConnectionPool _pool;
+            private DbConnection? _inner;
+
+            public PooledDbConnection(ConnectionPool pool, DbConnection inner)
+            {
+                _pool = pool;
+                _inner = inner;
+            }
+
+            protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+                => Inner.BeginTransaction(isolationLevel);
+
+            public override void ChangeDatabase(string database) => Inner.ChangeDatabase(database);
+
+            public override void Close() => Dispose();
+
+            public override void Open() => Inner.Open();
+
+            public override Task OpenAsync(CancellationToken cancellationToken) => Inner.OpenAsync(cancellationToken);
+
+            [System.Diagnostics.CodeAnalysis.AllowNull]
+            public override string ConnectionString
+            {
+                get => Inner.ConnectionString;
+                set => Inner.ConnectionString = value;
+            }
+
+            public override string Database => Inner.Database;
+            public override string DataSource => Inner.DataSource;
+            public override string ServerVersion => Inner.ServerVersion;
+            public override ConnectionState State => Inner.State;
+            protected override DbCommand CreateDbCommand() => Inner.CreateCommand();
+
+            private DbConnection Inner => _inner ?? throw new ObjectDisposedException(nameof(PooledDbConnection));
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    var cn = Interlocked.Exchange(ref _inner, null);
+                    if (cn != null)
+                        _pool.Return(cn);
+                }
+            }
+
+            public override ValueTask DisposeAsync()
+            {
+                Dispose();
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/nORM/Core/ConnectionPoolOptions.cs
+++ b/src/nORM/Core/ConnectionPoolOptions.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace nORM.Core
+{
+    /// <summary>
+    /// Configuration settings for <see cref="ConnectionPool"/>.
+    /// </summary>
+    public class ConnectionPoolOptions
+    {
+        /// <summary>
+        /// Gets or sets the maximum number of connections that can be created by the pool.
+        /// </summary>
+        public int MaxPoolSize { get; set; } = Environment.ProcessorCount * 2;
+
+        /// <summary>
+        /// Gets or sets the minimum number of idle connections the pool tries to maintain.
+        /// </summary>
+        public int MinPoolSize { get; set; } = 0;
+
+        /// <summary>
+        /// Gets or sets how long an idle connection can stay in the pool before being disposed.
+        /// </summary>
+        public TimeSpan ConnectionIdleLifetime { get; set; } = TimeSpan.FromMinutes(2);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ConnectionPool` with asynchronous rent/return, idle cleanup, and thread-safe limits
- expose `ConnectionPoolOptions` for tuning pool size and idle lifetime
- document connection pooling usage in README

## Testing
- `dotnet build src/nORM.csproj -p:GeneratePackageOnBuild=false`

------
https://chatgpt.com/codex/tasks/task_e_68b7021c8e30832c8188c305d773e368