### PR TITLE
Add ThenInclude support for nested eager loading

### DIFF
--- a/src/nORM/Core/NormQueryable.cs
+++ b/src/nORM/Core/NormQueryable.cs
@@ -27,7 +27,7 @@ namespace nORM.Core
     /// </summary>
     public interface INormQueryable<T> : IOrderedQueryable<T>
     {
-        INormQueryable<T> Include(Expression<Func<T, object>> navigationPropertyPath);
+        INormIncludableQueryable<T, TProperty> Include<TProperty>(Expression<Func<T, TProperty>> navigationPropertyPath);
         INormQueryable<T> AsNoTracking();
         Task<List<T>> ToListAsync(CancellationToken ct = default);
         Task<T[]> ToArrayAsync(CancellationToken ct = default);
@@ -37,6 +37,10 @@ namespace nORM.Core
         Task<T?> FirstOrDefaultAsync(CancellationToken ct = default);
         Task<T> SingleAsync(CancellationToken ct = default);
         Task<T?> SingleOrDefaultAsync(CancellationToken ct = default);
+    }
+
+    public interface INormIncludableQueryable<TEntity, out TProperty> : INormQueryable<TEntity>
+    {
     }
 
     // Base interface for internal use without constraints
@@ -66,16 +70,14 @@ namespace nORM.Core
         public IEnumerator<T> GetEnumerator() => Provider.Execute<IEnumerable<T>>(Expression).GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public INormQueryable<T> Include(Expression<Func<T, object>> path)
+        public INormIncludableQueryable<T, TProperty> Include<TProperty>(Expression<Func<T, TProperty>> path)
         {
-            var expression = Expression.Call(
-                typeof(INormQueryable<>).MakeGenericType(typeof(T)),
-                nameof(Include),
-                Type.EmptyTypes,
-                Expression,
-                path
-            );
-            return new NormQueryableImpl<T>(Provider, expression);
+            var method = typeof(INormQueryable<>).MakeGenericType(typeof(T))
+                .GetMethods()
+                .Single(m => m.Name == nameof(Include) && m.IsGenericMethod);
+            var generic = method.MakeGenericMethod(typeof(TProperty));
+            var expression = Expression.Call(Expression, generic, Expression.Quote(path));
+            return new NormIncludableQueryable<T, TProperty>(Provider, expression);
         }
 
         public INormQueryable<T> AsNoTracking()
@@ -123,5 +125,85 @@ namespace nORM.Core
 
         public IEnumerator<T> GetEnumerator() => Provider.Execute<IEnumerable<T>>(Expression).GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    internal sealed class NormIncludableQueryable<T, TProperty> : INormIncludableQueryable<T, TProperty> where T : class, new()
