### PR TITLE
Add SQL translation for common .NET methods

### DIFF
--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -23,6 +23,7 @@ namespace nORM.Providers
         public abstract void ApplyPaging(StringBuilder sb, int? limit, int? offset);
         public abstract string GetIdentityRetrievalString(TableMapping m);
         public abstract DbParameter CreateParameter(string name, object? value);
+        public abstract string? TranslateFunction(string name, Type declaringType, params string[] args);
 
         public virtual char LikeEscapeChar => '\\';
 

--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -43,6 +43,49 @@ namespace nORM.Providers
                 throw new InvalidOperationException("MySQL package is required for MySQL support. Please install either MySqlConnector or MySql.Data NuGet package.");
             }
         }
+
+        public override string? TranslateFunction(string name, Type declaringType, params string[] args)
+        {
+            if (declaringType == typeof(string))
+            {
+                return name switch
+                {
+                    nameof(string.ToUpper) => $"UPPER({args[0]})",
+                    nameof(string.ToLower) => $"LOWER({args[0]})",
+                    nameof(string.Length) when args.Length == 1 => $"CHAR_LENGTH({args[0]})",
+                    _ => null
+                };
+            }
+
+            if (declaringType == typeof(DateTime))
+            {
+                return name switch
+                {
+                    nameof(DateTime.Year) => $"YEAR({args[0]})",
+                    nameof(DateTime.Month) => $"MONTH({args[0]})",
+                    nameof(DateTime.Day) => $"DAY({args[0]})",
+                    nameof(DateTime.Hour) => $"HOUR({args[0]})",
+                    nameof(DateTime.Minute) => $"MINUTE({args[0]})",
+                    nameof(DateTime.Second) => $"SECOND({args[0]})",
+                    _ => null
+                };
+            }
+
+            if (declaringType == typeof(Math))
+            {
+                return name switch
+                {
+                    nameof(Math.Abs) => $"ABS({args[0]})",
+                    nameof(Math.Ceiling) => $"CEILING({args[0]})",
+                    nameof(Math.Floor) => $"FLOOR({args[0]})",
+                    nameof(Math.Round) when args.Length > 1 => $"ROUND({args[0]}, {args[1]})",
+                    nameof(Math.Round) => $"ROUND({args[0]})",
+                    _ => null
+                };
+            }
+
+            return null;
+        }
         
         public override async Task<int> BulkInsertAsync<T>(DbContext ctx, TableMapping m, IEnumerable<T> entities, CancellationToken ct) where T : class
         {

--- a/src/nORM/Providers/PostgresProvider.cs
+++ b/src/nORM/Providers/PostgresProvider.cs
@@ -47,6 +47,49 @@ namespace nORM.Providers
             }
         }
 
+        public override string? TranslateFunction(string name, Type declaringType, params string[] args)
+        {
+            if (declaringType == typeof(string))
+            {
+                return name switch
+                {
+                    nameof(string.ToUpper) => $"UPPER({args[0]})",
+                    nameof(string.ToLower) => $"LOWER({args[0]})",
+                    nameof(string.Length) when args.Length == 1 => $"LENGTH({args[0]})",
+                    _ => null
+                };
+            }
+
+            if (declaringType == typeof(DateTime))
+            {
+                return name switch
+                {
+                    nameof(DateTime.Year) => $"EXTRACT(YEAR FROM {args[0]})",
+                    nameof(DateTime.Month) => $"EXTRACT(MONTH FROM {args[0]})",
+                    nameof(DateTime.Day) => $"EXTRACT(DAY FROM {args[0]})",
+                    nameof(DateTime.Hour) => $"EXTRACT(HOUR FROM {args[0]})",
+                    nameof(DateTime.Minute) => $"EXTRACT(MINUTE FROM {args[0]})",
+                    nameof(DateTime.Second) => $"EXTRACT(SECOND FROM {args[0]})",
+                    _ => null
+                };
+            }
+
+            if (declaringType == typeof(Math))
+            {
+                return name switch
+                {
+                    nameof(Math.Abs) => $"ABS({args[0]})",
+                    nameof(Math.Ceiling) => $"CEILING({args[0]})",
+                    nameof(Math.Floor) => $"FLOOR({args[0]})",
+                    nameof(Math.Round) when args.Length > 1 => $"ROUND({args[0]}, {args[1]})",
+                    nameof(Math.Round) => $"ROUND({args[0]})",
+                    _ => null
+                };
+            }
+
+            return null;
+        }
+
         // PostgreSQL-optimized bulk operations
         public override async Task<int> BulkInsertAsync<T>(DbContext ctx, TableMapping m, IEnumerable<T> entities, CancellationToken ct) where T : class
         {

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -48,6 +48,49 @@ namespace nORM.Providers
                 .Replace("^", esc + "^");
         }
 
