### PR TITLE
Add optimistic concurrency checks

### DIFF
--- a/src/nORM/Core/DbConcurrencyException.cs
+++ b/src/nORM/Core/DbConcurrencyException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace nORM.Core
+{
+    /// <summary>
+    /// Exception thrown when an optimistic concurrency conflict is detected.
+    /// </summary>
+    public class DbConcurrencyException : Exception
+    {
+        public DbConcurrencyException() { }
+        public DbConcurrencyException(string? message) : base(message) { }
+        public DbConcurrencyException(string? message, Exception? innerException) : base(message, innerException) { }
+    }
+}

--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -243,9 +243,10 @@ namespace nORM.Core
                 }
 
                 var recordsAffected = await cmd.ExecuteNonQueryWithInterceptionAsync(this, ct);
-                if (operation != WriteOperation.Insert && map.TimestampColumn != null && recordsAffected == 0)
+                if ((operation is WriteOperation.Update or WriteOperation.Delete) &&
+                    map.TimestampColumn != null && recordsAffected == 0)
                 {
-                    throw new DBConcurrencyException("A concurrency conflict occurred. The row may have been modified or deleted by another user.");
+                    throw new DbConcurrencyException("A concurrency conflict occurred. The row may have been modified or deleted by another user.");
                 }
                 if (ownsTransaction) await currentTransaction.CommitAsync(ct);
                 return recordsAffected;

--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -211,25 +211,32 @@ namespace nORM.Providers
 
         public string BuildUpdate(TableMapping m)
         {
-            return _sqlCache.GetOrAdd((m.Type, "UPDATE"), _ => {
-                var set = string.Join(", ", m.Columns.Where(c => !c.IsKey && !c.IsTimestamp).Select(c => $"{c.EscCol}={ParamPrefix}{c.PropName}"));
-                var where = string.Join(" AND ", m.KeyColumns.Select(c => $"{c.EscCol}={ParamPrefix}{c.PropName}"));
+            return _sqlCache.GetOrAdd((m.Type, "UPDATE"), _ =>
+            {
+                var set = string.Join(", ", m.Columns
+                    .Where(c => !c.IsKey && !c.IsTimestamp)
+                    .Select(c => $"{c.EscCol}={ParamPrefix}{c.PropName}"));
+
+                var whereCols = m.KeyColumns
+                    .Select(c => $"{c.EscCol}={ParamPrefix}{c.PropName}");
                 if (m.TimestampColumn != null)
-                {
-                    where += $" AND {m.TimestampColumn.EscCol}={ParamPrefix}{m.TimestampColumn.PropName}";
-                }
+                    whereCols = whereCols.Append($"{m.TimestampColumn.EscCol}={ParamPrefix}{m.TimestampColumn.PropName}");
+                var where = string.Join(" AND ", whereCols);
+
                 return $"UPDATE {m.EscTable} SET {set} WHERE {where}";
             });
         }
 
         public string BuildDelete(TableMapping m)
         {
-            return _sqlCache.GetOrAdd((m.Type, "DELETE"), _ => {
-                var where = string.Join(" AND ", m.KeyColumns.Select(c => $"{c.EscCol}={ParamPrefix}{c.PropName}"));
+            return _sqlCache.GetOrAdd((m.Type, "DELETE"), _ =>
+            {
+                var whereCols = m.KeyColumns
+                    .Select(c => $"{c.EscCol}={ParamPrefix}{c.PropName}");
                 if (m.TimestampColumn != null)
-                {
-                    where += $" AND {m.TimestampColumn.EscCol}={ParamPrefix}{m.TimestampColumn.PropName}";
-                }
+                    whereCols = whereCols.Append($"{m.TimestampColumn.EscCol}={ParamPrefix}{m.TimestampColumn.PropName}");
+                var where = string.Join(" AND ", whereCols);
+
                 return $"DELETE FROM {m.EscTable} WHERE {where}";
             });
         }


### PR DESCRIPTION
## Summary
- append timestamp checks when building UPDATE and DELETE statements
- throw `DbConcurrencyException` when a row update or deletion fails due to a version mismatch
- introduce `DbConcurrencyException` type for concurrency conflicts

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ed7899a4832c92ce3103f6513f8c