### PR TITLE
Implement robust global query filters with tenant support

### DIFF
--- a/src/nORM/Internal/ParameterReplacer.cs
+++ b/src/nORM/Internal/ParameterReplacer.cs
@@ -1,0 +1,22 @@
+using System.Linq.Expressions;
+
+#nullable enable
+
+namespace nORM.Internal
+{
+    internal sealed class ParameterReplacer : ExpressionVisitor
+    {
+        private readonly ParameterExpression _parameter;
+        private readonly Expression _replacement;
+
+        public ParameterReplacer(ParameterExpression parameter, Expression replacement)
+        {
+            _parameter = parameter;
+            _replacement = replacement;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+            => node == _parameter ? _replacement : base.VisitParameter(node);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Introduce global filter registration APIs in `DbContextOptions`
- Apply global query filters (including tenant filter) in `NormQueryProvider`
- Support method-call constant evaluation and context parameter replacement

## Testing
- `dotnet test`
- `dotnet build src/nORM.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b7075e45fc832c8dca42688d969e18