+        public override string? TranslateFunction(string name, Type declaringType, params string[] args)
+        {
+            if (declaringType == typeof(string))
+            {
+                return name switch
+                {
+                    nameof(string.ToUpper) => $"UPPER({args[0]})",
+                    nameof(string.ToLower) => $"LOWER({args[0]})",
+                    nameof(string.Length) when args.Length == 1 => $"LEN({args[0]})",
+                    _ => null
+                };
+            }
+
+            if (declaringType == typeof(DateTime))
+            {
+                return name switch
+                {
+                    nameof(DateTime.Year) => $"YEAR({args[0]})",
+                    nameof(DateTime.Month) => $"MONTH({args[0]})",
+                    nameof(DateTime.Day) => $"DAY({args[0]})",
+                    nameof(DateTime.Hour) => $"DATEPART(hour, {args[0]})",
+                    nameof(DateTime.Minute) => $"DATEPART(minute, {args[0]})",
+                    nameof(DateTime.Second) => $"DATEPART(second, {args[0]})",
+                    _ => null
+                };
+            }
+
+            if (declaringType == typeof(Math))
+            {
+                return name switch
+                {
+                    nameof(Math.Abs) => $"ABS({args[0]})",
+                    nameof(Math.Ceiling) => $"CEILING({args[0]})",
+                    nameof(Math.Floor) => $"FLOOR({args[0]})",
+                    nameof(Math.Round) when args.Length > 1 => $"ROUND({args[0]}, {args[1]})",
+                    nameof(Math.Round) => $"ROUND({args[0]})",
+                    _ => null
+                };
+            }
+
+            return null;
+        }
+
         #region SQL Server Bulk Operations
         public override async Task<int> BulkInsertAsync<T>(DbContext ctx, TableMapping m, IEnumerable<T> entities, CancellationToken ct) where T : class
         {

--- a/tests/ExpressionToSqlVisitorTests.cs
+++ b/tests/ExpressionToSqlVisitorTests.cs
@@ -30,6 +30,7 @@ namespace nORM.Tests
             public string? Name { get; set; }
             public decimal Price { get; set; }
             public bool IsAvailable { get; set; }
+            public DateTime CreatedAt { get; set; }
         }
 
         [Fact]
@@ -129,8 +130,28 @@ namespace nORM.Tests
         public void Where_with_method_call_resolving_to_constant()
         {
             var testName = "TEST";
-            var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() => Translate<Product>(p => p.Name == testName.ToLower()));
-            Assert.IsType<NotSupportedException>(ex.InnerException);
+            var (sql, parameters) = Translate<Product>(p => p.Name == testName.ToLower());
+            Assert.Equal("(T0.\"Name\" = @p0)", sql);
+            Assert.Single(parameters);
+            Assert.Equal("test", parameters["@p0"]);
+        }
+
+        [Fact]
+        public void Where_with_string_ToUpper()
+        {
+            var (sql, parameters) = Translate<Product>(p => p.Name!.ToUpper() == "TEST");
+            Assert.Equal("(UPPER(T0.\"Name\") = @p0)", sql);
+            Assert.Single(parameters);
+            Assert.Equal("TEST", parameters["@p0"]);
+        }
+
+        [Fact]
+        public void Where_with_datetime_year()
+        {
+            var (sql, parameters) = Translate<Product>(p => p.CreatedAt.Year == 2025);
+            Assert.Equal("(CAST(strftime('%Y', T0.\"CreatedAt\") AS INTEGER) = @p0)", sql);
+            Assert.Single(parameters);
+            Assert.Equal(2025, parameters["@p0"]);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- map common .NET string/date/math members to SQL functions via new provider API
- extend ExpressionToSqlVisitor to translate these method and property calls
- add unit tests for translating ToUpper and DateTime.Year and constant method calls

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7f6dc95d0832cafe47d2d313dfffd