### PR TITLE
Add rank window function support

### DIFF
--- a/examples/AdvancedFeaturesExample.cs
+++ b/examples/AdvancedFeaturesExample.cs
@@ -310,15 +310,27 @@ namespace nORM.Examples
         private static async Task DemonstrateWindowFunctionsAsync(DbContext context)
         {
             Console.WriteLine("Window Functions: Users with row numbers ordered by salary:");
-            
+
             var usersWithRowNumbers = await context.Query<User>()
                 .OrderByDescending(u => u.Salary)
                 .WithRowNumber((user, rowNum) => new { User = user, RowNumber = rowNum })
                 .ToListAsync();
-            
+
             foreach (var item in usersWithRowNumbers)
             {
                 Console.WriteLine($"   #{item.RowNumber}: {item.User.Name} - ${item.User.Salary:N2}");
+            }
+
+            Console.WriteLine("Window Functions: Users ranked by salary:");
+
+            var usersWithRanks = await context.Query<User>()
+                .OrderByDescending(u => u.Salary)
+                .WithRank((user, rank) => new { User = user, Rank = rank })
+                .ToListAsync();
+
+            foreach (var item in usersWithRanks)
+            {
+                Console.WriteLine($"   Rank {item.Rank}: {item.User.Name} - ${item.User.Salary:N2}");
             }
         }
     }

--- a/src/nORM/Core/WindowFunctionsExtensions.cs
+++ b/src/nORM/Core/WindowFunctionsExtensions.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace nORM.Core
+{
+    /// <summary>
+    /// Provides LINQ extension methods for SQL window functions.
+    /// </summary>
+    public static class WindowFunctionsExtensions
+    {
+        /// <summary>
+        /// Adds a ROW_NUMBER() column to the query projection.
+        /// </summary>
+        public static IQueryable<TResult> WithRowNumber<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, int, TResult>> resultSelector)
+            where TSource : class
+        {
+            if (source.Provider is Query.NormQueryProvider provider)
+            {
+                var method = ((MethodInfo)MethodBase.GetCurrentMethod()!).MakeGenericMethod(typeof(TSource), typeof(TResult));
+                var call = Expression.Call(null, method, source.Expression, Expression.Quote(resultSelector));
+                return provider.CreateQuery<TResult>(call);
+            }
+
+            throw new InvalidOperationException("WithRowNumber extension can only be used with nORM queries.");
+        }
+
+        /// <summary>
+        /// Adds a RANK() column to the query projection.
+        /// </summary>
+        public static IQueryable<TResult> WithRank<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, int, TResult>> resultSelector)
+            where TSource : class
+        {
+            if (source.Provider is Query.NormQueryProvider provider)
+            {
+                var method = ((MethodInfo)MethodBase.GetCurrentMethod()!).MakeGenericMethod(typeof(TSource), typeof(TResult));
+                var call = Expression.Call(null, method, source.Expression, Expression.Quote(resultSelector));
+                return provider.CreateQuery<TResult>(call);
+            }
+
+            throw new InvalidOperationException("WithRank extension can only be used with nORM queries.");
+        }
+
+        /// <summary>
+        /// Adds a DENSE_RANK() column to the query projection.
+        /// </summary>
+        public static IQueryable<TResult> WithDenseRank<TSource, TResult>(this IQueryable<TSource> source, Expression<Func<TSource, int, TResult>> resultSelector)
+            where TSource : class
+        {
+            if (source.Provider is Query.NormQueryProvider provider)
+            {
+                var method = ((MethodInfo)MethodBase.GetCurrentMethod()!).MakeGenericMethod(typeof(TSource), typeof(TResult));
+                var call = Expression.Call(null, method, source.Expression, Expression.Quote(resultSelector));
+                return provider.CreateQuery<TResult>(call);
+            }
+
+            throw new InvalidOperationException("WithDenseRank extension can only be used with nORM queries.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `WithRank` and `WithDenseRank` extensions for RANK and DENSE_RANK window functions
- translate RANK and DENSE_RANK into SQL and materialize scalar window values
- demonstrate ranking by salary in window function example

## Testing
- `dotnet build src/nORM.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b710fb440c832ca12c7ff5c2781dca