+    {
+        public Expression Expression { get; }
+        public Type ElementType => typeof(T);
+        public IQueryProvider Provider { get; }
+
+        public NormIncludableQueryable(IQueryProvider provider, Expression expression)
+        {
+            Provider = provider;
+            Expression = expression;
+        }
+
+        public IEnumerator<T> GetEnumerator() => Provider.Execute<IEnumerable<T>>(Expression).GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public INormIncludableQueryable<T, TProperty2> Include<TProperty2>(Expression<Func<T, TProperty2>> path)
+        {
+            var method = typeof(INormQueryable<>).MakeGenericType(typeof(T))
+                .GetMethods()
+                .Single(m => m.Name == nameof(INormQueryable<T>.Include) && m.IsGenericMethod);
+            var generic = method.MakeGenericMethod(typeof(TProperty2));
+            var expression = Expression.Call(Expression, generic, Expression.Quote(path));
+            return new NormIncludableQueryable<T, TProperty2>(Provider, expression);
+        }
+
+        public INormQueryable<T> AsNoTracking()
+        {
+            var expression = Expression.Call(
+                typeof(INormQueryable<>).MakeGenericType(typeof(T)),
+                nameof(INormQueryable<T>.AsNoTracking),
+                Type.EmptyTypes,
+                Expression
+            );
+            return new NormQueryableImpl<T>(Provider, expression);
+        }
+
+        public Task<List<T>> ToListAsync(CancellationToken ct = default)
+            => ((NormQueryProvider)Provider).ExecuteAsync<List<T>>(Expression, ct);
+        public async Task<T[]> ToArrayAsync(CancellationToken ct = default) => (await ToListAsync(ct)).ToArray();
+        public Task<int> CountAsync(CancellationToken ct = default)
+            => ((NormQueryProvider)Provider).ExecuteAsync<int>(Expression.Call(typeof(Queryable), nameof(Queryable.Count), new[] { typeof(T) }, Expression), ct);
+        public async Task<bool> AnyAsync(CancellationToken ct = default)
+            => await ((NormQueryProvider)Provider).ExecuteAsync<bool>(Expression.Call(typeof(Queryable), nameof(Queryable.Any), new[] { typeof(T) }, Expression), ct);
+        public Task<T> FirstAsync(CancellationToken ct = default)
+            => ((NormQueryProvider)Provider).ExecuteAsync<T>(Expression.Call(typeof(Queryable), nameof(Queryable.First), new[] { typeof(T) }, Expression), ct);
+        public Task<T?> FirstOrDefaultAsync(CancellationToken ct = default)
+            => ((NormQueryProvider)Provider).ExecuteAsync<T?>(Expression.Call(typeof(Queryable), nameof(Queryable.FirstOrDefault), new[] { typeof(T) }, Expression), ct);
+        public Task<T> SingleAsync(CancellationToken ct = default)
+            => ((NormQueryProvider)Provider).ExecuteAsync<T>(Expression.Call(typeof(Queryable), nameof(Queryable.Single), new[] { typeof(T) }, Expression), ct);
+        public Task<T?> SingleOrDefaultAsync(CancellationToken ct = default)
+            => ((NormQueryProvider)Provider).ExecuteAsync<T?>(Expression.Call(typeof(Queryable), nameof(Queryable.SingleOrDefault), new[] { typeof(T) }, Expression), ct);
+    }
+
+    public static class NormIncludableQueryableExtensions
+    {
+        public static INormIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+            this INormIncludableQueryable<TEntity, TPreviousProperty> source,
+            Expression<Func<TPreviousProperty, TProperty>> path)
+            where TEntity : class, new()
+        {
+            var method = ((System.Reflection.MethodInfo)System.Reflection.MethodBase.GetCurrentMethod()!)
+                .GetGenericMethodDefinition()
+                .MakeGenericMethod(typeof(TEntity), typeof(TPreviousProperty), typeof(TProperty));
+            var expression = Expression.Call(method, ((IQueryable<TEntity>)source).Expression, Expression.Quote(path));
+            return new NormIncludableQueryable<TEntity, TProperty>(((IQueryable<TEntity>)source).Provider, expression);
+        }
+
+        public static INormIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+            this INormIncludableQueryable<TEntity, IEnumerable<TPreviousProperty>> source,
+            Expression<Func<TPreviousProperty, TProperty>> path)
+            where TEntity : class, new()
+        {
+            var method = ((System.Reflection.MethodInfo)System.Reflection.MethodBase.GetCurrentMethod()!)
+                .GetGenericMethodDefinition()
+                .MakeGenericMethod(typeof(TEntity), typeof(TPreviousProperty), typeof(TProperty));
+            var expression = Expression.Call(method, ((IQueryable<TEntity>)source).Expression, Expression.Quote(path));
+            return new NormIncludableQueryable<TEntity, TProperty>(((IQueryable<TEntity>)source).Provider, expression);
+        }
     }
 }

--- a/src/nORM/Query/QueryPlan.cs
+++ b/src/nORM/Query/QueryPlan.cs
@@ -20,8 +20,8 @@ namespace nORM.Query
         List<IncludePlan> Includes,
         GroupJoinInfo? GroupJoinInfo
     );
-    
-    internal sealed record IncludePlan(TableMapping.Relation Relation);
+
+    internal sealed record IncludePlan(List<TableMapping.Relation> Path);
     
     internal sealed record GroupJoinInfo(
         Type OuterType, 


### PR DESCRIPTION
## Summary
- support nested eager loading via new `ThenInclude` API
- track include paths in query planning
- traverse include paths during eager loading

## Testing
- `dotnet test` *(fails: LocalDB is not supported on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b801c79424832cab4bb02a8a026725