### PR TITLE
Enable record type mapping and TPH inheritance

### DIFF
--- a/src/nORM/Mapping/DiscriminatorColumnAttribute.cs
+++ b/src/nORM/Mapping/DiscriminatorColumnAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace nORM.Mapping
+{
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public sealed class DiscriminatorColumnAttribute : Attribute
+    {
+        public string PropertyName { get; }
+        public DiscriminatorColumnAttribute(string propertyName)
+            => PropertyName = propertyName;
+    }
+}

--- a/src/nORM/Mapping/DiscriminatorValueAttribute.cs
+++ b/src/nORM/Mapping/DiscriminatorValueAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace nORM.Mapping
+{
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public sealed class DiscriminatorValueAttribute : Attribute
+    {
+        public object Value { get; }
+        public DiscriminatorValueAttribute(object value)
+            => Value = value;
+    }
+}

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -144,7 +144,8 @@ namespace nORM.Query
                 if (trackable)
                 {
                     NavigationPropertyExtensions.EnableLazyLoading(entity, _ctx);
-                    _ctx.ChangeTracker.Track(entity, EntityState.Unchanged, entityMap!);
+                    var actualMap = _ctx.GetMapping(entity.GetType());
+                    _ctx.ChangeTracker.Track(entity, EntityState.Unchanged, actualMap);
                 }
 
                 list.Add(entity);
@@ -266,7 +267,8 @@ namespace nORM.Query
         private QueryPlan GetPlan(Expression expression)
         {
             var filtered = ApplyGlobalFilters(expression);
-            var key = new QueryPlanCacheKey(filtered, _ctx.Options.TenantProvider?.GetCurrentTenantId());
+            var elementType = GetElementType(filtered);
+            var key = new QueryPlanCacheKey(filtered, _ctx.Options.TenantProvider?.GetCurrentTenantId(), elementType);
             return _planCache.GetOrAdd(key, _ => new QueryTranslator(_ctx).Translate(filtered));
         }
 

--- a/src/nORM/Query/QueryPlan.cs
+++ b/src/nORM/Query/QueryPlan.cs
@@ -38,17 +38,18 @@ namespace nORM.Query
         private readonly object? _tenantId;
         private readonly int _fingerprint;
         private readonly int _hashCode;
-
-        public QueryPlanCacheKey(Expression expression, object? tenantId)
+        private readonly Type _elementType;
+        public QueryPlanCacheKey(Expression expression, object? tenantId, Type elementType)
         {
             _tenantId = tenantId;
+            _elementType = elementType;
             _fingerprint = ExpressionFingerprint.Compute(expression);
-            _hashCode = HashCode.Combine(_tenantId?.GetHashCode() ?? 0, _fingerprint);
+            _hashCode = HashCode.Combine(_tenantId?.GetHashCode() ?? 0, _fingerprint, _elementType);
         }
 
         public override int GetHashCode() => _hashCode;
         public override bool Equals(object? obj) => Equals(obj as QueryPlanCacheKey);
         public bool Equals(QueryPlanCacheKey? other)
-            => other != null && _fingerprint == other._fingerprint && Equals(_tenantId, other._tenantId);
+            => other != null && _fingerprint == other._fingerprint && Equals(_tenantId, other._tenantId) && _elementType == other._elementType;
     }
 }

--- a/tests/AdvancedMappingTests.cs
+++ b/tests/AdvancedMappingTests.cs
@@ -1,0 +1,70 @@
+using System.Linq;
+using Microsoft.Data.Sqlite;
+using nORM.Core;
+using nORM.Providers;
+using nORM.Mapping;
+using Xunit;
+
+namespace nORM.Tests
+{
+    public record Person(int Id, string Name);
+
+    [DiscriminatorColumn(nameof(Type))]
+    public class Animal
+    {
+        public int Id { get; set; }
+        public string Type { get; set; } = string.Empty;
+    }
+
+    [DiscriminatorValue("Cat")]
+    public class Cat : Animal
+    {
+        public int Lives { get; set; }
+    }
+
+    [DiscriminatorValue("Dog")]
+    public class Dog : Animal
+    {
+        public bool GoodBoy { get; set; }
+    }
+
+    public class AdvancedMappingTests
+    {
+        [Fact]
+        public void Record_type_materializes_correctly()
+        {
+            using var cn = new SqliteConnection("Data Source=:memory:");
+            cn.Open();
+            using (var cmd = cn.CreateCommand())
+            {
+                cmd.CommandText = "CREATE TABLE Person(Id INTEGER, Name TEXT); INSERT INTO Person VALUES(1,'Alice');";
+                cmd.ExecuteNonQuery();
+            }
+            using var ctx = new DbContext(cn, new SqliteProvider());
+            var people = ctx.Query<Person>().ToList();
+            Assert.Single(people);
+            Assert.Equal(new Person(1, "Alice"), people[0]);
+        }
+
+        [Fact]
+        public void Tph_mapping_creates_derived_instances()
+        {
+            using var cn = new SqliteConnection("Data Source=:memory:");
+            cn.Open();
+            using (var cmd = cn.CreateCommand())
+            {
+                cmd.CommandText = @"CREATE TABLE Animal(Id INTEGER, Type TEXT, Lives INTEGER, GoodBoy INTEGER);
+                                    INSERT INTO Animal VALUES(1,'Cat',9,NULL);
+                                    INSERT INTO Animal VALUES(2,'Dog',NULL,1);";
+                cmd.ExecuteNonQuery();
+            }
+            using var ctx = new DbContext(cn, new SqliteProvider());
+            var animals = ctx.Query<Animal>().OrderBy(a => a.Id).ToList();
+            Assert.Equal(2, animals.Count);
+            Assert.IsType<Cat>(animals[0]);
+            Assert.Equal(9, ((Cat)animals[0]).Lives);
+            Assert.IsType<Dog>(animals[1]);
+            Assert.True(((Dog)animals[1]).GoodBoy);
+        }
+    }
+}

--- a/tests/QueryTranslatorTests.cs
+++ b/tests/QueryTranslatorTests.cs
@@ -10,7 +10,7 @@ namespace nORM.Tests
 {
     public class QueryTranslatorTests
     {
-        private static (string Sql, Dictionary<string, object> Params, Type ElementType) Translate<T, TResult>(Func<INormQueryable<T>, IQueryable<TResult>> build) where T : class, new()
+        private static (string Sql, Dictionary<string, object> Params, Type ElementType) Translate<T, TResult>(Func<IQueryable<T>, IQueryable<TResult>> build) where T : class, new()
         {
             using var cn = new SqliteConnection("Data Source=:memory:");
             using var ctx = new DbContext(cn, new SqliteProvider());


### PR DESCRIPTION
## Summary
- support discriminated inheritance with table-per-hierarchy via new attributes and mapping logic
- allow querying record types without parameterless constructors
- extend materializer to handle record constructors and TPH discriminator dispatch
- fix change tracking and query plan caching for polymorphic entities
- add coverage for record and TPH scenarios

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b7e3eaa9ac832c923b0070f7553965