### PR TITLE
Use precompiled materializers before IL generation

### DIFF
--- a/tests/ExpressionToSqlVisitorTests.cs
+++ b/tests/ExpressionToSqlVisitorTests.cs
@@ -16,7 +16,7 @@ namespace nORM.Tests
             public DateTime CreatedAt { get; set; }
         }
 
-        private class NumericTypesEntity
+        public class NumericTypesEntity
         {
             public int IntValue { get; set; }
             public long LongValue { get; set; }

--- a/tests/SourceGeneratorIntegrationTests.cs
+++ b/tests/SourceGeneratorIntegrationTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using nORM.Core;
+using nORM.Providers;
+using nORM.SourceGeneration;
+using Xunit;
+
+namespace nORM.Tests
+{
+    public class SourceGeneratorIntegrationTests
+    {
+        [Fact]
+        public void QueryTranslator_uses_precompiled_materializer_when_available()
+        {
+            using var cn = new SqliteConnection("Data Source=:memory:");
+            using var ctx = new DbContext(cn, new SqliteProvider());
+            var translatorType = typeof(DbContext).Assembly.GetType("nORM.Query.QueryTranslator", true)!;
+            var translator = Activator.CreateInstance(translatorType, ctx)!;
+            var getMapping = typeof(DbContext).GetMethod("GetMapping", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var mapping = getMapping.Invoke(ctx, new object[] { typeof(Materialized) });
+            var create = translatorType.GetMethod("CreateMaterializer")!;
+            var materializer = (Func<DbDataReader, object>)create.Invoke(translator, new object?[] { mapping!, typeof(Materialized), null })!;
+            Assert.True(CompiledMaterializerStore.TryGet(typeof(Materialized), out var precompiled));
+            Assert.Same(precompiled, materializer);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- consult `CompiledMaterializerStore` for precompiled materializers in `QueryTranslator`
- add integration test to ensure precompiled materializers are used

## Testing
- `dotnet test` *(fails: LocalDB is not supported on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fd4fa4b0832c965483ebd9de9379