### PR TITLE
feat(cli): add dotnet-norm global tool

### DIFF
--- a/nORM.sln
+++ b/nORM.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -26,6 +26,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{D4
 		examples\Program.cs = examples\Program.cs
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D6DD25C8-8170-4520-90C0-97108ABD54EE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnet-norm", "src\dotnet-norm\dotnet-norm.csproj", "{A144AE26-3E9F-4CE5-BF35-DB0B989CB7D3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,21 +42,28 @@ Global
 		{F8B7E3C2-4A1D-4E5F-8B9C-1A2B3C4D5E6F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B1C2D3E4-F567-8901-2345-6789ABCDEF01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B1C2D3E4-F567-8901-2345-6789ABCDEF01}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {B1C2D3E4-F567-8901-2345-6789ABCDEF01}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {B1C2D3E4-F567-8901-2345-6789ABCDEF01}.Release|Any CPU.Build.0 = Release|Any CPU
-                {12345678-ABCD-4E5F-9012-ABCDEF123456}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {12345678-ABCD-4E5F-9012-ABCDEF123456}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {12345678-ABCD-4E5F-9012-ABCDEF123456}.Release|Any CPU.ActiveCfg = Release|Any CPU
-{12345678-ABCD-4E5F-9012-ABCDEF123456}.Release|Any CPU.Build.0 = Release|Any CPU
-{37AF72CC-12DE-429B-A280-1F453699DA82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-{37AF72CC-12DE-429B-A280-1F453699DA82}.Debug|Any CPU.Build.0 = Debug|Any CPU
-{37AF72CC-12DE-429B-A280-1F453699DA82}.Release|Any CPU.ActiveCfg = Release|Any CPU
-{37AF72CC-12DE-429B-A280-1F453699DA82}.Release|Any CPU.Build.0 = Release|Any CPU
-EndGlobalSection
+		{B1C2D3E4-F567-8901-2345-6789ABCDEF01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1C2D3E4-F567-8901-2345-6789ABCDEF01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12345678-ABCD-4E5F-9012-ABCDEF123456}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12345678-ABCD-4E5F-9012-ABCDEF123456}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12345678-ABCD-4E5F-9012-ABCDEF123456}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12345678-ABCD-4E5F-9012-ABCDEF123456}.Release|Any CPU.Build.0 = Release|Any CPU
+		{37AF72CC-12DE-429B-A280-1F453699DA82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{37AF72CC-12DE-429B-A280-1F453699DA82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{37AF72CC-12DE-429B-A280-1F453699DA82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{37AF72CC-12DE-429B-A280-1F453699DA82}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A144AE26-3E9F-4CE5-BF35-DB0B989CB7D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A144AE26-3E9F-4CE5-BF35-DB0B989CB7D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A144AE26-3E9F-4CE5-BF35-DB0B989CB7D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A144AE26-3E9F-4CE5-BF35-DB0B989CB7D3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D4E5F678-9012-3456-7890-ABCDEF123456}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{A144AE26-3E9F-4CE5-BF35-DB0B989CB7D3} = {D6DD25C8-8170-4520-90C0-97108ABD54EE}
 	EndGlobalSection
 EndGlobal

--- a/src/dotnet-norm/Program.cs
+++ b/src/dotnet-norm/Program.cs
@@ -1,0 +1,84 @@
+using System;
+using System.CommandLine;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.Sqlite;
+using nORM.Configuration;
+using nORM.Migration;
+using nORM.Providers;
+using nORM.Scaffolding;
+
+var root = new RootCommand("nORM command line tools");
+
+var scaffold = new Command("scaffold", "Scaffold entity classes and a DbContext from an existing database");
+var connOpt = new Option<string>("--connection", description: "Connection string") { IsRequired = true };
+var providerOpt = new Option<string>("--provider", description: "Database provider (sqlserver, sqlite)") { IsRequired = true };
+var outputOpt = new Option<string>("--output", () => ".", "Output directory for generated code");
+var nsOpt = new Option<string>("--namespace", () => "Scaffolded", "Namespace for generated classes");
+var ctxOpt = new Option<string>("--context", () => "AppDbContext", "DbContext class name");
+scaffold.AddOption(connOpt);
+scaffold.AddOption(providerOpt);
+scaffold.AddOption(outputOpt);
+scaffold.AddOption(nsOpt);
+scaffold.AddOption(ctxOpt);
+
+scaffold.SetHandler(async (conn, prov, output, ns, ctx) =>
+{
+    using var connection = CreateConnection(prov, conn);
+    var provider = CreateProvider(prov);
+    await DatabaseScaffolder.ScaffoldAsync(connection, provider, output!, ns!, ctx!);
+    Console.WriteLine($"Scaffolding completed. Files written to {output}.");
+}, connOpt, providerOpt, outputOpt, nsOpt, ctxOpt);
+
+root.AddCommand(scaffold);
+
+var database = new Command("database", "Database related commands");
+var update = new Command("update", "Apply pending migrations to the database");
+var migConnOpt = new Option<string>("--connection", description: "Connection string") { IsRequired = true };
+var migProvOpt = new Option<string>("--provider", description: "Database provider (sqlserver)") { IsRequired = true };
+var assemblyOpt = new Option<string>("--assembly", description: "Path to migrations assembly") { IsRequired = true };
+update.AddOption(migConnOpt);
+update.AddOption(migProvOpt);
+update.AddOption(assemblyOpt);
+update.SetHandler(async (conn, prov, asmPath) =>
+{
+    using var connection = CreateConnection(prov, conn);
+    var assembly = Assembly.LoadFrom(asmPath!);
+    IMigrationRunner runner = prov.ToLowerInvariant() switch
+    {
+        "sqlserver" => new SqlServerMigrationRunner(connection, assembly),
+        _ => throw new ArgumentException($"Provider '{prov}' does not support migrations.")
+    };
+
+    if (!await runner.HasPendingMigrationsAsync())
+    {
+        Console.WriteLine("No pending migrations found.");
+        return;
+    }
+
+    await runner.ApplyMigrationsAsync();
+    Console.WriteLine("Migrations applied successfully.");
+}, migConnOpt, migProvOpt, assemblyOpt);
+
+database.AddCommand(update);
+root.AddCommand(database);
+
+return await root.InvokeAsync(args);
+
+static DbConnection CreateConnection(string provider, string connectionString)
+    => provider.ToLowerInvariant() switch
+    {
+        "sqlserver" => new SqlConnection(connectionString),
+        "sqlite" => new SqliteConnection(connectionString),
+        _ => throw new ArgumentException($"Unsupported provider '{provider}'.")
+    };
+
+static DatabaseProvider CreateProvider(string provider)
+    => provider.ToLowerInvariant() switch
+    {
+        "sqlserver" => new SqlServerProvider(),
+        "sqlite" => new SqliteProvider(),
+        _ => throw new ArgumentException($"Unsupported provider '{provider}'.")
+    };

--- a/src/dotnet-norm/dotnet-norm.csproj
+++ b/src/dotnet-norm/dotnet-norm.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>norm</ToolCommandName>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>dotnet-norm</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Your Name</Authors>
+    <Description>CLI tooling for nORM ORM framework</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\nORM.csproj" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta7.25380.108" />
+  </ItemGroup>
+</Project>

--- a/src/nORM.csproj
+++ b/src/nORM.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <Compile Remove="nORM.SourceGenerators/**" />
+    <Compile Remove="dotnet-norm/**" />
   </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- add `dotnet-norm` CLI project packaged as a global tool
- enable `dotnet norm scaffold` for reverse engineering entities
- enable `dotnet norm database update` to apply pending migrations

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e2cece34832cb569a9bef8a3c18e