### PR TITLE
Enable LINQ select projections

### DIFF
--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -93,7 +93,17 @@ namespace nORM.Query
                 }
                 else
                 {
-                    var select = string.Join(", ", _mapping.Columns.Select(c => c.EscCol));
+                    string select;
+                    if (_projection != null)
+                    {
+                        var selectVisitor = new SelectClauseVisitor(_mapping, _groupBy, _provider);
+                        select = selectVisitor.Translate(_projection.Body);
+                    }
+                    else
+                    {
+                        select = string.Join(", ", _mapping.Columns.Select(c => c.EscCol));
+                    }
+
                     var alias = _correlatedParams.Count > 0 ? _correlatedParams.Values.First().Alias : null;
                     _sql.Insert(0, $"SELECT {select} FROM {_mapping.EscTable}" + (alias != null ? $" {alias}" : string.Empty));
                 }

--- a/src/nORM/Query/SelectClauseVisitor.cs
+++ b/src/nORM/Query/SelectClauseVisitor.cs
@@ -77,6 +77,20 @@ namespace nORM.Query
             return node;
         }
 
+        protected override Expression VisitMemberInit(MemberInitExpression node)
+        {
+            for (int i = 0; i < node.Bindings.Count; i++)
+            {
+                if (i > 0) _sb.Append(", ");
+                if (node.Bindings[i] is MemberAssignment assignment)
+                {
+                    Visit(assignment.Expression);
+                    _sb.Append($" AS {_provider.Escape(assignment.Member.Name)}");
+                }
+            }
+            return node;
+        }
+
         private static Expression StripQuotes(Expression e) => e is UnaryExpression u && u.NodeType == ExpressionType.Quote ? u.Operand : e;
     }
 }

--- a/tests/QueryTranslatorTests.cs
+++ b/tests/QueryTranslatorTests.cs
@@ -44,7 +44,7 @@ namespace nORM.Tests
         public void Select_into_anonymous_type()
         {
             var (sql, parameters, elementType) = Translate<Product, object>(q => q.Select(p => new { p.Id, p.Name }));
-            Assert.Equal("SELECT \"Id\", \"Name\", \"Price\", \"CategoryId\", \"IsAvailable\" FROM \"Product\"", sql);
+            Assert.Equal("SELECT \"Id\" AS \"Id\", \"Name\" AS \"Name\" FROM \"Product\"", sql);
             Assert.Empty(parameters);
             Assert.StartsWith("<>", elementType.Name);
         }
@@ -53,7 +53,7 @@ namespace nORM.Tests
         public void Select_into_named_dto_class()
         {
             var (sql, parameters, elementType) = Translate<Product, ProductDto>(q => q.Select(p => new ProductDto { Id = p.Id, Name = p.Name }));
-            Assert.Equal("SELECT \"Id\", \"Name\", \"Price\", \"CategoryId\", \"IsAvailable\" FROM \"Product\"", sql);
+            Assert.Equal("SELECT \"Id\" AS \"Id\", \"Name\" AS \"Name\" FROM \"Product\"", sql);
             Assert.Empty(parameters);
             Assert.Equal(typeof(ProductDto), elementType);
         }


### PR DESCRIPTION
## Summary
- Respect user-provided `Select` projections by translating them into SQL select lists
- Handle member-initializer projections in `SelectClauseVisitor`
- Update tests to assert projected column selection

## Testing
- `dotnet build src/nORM.csproj -v minimal`
- `dotnet build tests/nORM.Tests.csproj -v minimal`
- `dotnet test tests/nORM.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68b7e7e28240832cb6da5da921033594