### PR TITLE
feat(mapping): infer relationships via conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ nORM (The Norm) is a modern, high-performance Object-Relational Mapping (ORM) li
 - **🏢 Enterprise Ready**: Multi-tenancy, connection resilience, advanced logging, and migration framework
 - **📊 Bulk Operations**: High-performance bulk insert, update, and delete operations
 - **🔧 Provider Agnostic**: Support for SQL Server, PostgreSQL, SQLite, and MySQL
+- **🔗 Smart Conventions**: Automatic relationship discovery using standard naming patterns
 - **🎯 Simple API**: Clean, intuitive API that feels familiar to EF users
 - **🔨 Database Scaffolding**: Reverse-engineer existing databases into entity classes and a DbContext
 

--- a/src/nORM/Mapping/Column.cs
+++ b/src/nORM/Mapping/Column.cs
@@ -35,6 +35,22 @@ namespace nORM.Mapping
             IsTimestamp = pi.GetCustomAttribute<TimestampAttribute>() != null;
             IsDbGenerated = pi.GetCustomAttribute<DatabaseGeneratedAttribute>()?.DatabaseGeneratedOption == DatabaseGeneratedOption.Identity;
             ForeignKeyPrincipalTypeName = pi.GetCustomAttribute<ForeignKeyAttribute>()?.Name;
+            if (ForeignKeyPrincipalTypeName == null && !IsKey)
+            {
+                var propName = pi.Name;
+                if (propName.EndsWith("Id", StringComparison.OrdinalIgnoreCase) && propName.Length > 2)
+                {
+                    var principalName = propName[..^2];
+                    if (!string.Equals(principalName, "Id", StringComparison.OrdinalIgnoreCase))
+                        ForeignKeyPrincipalTypeName = principalName;
+                }
+                else
+                {
+                    var underscore = propName.IndexOf('_');
+                    if (underscore > 0)
+                        ForeignKeyPrincipalTypeName = propName.Substring(0, underscore);
+                }
+            }
 
             Getter = getterOverride ?? CreateGetterDelegate(pi);
             Setter = setterOverride ?? CreateSetterDelegate(pi);

--- a/src/nORM/Mapping/TableMapping.cs
+++ b/src/nORM/Mapping/TableMapping.cs
@@ -119,7 +119,18 @@ namespace nORM.Mapping
                 {
                     var dependentType = prop.PropertyType.GetGenericArguments()[0];
                     var dependentMap = ctx.GetMapping(dependentType);
-                    var foreignKeyProp = dependentMap.Columns.FirstOrDefault(c => c.ForeignKeyPrincipalTypeName == Type.Name);
+
+                    Column? foreignKeyProp = dependentMap.Columns
+                        .FirstOrDefault(c => string.Equals(c.ForeignKeyPrincipalTypeName, Type.Name, StringComparison.OrdinalIgnoreCase));
+
+                    if (foreignKeyProp == null && KeyColumns.Length == 1)
+                    {
+                        var fkName = $"{Type.Name}Id";
+                        var fkComposite = $"{Type.Name}_{KeyColumns[0].PropName}";
+                        foreignKeyProp = dependentMap.Columns.FirstOrDefault(c =>
+                            string.Equals(c.PropName, fkName, StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(c.PropName, fkComposite, StringComparison.OrdinalIgnoreCase));
+                    }
 
                     if (foreignKeyProp != null && KeyColumns.Length == 1)
                     {


### PR DESCRIPTION
## Summary
- infer foreign key columns by matching `<EntityName>Id` and similar patterns
- discover one-to-many navigation relationships via naming conventions
- document smart convention-based mapping

## Testing
- `dotnet build src/nORM.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b7cfcc33c4832cac6d52102b9bd7c6