### PR TITLE
Add robust command interception infrastructure

### DIFF
--- a/src/nORM/Configuration/DbContextOptions.cs
+++ b/src/nORM/Configuration/DbContextOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using nORM.Enterprise;
 
 #nullable enable
@@ -15,5 +16,6 @@ namespace nORM.Configuration
         public string TenantColumnName { get; set; } = "TenantId";
         public Action<ModelBuilder>? OnModelCreating { get; set; }
         public bool UseBatchedBulkOps { get; set; } = false;
+        public IList<IDbCommandInterceptor> CommandInterceptors { get; } = new List<IDbCommandInterceptor>();
     }
 }

--- a/src/nORM/Enterprise/IDbCommandInterceptor.cs
+++ b/src/nORM/Enterprise/IDbCommandInterceptor.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using nORM.Core;
+
+#nullable enable
+
+namespace nORM.Enterprise
+{
+    /// <summary>
+    /// Defines hooks that are invoked before and after execution of <see cref="DbCommand"/> instances.
+    /// Implementations may inspect or modify the command, short-circuit execution, or react to failures.
+    /// </summary>
+    public interface IDbCommandInterceptor
+    {
+        /// <summary>
+        /// Called before a command that does not return rows is executed.
+        /// Returning a suppressed result prevents command execution and returns the provided value instead.
+        /// </summary>
+        Task<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, DbContext context, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Called after a command that does not return rows has executed.
+        /// </summary>
+        Task NonQueryExecutedAsync(DbCommand command, DbContext context, int result, TimeSpan duration, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Called before a command that returns a scalar value is executed.
+        /// Returning a suppressed result prevents command execution and returns the provided value instead.
+        /// </summary>
+        Task<InterceptionResult<object?>> ScalarExecutingAsync(DbCommand command, DbContext context, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Called after a command that returns a scalar value has executed.
+        /// </summary>
+        Task ScalarExecutedAsync(DbCommand command, DbContext context, object? result, TimeSpan duration, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Called before a command that returns a reader is executed.
+        /// Returning a suppressed reader prevents command execution and returns the provided reader instead.
+        /// </summary>
+        Task<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, DbContext context, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Called after a command that returns a reader has executed.
+        /// </summary>
+        Task ReaderExecutedAsync(DbCommand command, DbContext context, DbDataReader reader, TimeSpan duration, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Called when execution of a command results in an exception.
+        /// </summary>
+        Task CommandFailedAsync(DbCommand command, DbContext context, Exception exception, CancellationToken cancellationToken);
+    }
+}

--- a/src/nORM/Enterprise/InterceptionResult.cs
+++ b/src/nORM/Enterprise/InterceptionResult.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.CodeAnalysis;
+
+#nullable enable
+
+namespace nORM.Enterprise
+{
+    /// <summary>
+    /// Represents the result of an interceptor call. When <see cref="IsSuppressed"/> is true,
+    /// the command execution is skipped and <see cref="Result"/> is returned instead.
+    /// </summary>
+    /// <typeparam name="T">Type of the result.</typeparam>
+    public readonly struct InterceptionResult<T>
+    {
+        public bool IsSuppressed { get; }
+        [MaybeNull]
+        public T Result { get; }
+
+        private InterceptionResult(bool suppressed, T result)
+        {
+            IsSuppressed = suppressed;
+            Result = result;
+        }
+
+        public static InterceptionResult<T> Continue() => default;
+
+        public static InterceptionResult<T> SuppressWithResult(T result) => new(true, result);
+    }
+}

--- a/src/nORM/Internal/CommandInterceptorExtensions.cs
+++ b/src/nORM/Internal/CommandInterceptorExtensions.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using nORM.Core;
+using nORM.Enterprise;
+
+#nullable enable
+
+namespace nORM.Internal
+{
+    internal static class CommandInterceptorExtensions
+    {
+        public static async Task<int> ExecuteNonQueryWithInterceptionAsync(this DbCommand command, DbContext ctx, CancellationToken ct)
+        {
+            var interceptors = ctx.Options.CommandInterceptors;
+            if (interceptors.Count == 0)
+            {
+                return await command.ExecuteNonQueryAsync(ct);
+            }
+
+            foreach (var interceptor in interceptors)
+            {
+                var interception = await interceptor.NonQueryExecutingAsync(command, ctx, ct);
+                if (interception.IsSuppressed)
+                {
+                    foreach (var i in interceptors)
+                        await i.NonQueryExecutedAsync(command, ctx, interception.Result, TimeSpan.Zero, ct);
+                    return interception.Result;
+                }
+            }
+
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                var result = await command.ExecuteNonQueryAsync(ct);
+                sw.Stop();
+                foreach (var interceptor in interceptors)
+                {
+                    await interceptor.NonQueryExecutedAsync(command, ctx, result, sw.Elapsed, ct);
+                }
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                foreach (var interceptor in interceptors)
+                {
+                    await interceptor.CommandFailedAsync(command, ctx, ex, ct);
+                }
+                throw;
+            }
+        }
+
+        public static async Task<object?> ExecuteScalarWithInterceptionAsync(this DbCommand command, DbContext ctx, CancellationToken ct)
+        {
+            var interceptors = ctx.Options.CommandInterceptors;
+            if (interceptors.Count == 0)
+            {
+                return await command.ExecuteScalarAsync(ct);
+            }
+
+            foreach (var interceptor in interceptors)
+            {
+                var interception = await interceptor.ScalarExecutingAsync(command, ctx, ct);
+                if (interception.IsSuppressed)
+                {
+                    foreach (var i in interceptors)
+                        await i.ScalarExecutedAsync(command, ctx, interception.Result, TimeSpan.Zero, ct);
+                    return interception.Result;
+                }
+            }
+
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                var result = await command.ExecuteScalarAsync(ct);
+                sw.Stop();
+                foreach (var interceptor in interceptors)
+                {
+                    await interceptor.ScalarExecutedAsync(command, ctx, result, sw.Elapsed, ct);
+                }
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                foreach (var interceptor in interceptors)
+                {
+                    await interceptor.CommandFailedAsync(command, ctx, ex, ct);
+                }
+                throw;
+            }
+        }
+
+        public static async Task<DbDataReader> ExecuteReaderWithInterceptionAsync(this DbCommand command, DbContext ctx, CommandBehavior behavior, CancellationToken ct)
+        {
+            var interceptors = ctx.Options.CommandInterceptors;
+            if (interceptors.Count == 0)
+            {
+                return await command.ExecuteReaderAsync(behavior, ct);
+            }
+
+            foreach (var interceptor in interceptors)
+            {
+                var interception = await interceptor.ReaderExecutingAsync(command, ctx, ct);
+                if (interception.IsSuppressed)
+                {
+                    foreach (var i in interceptors)
+                        await i.ReaderExecutedAsync(command, ctx, interception.Result!, TimeSpan.Zero, ct);
+                    return interception.Result!;
+                }
+            }
+
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                var reader = await command.ExecuteReaderAsync(behavior, ct);
+                sw.Stop();
+                foreach (var interceptor in interceptors)
+                {
+                    await interceptor.ReaderExecutedAsync(command, ctx, reader, sw.Elapsed, ct);
+                }
+                return reader;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                foreach (var interceptor in interceptors)
+                {
+                    await interceptor.CommandFailedAsync(command, ctx, ex, ct);
+                }
+                throw;
+            }
+        }
+    }
+}

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Data;
 using nORM.Core;
 using nORM.Mapping;
 using nORM.Internal;
@@ -347,7 +348,7 @@ namespace nORM.Navigation
             var materializer = new Query.QueryTranslator(context).CreateMaterializer(mapping, entityType);
             var results = new List<object>();
             
-            using var reader = await cmd.ExecuteReaderAsync(ct);
+            using var reader = await cmd.ExecuteReaderWithInterceptionAsync(context, CommandBehavior.Default, ct);
             while (await reader.ReadAsync(ct))
             {
                 var entity = materializer(reader);
@@ -376,7 +377,7 @@ namespace nORM.Navigation
 
             var materializer = new Query.QueryTranslator(context).CreateMaterializer(mapping, entityType);
             
-            using var reader = await cmd.ExecuteReaderAsync(ct);
+            using var reader = await cmd.ExecuteReaderWithInterceptionAsync(context, CommandBehavior.Default, ct);
             if (await reader.ReadAsync(ct))
             {
                 var entity = materializer(reader);

--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using nORM.Core;
+using nORM.Internal;
 using nORM.Mapping;
 
 #nullable enable
@@ -84,7 +85,7 @@ namespace nORM.Providers
             {
                 cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
                 cmd.CommandText = $"CREATE TEMPORARY TABLE {tempTableName} ({colDefs})";
-                await cmd.ExecuteNonQueryAsync(ct);
+                await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
             }
 
             var tempMapping = new TableMapping(m.Type, this, ctx, null) { EscTable = tempTableName };
@@ -96,7 +97,7 @@ namespace nORM.Providers
             {
                 cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
                 cmd.CommandText = $"UPDATE {m.EscTable} T1 JOIN {tempTableName} T2 ON {joinClause} SET {setClause}";
-                var updatedCount = await cmd.ExecuteNonQueryAsync(ct);
+                var updatedCount = await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
                 ctx.Options.Logger?.LogBulkOperation(nameof(BulkUpdateAsync), m.EscTable, updatedCount, sw.Elapsed);
                 return updatedCount;
             }

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -104,7 +104,7 @@ namespace nORM.Providers
             {
                 cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
                 cmd.CommandText = $"CREATE TABLE {tempTableName} ({colDefs})";
-                await cmd.ExecuteNonQueryAsync(ct);
+                await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
             }
 
             await BulkInsertInternalAsync(ctx, m, entities, tempTableName, ct);
@@ -115,7 +115,7 @@ namespace nORM.Providers
             {
                 cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
                 cmd.CommandText = $"UPDATE T1 SET {setClause} FROM {m.EscTable} T1 JOIN {tempTableName} T2 ON {joinClause}";
-                var updatedCount = await cmd.ExecuteNonQueryAsync(ct);
+                var updatedCount = await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
                 ctx.Options.Logger?.LogBulkOperation(nameof(BulkUpdateAsync), m.EscTable, updatedCount, sw.Elapsed);
                 return updatedCount;
             }
@@ -172,7 +172,7 @@ namespace nORM.Providers
             {
                 cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
                 cmd.CommandText = $"CREATE TABLE {tempTableName} ({keyColDefs})";
-                await cmd.ExecuteNonQueryAsync(ct);
+                await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
             }
 
             using (var bulkCopy = new SqlBulkCopy((SqlConnection)ctx.Connection)
@@ -204,7 +204,7 @@ namespace nORM.Providers
             {
                 cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
                 cmd.CommandText = $"DELETE T1 FROM {m.EscTable} T1 JOIN {tempTableName} T2 ON {joinClause}";
-                var deletedCount = await cmd.ExecuteNonQueryAsync(ct);
+                var deletedCount = await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
                 ctx.Options.Logger?.LogBulkOperation(nameof(BulkDeleteAsync), m.EscTable, deletedCount, sw.Elapsed);
                 return deletedCount;
             }

--- a/src/nORM/Providers/SqliteProvider.cs
+++ b/src/nORM/Providers/SqliteProvider.cs
@@ -75,7 +75,7 @@ namespace nORM.Providers
                     {
                         cmd.Parameters[ParamPrefix + col.PropName].Value = col.Getter(entity) ?? DBNull.Value;
                     }
-                    recordsAffected += await cmd.ExecuteNonQueryAsync(ct);
+                    recordsAffected += await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
                 }
                 
                 await transaction.CommitAsync(ct);
@@ -128,7 +128,7 @@ namespace nORM.Providers
                         cmd.AddParam(ParamPrefix + m.TimestampColumn.PropName, m.TimestampColumn.Getter(entity));
                     }
                     
-                    totalUpdated += await cmd.ExecuteNonQueryAsync(ct);
+                    totalUpdated += await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
                 }
                 
                 await transaction.CommitAsync(ct);
@@ -181,7 +181,7 @@ namespace nORM.Providers
                         }
                         
                         cmd.CommandText = $"DELETE FROM {m.EscTable} WHERE {keyCol.EscCol} IN ({string.Join(",", paramNames)})";
