### PR TITLE
Integrate precompiled materializers into query pipeline

### DIFF
--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -138,8 +138,7 @@ namespace nORM.Query
 
             return _materializerCache.GetOrAdd(cacheKey, _ =>
             {
-                if (projection == null && targetType == mapping.Type &&
-                    CompiledMaterializerStore.TryGet(targetType, out var precompiled))
+                if (CompiledMaterializerStore.TryGet(targetType, out var precompiled))
                 {
                     return precompiled;
                 }


### PR DESCRIPTION
## Summary
- Use `CompiledMaterializerStore` in `QueryTranslator` to prefer pre-generated materializers before IL emission

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e94a3020832ca4b826571ee7a899