### PR TITLE
feat: generate compiled materializers

### DIFF
--- a/src/SourceGeneration/CompiledMaterializerStore.cs
+++ b/src/SourceGeneration/CompiledMaterializerStore.cs
@@ -6,14 +6,26 @@ namespace nORM.SourceGeneration
 {
     public static class CompiledMaterializerStore
     {
-        private static readonly ConcurrentDictionary<Type, Func<DbDataReader, object>> _map = new();
+        private static readonly ConcurrentDictionary<Type, (Delegate Typed, Func<DbDataReader, object> Untyped)> _map = new();
 
         public static void Add(Type type, Func<DbDataReader, object> materializer)
-            => _map[type] = materializer;
+            => _map[type] = (materializer, materializer);
+
+        public static void Add<T>(Func<DbDataReader, T> materializer)
+            => _map[typeof(T)] = (materializer, reader => materializer(reader)!);
 
         public static bool TryGet(Type type, out Func<DbDataReader, object> materializer)
-            => _map.TryGetValue(type, out materializer!);
+        {
+            if (_map.TryGetValue(type, out var entry))
+            {
+                materializer = entry.Untyped;
+                return true;
+            }
+            materializer = null!;
+            return false;
+        }
 
-        public static Func<DbDataReader, T> Get<T>() => (Func<DbDataReader, T>)(object)_map[typeof(T)];
+        public static Func<DbDataReader, T> Get<T>()
+            => (Func<DbDataReader, T>)_map[typeof(T)].Typed;
     }
 }

--- a/tests/MaterializerGeneratorTests.cs
+++ b/tests/MaterializerGeneratorTests.cs
@@ -1,0 +1,48 @@
+using System;
+using Microsoft.Data.Sqlite;
+using nORM.SourceGeneration;
+using Xunit;
+
+namespace nORM.Tests
+{
+    internal enum Status { Inactive = 0, Active = 1 }
+
+    [GenerateMaterializer]
+    internal class Materialized
+    {
+        public DateTime? Created { get; set; }
+        public Guid Guid { get; set; }
+        public int Id { get; set; }
+        public bool? IsActive { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public decimal Price { get; set; }
+        public Status Status { get; set; }
+    }
+
+    public class MaterializerGeneratorTests
+    {
+        [Fact]
+        public void Generated_materializer_reads_data_correctly()
+        {
+            Assert.True(CompiledMaterializerStore.TryGet(typeof(Materialized), out _));
+
+            using var cn = new SqliteConnection("Data Source=:memory:");
+            cn.Open();
+            using var cmd = cn.CreateCommand();
+            var g = Guid.NewGuid();
+            cmd.CommandText = "SELECT NULL AS Created, $g AS Guid, 1 AS Id, 1 AS IsActive, 'foo' AS Name, 12.34 AS Price, 1 AS Status";
+            cmd.Parameters.AddWithValue("$g", g);
+            using var reader = cmd.ExecuteReader();
+            Assert.True(reader.Read());
+            var mat = CompiledMaterializerStore.Get<Materialized>();
+            var entity = mat(reader);
+            Assert.Null(entity.Created);
+            Assert.Equal(g, entity.Guid);
+            Assert.Equal(1, entity.Id);
+            Assert.True(entity.IsActive);
+            Assert.Equal("foo", entity.Name);
+            Assert.Equal(12.34m, entity.Price);
+            Assert.Equal(Status.Active, entity.Status);
+        }
+    }
+}

--- a/tests/nORM.Tests.csproj
+++ b/tests/nORM.Tests.csproj
@@ -14,4 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\src\nORM.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\nORM.SourceGenerators\nORM.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- use Source Generator to build compile-time DbDataReader materializers with typed accessors and enum support
- store materializers in new CompiledMaterializerStore with typed and untyped retrieval
- add tests exercising generated materializer

## Testing
- `/workspace/dotnet/dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68b7e11f15a8832cacaa16810201e551