-                        totalDeleted += await cmd.ExecuteNonQueryAsync(ct);
+                        totalDeleted += await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
                     }
                 }
                 else
@@ -206,7 +206,7 @@ namespace nORM.Providers
                             cmd.AddParam(ParamPrefix + m.TimestampColumn.PropName, m.TimestampColumn.Getter(entity));
                         }
                         
-                        totalDeleted += await cmd.ExecuteNonQueryAsync(ct);
+                        totalDeleted += await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
                     }
                 }
                 

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -93,7 +93,7 @@ namespace nORM.Query
             object result;
             if (plan.IsScalar)
             {
-                var scalarResult = await cmd.ExecuteScalarAsync(ct);
+                var scalarResult = await cmd.ExecuteScalarWithInterceptionAsync(_ctx, ct);
                 _ctx.Options.Logger?.LogQuery(plan.Sql, plan.Parameters, sw.Elapsed, scalarResult == null || scalarResult is DBNull ? 0 : 1);
                 if (scalarResult == null || scalarResult is DBNull) return default(TResult)!;
                 var resultType = typeof(TResult);
@@ -136,7 +136,7 @@ namespace nORM.Query
                              plan.ElementType.GetConstructor(Type.EmptyTypes) != null;
             TableMapping? entityMap = trackable ? _ctx.GetMapping(plan.ElementType) : null;
 
-            await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, ct);
+            await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(_ctx, CommandBehavior.SequentialAccess, ct);
             while (await reader.ReadAsync(ct))
             {
                 var entity = plan.Materializer(reader);
@@ -182,7 +182,7 @@ namespace nORM.Query
 
             var childMaterializer = new QueryTranslator(_ctx).CreateMaterializer(childMap, childMap.Type);
             var children = new List<object>();
-            await using (var reader = await cmd.ExecuteReaderAsync(ct))
+            await using (var reader = await cmd.ExecuteReaderWithInterceptionAsync(_ctx, CommandBehavior.Default, ct))
             {
                 while (await reader.ReadAsync(ct))
                 {
@@ -232,7 +232,7 @@ namespace nORM.Query
 
             var childMaterializer = new QueryTranslator(_ctx).CreateMaterializer(childMap, childMap.Type);
             var children = new List<object>();
-            await using (var reader = await cmd.ExecuteReaderAsync(ct))
+            await using (var reader = await cmd.ExecuteReaderWithInterceptionAsync(_ctx, CommandBehavior.Default, ct))
             {
                 while (await reader.ReadAsync(ct))
                 {


### PR DESCRIPTION
## Summary
- introduce `IDbCommandInterceptor` and `InterceptionResult` for interception lifecycle
- support registering interceptors via `DbContextOptions`
- route all database calls through interception helpers and update providers and context

## Testing
- `dotnet build src/nORM.csproj -p:GeneratePackageOnBuild=false`


------
https://chatgpt.com/codex/tasks/task_e_68b70366ccb4832cada04b13c69d30e3