### PR TITLE
Bound static caches with LRU

### DIFF
--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics;
@@ -17,7 +16,7 @@ namespace nORM.Providers
 {
     public abstract class DatabaseProvider
     {
-        private static readonly ConcurrentDictionary<(Type Type, string Operation), string> _sqlCache = new();
+        private static readonly ConcurrentLruCache<(Type Type, string Operation), string> _sqlCache = new(maxSize: 1000);
         
         public string ParamPrefix { get; protected init; } = "@";
         public abstract string Escape(string id);

--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
 using System.Data;
 using System.Diagnostics;
 using System.Linq;
@@ -17,7 +16,7 @@ namespace nORM.Providers
 {
     public sealed class MySqlProvider : DatabaseProvider
     {
-        private static readonly ConcurrentDictionary<Type, DataTable> _tableSchemas = new();
+        private static readonly ConcurrentLruCache<Type, DataTable> _tableSchemas = new(maxSize: 100);
         public override string Escape(string id) => $"`{id}`";
         
         public override void ApplyPaging(StringBuilder sb, int? limit, int? offset)

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
 using System.Data;
 using System.Diagnostics;
 using System.Linq;
@@ -18,8 +17,8 @@ namespace nORM.Providers
 {
     public sealed class SqlServerProvider : DatabaseProvider
     {
-        private static readonly ConcurrentDictionary<Type, DataTable> _tableSchemas = new();
-        private static readonly ConcurrentDictionary<Type, DataTable> _keyTableSchemas = new();
+        private static readonly ConcurrentLruCache<Type, DataTable> _tableSchemas = new(maxSize: 100);
+        private static readonly ConcurrentLruCache<Type, DataTable> _keyTableSchemas = new(maxSize: 100);
         public override string Escape(string id) => $"[{id}]";
         
         public override void ApplyPaging(StringBuilder sb, int? limit, int? offset)

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -22,7 +21,7 @@ namespace nORM.Query
     internal sealed class NormQueryProvider : IQueryProvider
     {
         internal readonly DbContext _ctx;
-        private static readonly ConcurrentDictionary<QueryPlanCacheKey, QueryPlan> _planCache = new();
+        private static readonly ConcurrentLruCache<QueryPlanCacheKey, QueryPlan> _planCache = new(maxSize: 1000);
 
         public NormQueryProvider(DbContext ctx) => _ctx = ctx;
 


### PR DESCRIPTION
## Summary
- limit query plan cache via ConcurrentLruCache
- add bounded cache for generated SQL and provider schema caches
- use bounded LRU navigation property cache

## Testing
- `dotnet build src/nORM.csproj`
- `dotnet test src/nORM.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68b70dce8f24832caf5e12839a4487fc