### PR TITLE
Enable streaming query results via IAsyncEnumerable

### DIFF
--- a/src/nORM/Core/NormAsyncExtensions.cs
+++ b/src/nORM/Core/NormAsyncExtensions.cs
@@ -14,6 +14,22 @@ namespace nORM.Core
     public static class NormAsyncExtensions
     {
         /// <summary>
+        /// Streams nORM query results asynchronously - only works with nORM queries
+        /// </summary>
+        public static IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IQueryable<T> source, CancellationToken ct = default)
+            where T : class
+        {
+            if (source.Provider is Query.NormQueryProvider normProvider)
+            {
+                return normProvider.AsAsyncEnumerable<T>(source.Expression, ct);
+            }
+
+            throw new InvalidOperationException(
+                "AsAsyncEnumerable extension can only be used with nORM queries. " +
+                "Make sure you started with context.Query<T>().");
+        }
+
+        /// <summary>
         /// Converts nORM query to List asynchronously - only works with nORM queries
         /// </summary>
         public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source, CancellationToken ct = default)

--- a/src/nORM/Core/NormQueryable.cs
+++ b/src/nORM/Core/NormQueryable.cs
@@ -29,6 +29,7 @@ namespace nORM.Core
     {
         INormIncludableQueryable<T, TProperty> Include<TProperty>(Expression<Func<T, TProperty>> navigationPropertyPath);
         INormQueryable<T> AsNoTracking();
+        IAsyncEnumerable<T> AsAsyncEnumerable(CancellationToken ct = default);
         Task<List<T>> ToListAsync(CancellationToken ct = default);
         Task<T[]> ToArrayAsync(CancellationToken ct = default);
         Task<int> CountAsync(CancellationToken ct = default);
@@ -90,6 +91,9 @@ namespace nORM.Core
             );
             return new NormQueryableImpl<T>(Provider, expression);
         }
+
+        public IAsyncEnumerable<T> AsAsyncEnumerable(CancellationToken ct = default)
+            => ((NormQueryProvider)Provider).AsAsyncEnumerable<T>(Expression, ct);
 
         public Task<List<T>> ToListAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<List<T>>(Expression, ct);
         public async Task<T[]> ToArrayAsync(CancellationToken ct = default) => (await ToListAsync(ct)).ToArray();
@@ -162,6 +166,9 @@ namespace nORM.Core
             );
             return new NormQueryableImpl<T>(Provider, expression);
         }
+
+        public IAsyncEnumerable<T> AsAsyncEnumerable(CancellationToken ct = default)
+            => ((NormQueryProvider)Provider).AsAsyncEnumerable<T>(Expression, ct);
 
         public Task<List<T>> ToListAsync(CancellationToken ct = default)
             => ((NormQueryProvider)Provider).ExecuteAsync<List<T>>(Expression, ct);

--- a/tests/AsyncEnumerableTests.cs
+++ b/tests/AsyncEnumerableTests.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using nORM.Core;
+using nORM.Providers;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class AsyncEnumerableTests
+{
+    public class Person
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public async Task AsAsyncEnumerable_streams_results()
+    {
+        using var cn = new SqliteConnection("Data Source=:memory:");
+        cn.Open();
+        using (var cmd = cn.CreateCommand())
+        {
+            cmd.CommandText = "CREATE TABLE Person(Id INTEGER, Name TEXT);" +
+                             "INSERT INTO Person VALUES(1,'Alice');" +
+                             "INSERT INTO Person VALUES(2,'Bob');";
+            cmd.ExecuteNonQuery();
+        }
+        using var ctx = new DbContext(cn, new SqliteProvider());
+        var results = new List<Person>();
+        await foreach (var p in ctx.Query<Person>().OrderBy(p => p.Id).AsAsyncEnumerable())
+        {
+            results.Add(p);
+        }
+        Assert.Equal(2, results.Count);
+        Assert.Equal("Alice", results[0].Name);
+        Assert.Equal("Bob", results[1].Name);
+    }
+}


### PR DESCRIPTION
## Summary
- add `AsAsyncEnumerable` to nORM query API
- implement streaming materialization with async iterator in `NormQueryProvider`
- expose `AsAsyncEnumerable` extension and cover with unit test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b804d211a0832cb958c134c6cbdc5a