### PR TITLE
feat(cli): add migrations add command

### DIFF
--- a/src/nORM/Migration/IMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/IMigrationSqlGenerator.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace nORM.Migration
+{
+    public interface IMigrationSqlGenerator
+    {
+        MigrationSqlStatements GenerateSql(SchemaDiff diff);
+    }
+
+    public record MigrationSqlStatements(IReadOnlyList<string> Up, IReadOnlyList<string> Down);
+}

--- a/src/nORM/Migration/SchemaSnapshot.cs
+++ b/src/nORM/Migration/SchemaSnapshot.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Reflection;
+
+namespace nORM.Migration
+{
+    public class SchemaSnapshot
+    {
+        public List<TableSchema> Tables { get; set; } = new();
+    }
+
+    public class TableSchema
+    {
+        public string Name { get; set; } = string.Empty;
+        public List<ColumnSchema> Columns { get; set; } = new();
+    }
+
+    public class ColumnSchema
+    {
+        public string Name { get; set; } = string.Empty;
+        public string ClrType { get; set; } = string.Empty;
+        public bool IsNullable { get; set; }
+    }
+
+    public static class SchemaSnapshotBuilder
+    {
+        public static SchemaSnapshot Build(Assembly assembly)
+        {
+            var snapshot = new SchemaSnapshot();
+            foreach (var type in assembly.GetTypes())
+            {
+                if (!type.IsClass || type.IsAbstract)
+                    continue;
+
+                var tableAttr = type.GetCustomAttribute<TableAttribute>();
+                // If no Table attribute and no Key property, skip
+                if (tableAttr == null && !type.GetProperties().Any(p => p.GetCustomAttribute<KeyAttribute>() != null))
+                    continue;
+
+                var table = new TableSchema
+                {
+                    Name = tableAttr?.Name ?? type.Name
+                };
+
+                foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    if (!prop.CanRead || !prop.CanWrite)
+                        continue;
+                    if (prop.GetCustomAttribute<NotMappedAttribute>() != null)
+                        continue;
+
+                    var colAttr = prop.GetCustomAttribute<ColumnAttribute>();
+                    var clr = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+                    var column = new ColumnSchema
+                    {
+                        Name = colAttr?.Name ?? prop.Name,
+                        ClrType = clr.FullName ?? clr.Name,
+                        IsNullable = !prop.PropertyType.IsValueType || Nullable.GetUnderlyingType(prop.PropertyType) != null
+                    };
+                    table.Columns.Add(column);
+                }
+
+                snapshot.Tables.Add(table);
+            }
+
+            return snapshot;
+        }
+    }
+
+    public class SchemaDiff
+    {
+        public List<TableSchema> AddedTables { get; } = new();
+        public List<(TableSchema Table, ColumnSchema Column)> AddedColumns { get; } = new();
+        public List<(TableSchema Table, ColumnSchema NewColumn, ColumnSchema OldColumn)> AlteredColumns { get; } = new();
+
+        public bool HasChanges => AddedTables.Count > 0 || AddedColumns.Count > 0 || AlteredColumns.Count > 0;
+    }
+
+    public static class SchemaDiffer
+    {
+        public static SchemaDiff Diff(SchemaSnapshot oldSnapshot, SchemaSnapshot newSnapshot)
+        {
+            var diff = new SchemaDiff();
+            foreach (var newTable in newSnapshot.Tables)
+            {
+                var oldTable = oldSnapshot.Tables.FirstOrDefault(t => string.Equals(t.Name, newTable.Name, StringComparison.OrdinalIgnoreCase));
+                if (oldTable == null)
+                {
+                    diff.AddedTables.Add(newTable);
+                    continue;
+                }
+
+                foreach (var col in newTable.Columns)
+                {
+                    var oldCol = oldTable.Columns.FirstOrDefault(c => string.Equals(c.Name, col.Name, StringComparison.OrdinalIgnoreCase));
+                    if (oldCol == null)
+                        diff.AddedColumns.Add((newTable, col));
+                    else if (!string.Equals(oldCol.ClrType, col.ClrType, StringComparison.OrdinalIgnoreCase) || oldCol.IsNullable != col.IsNullable)
+                        diff.AlteredColumns.Add((newTable, col, oldCol));
+                }
+            }
+            return diff;
+        }
+    }
+}

--- a/src/nORM/Migration/SqlServerMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/SqlServerMigrationSqlGenerator.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace nORM.Migration
+{
+    public class SqlServerMigrationSqlGenerator : IMigrationSqlGenerator
+    {
+        private static readonly Dictionary<string, string> TypeMap = new()
+        {
+            { typeof(int).FullName!, "INT" },
+            { typeof(long).FullName!, "BIGINT" },
+            { typeof(short).FullName!, "SMALLINT" },
+            { typeof(byte).FullName!, "TINYINT" },
+            { typeof(bool).FullName!, "BIT" },
+            { typeof(string).FullName!, "NVARCHAR(MAX)" },
+            { typeof(DateTime).FullName!, "DATETIME2" },
+            { typeof(decimal).FullName!, "DECIMAL(18,2)" },
+            { typeof(double).FullName!, "FLOAT" },
+            { typeof(float).FullName!, "REAL" },
+            { typeof(Guid).FullName!, "UNIQUEIDENTIFIER" }
+        };
+
+        public MigrationSqlStatements GenerateSql(SchemaDiff diff)
+        {
+            var up = new List<string>();
+            var down = new List<string>();
+
+            foreach (var table in diff.AddedTables)
+            {
+                var cols = table.Columns.Select(c =>
+                    $"[{c.Name}] {GetSqlType(c)} {(c.IsNullable ? "NULL" : "NOT NULL")}");
+                up.Add($"CREATE TABLE [{table.Name}] ({string.Join(", ", cols)})");
+                down.Add($"DROP TABLE [{table.Name}]");
+            }
+
+            foreach (var (table, column) in diff.AddedColumns)
+            {
+                var colDef = $"[{column.Name}] {GetSqlType(column)} {(column.IsNullable ? "NULL" : "NOT NULL")}";
+                up.Add($"ALTER TABLE [{table.Name}] ADD {colDef}");
+                down.Add($"ALTER TABLE [{table.Name}] DROP COLUMN [{column.Name}]");
+            }
+
+            foreach (var (table, newCol, oldCol) in diff.AlteredColumns)
+            {
+                var newDef = $"[{newCol.Name}] {GetSqlType(newCol)} {(newCol.IsNullable ? "NULL" : "NOT NULL")}";
+                up.Add($"ALTER TABLE [{table.Name}] ALTER COLUMN {newDef}");
+                var oldDef = $"[{oldCol.Name}] {GetSqlType(oldCol)} {(oldCol.IsNullable ? "NULL" : "NOT NULL")}";
+                down.Add($"ALTER TABLE [{table.Name}] ALTER COLUMN {oldDef}");
+            }
+
+            return new MigrationSqlStatements(up, down);
+        }
+
+        private static string GetSqlType(ColumnSchema column)
+            => TypeMap.TryGetValue(column.ClrType, out var sql) ? sql : "NVARCHAR(MAX)";
+    }
+}


### PR DESCRIPTION
## Summary
- add schema snapshot and diff utilities for migrations
- support generating SQL Server DDL from snapshot diffs
- add `dotnet norm migrations add` command to generate migration files and update schema snapshots

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b8070c4c0c832c97643291123a296e