### PR TITLE
Implement SelectMany join translation with cross join support

### DIFF
--- a/tests/QueryTranslatorTests.cs
+++ b/tests/QueryTranslatorTests.cs
@@ -93,5 +93,14 @@ namespace nORM.Tests
             Assert.Equal("SELECT \"Id\", \"Name\", \"Price\", \"CategoryId\", \"IsAvailable\" FROM \"Product\" T0 ORDER BY T0.\"Id\" ASC LIMIT 10 OFFSET 20", sql);
         }
 
+        [Fact]
+        public void SelectMany_creates_cross_join()
+        {
+            var (sql, parameters, elementType) = Translate<Product, Product>(q => q.SelectMany(p => q));
+            Assert.Equal("SELECT T1.\"Id\", T1.\"Name\", T1.\"Price\", T1.\"CategoryId\", T1.\"IsAvailable\" FROM \"Product\" T0 CROSS JOIN \"Product\" T1", sql);
+            Assert.Empty(parameters);
+            Assert.Equal(typeof(Product), elementType);
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
- Expand QueryTranslator to translate SelectMany into INNER or CROSS JOINs.
- Track correlated parameters for joined tables.
- Add unit test validating cross join SQL generation.

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b7ef7fef3c832c80d7a24ae14f885a