### PR TITLE
Implement batch update and delete operations

### DIFF
--- a/src/nORM/Core/NormAsyncExtensions.cs
+++ b/src/nORM/Core/NormAsyncExtensions.cs
@@ -140,17 +140,43 @@ namespace nORM.Core
             if (source.Provider is Query.NormQueryProvider normProvider)
             {
                 var firstOrDefaultExpression = Expression.Call(
-                    typeof(Queryable), 
-                    nameof(Queryable.FirstOrDefault), 
-                    new[] { typeof(T) }, 
+                    typeof(Queryable),
+                    nameof(Queryable.FirstOrDefault),
+                    new[] { typeof(T) },
                     source.Expression);
                 return normProvider.ExecuteAsync<T?>(firstOrDefaultExpression, ct);
             }
-            
+
             throw new InvalidOperationException(
                 "FirstOrDefaultAsync extension can only be used with nORM queries. " +
                 "Make sure you started with context.Query<T>(). " +
                 "For Entity Framework queries, use Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.FirstOrDefaultAsync().");
+        }
+
+        public static Task<int> ExecuteDeleteAsync<T>(this IQueryable<T> source, CancellationToken ct = default)
+            where T : class
+        {
+            if (source.Provider is Query.NormQueryProvider normProvider)
+            {
+                return normProvider.ExecuteDeleteAsync(source.Expression, ct);
+            }
+
+            throw new InvalidOperationException(
+                "ExecuteDeleteAsync extension can only be used with nORM queries. " +
+                "Make sure you started with context.Query<T>().");
+        }
+
+        public static Task<int> ExecuteUpdateAsync<T>(this IQueryable<T> source, Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> set, CancellationToken ct = default)
+            where T : class
+        {
+            if (source.Provider is Query.NormQueryProvider normProvider)
+            {
+                return normProvider.ExecuteUpdateAsync(source.Expression, set, ct);
+            }
+
+            throw new InvalidOperationException(
+                "ExecuteUpdateAsync extension can only be used with nORM queries. " +
+                "Make sure you started with context.Query<T>().");
         }
         
         // Join operations for nORM - these don't conflict since they return IQueryable

--- a/src/nORM/Core/NormQueryable.cs
+++ b/src/nORM/Core/NormQueryable.cs
@@ -38,6 +38,8 @@ namespace nORM.Core
         Task<T?> FirstOrDefaultAsync(CancellationToken ct = default);
         Task<T> SingleAsync(CancellationToken ct = default);
         Task<T?> SingleOrDefaultAsync(CancellationToken ct = default);
+        Task<int> ExecuteDeleteAsync(CancellationToken ct = default);
+        Task<int> ExecuteUpdateAsync(Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> set, CancellationToken ct = default);
     }
 
     public interface INormIncludableQueryable<TEntity, out TProperty> : INormQueryable<TEntity>
@@ -103,6 +105,9 @@ namespace nORM.Core
         public Task<T?> FirstOrDefaultAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<T?>(Expression.Call(typeof(Queryable), nameof(Queryable.FirstOrDefault), new[] { typeof(T) }, Expression), ct);
         public Task<T> SingleAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<T>(Expression.Call(typeof(Queryable), nameof(Queryable.Single), new[] { typeof(T) }, Expression), ct);
         public Task<T?> SingleOrDefaultAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<T?>(Expression.Call(typeof(Queryable), nameof(Queryable.SingleOrDefault), new[] { typeof(T) }, Expression), ct);
+        public Task<int> ExecuteDeleteAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteDeleteAsync(Expression, ct);
+        public Task<int> ExecuteUpdateAsync(Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> set, CancellationToken ct = default)
+            => ((NormQueryProvider)Provider).ExecuteUpdateAsync(Expression, set, ct);
     }
 
     /// <summary>
@@ -185,6 +190,9 @@ namespace nORM.Core
             => ((NormQueryProvider)Provider).ExecuteAsync<T>(Expression.Call(typeof(Queryable), nameof(Queryable.Single), new[] { typeof(T) }, Expression), ct);
         public Task<T?> SingleOrDefaultAsync(CancellationToken ct = default)
             => ((NormQueryProvider)Provider).ExecuteAsync<T?>(Expression.Call(typeof(Queryable), nameof(Queryable.SingleOrDefault), new[] { typeof(T) }, Expression), ct);
+        public Task<int> ExecuteDeleteAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteDeleteAsync(Expression, ct);
+        public Task<int> ExecuteUpdateAsync(Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> set, CancellationToken ct = default)
+            => ((NormQueryProvider)Provider).ExecuteUpdateAsync(Expression, set, ct);
     }
 
     public static class NormIncludableQueryableExtensions

--- a/src/nORM/Core/SetPropertyCalls.cs
+++ b/src/nORM/Core/SetPropertyCalls.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Linq.Expressions;
+
+namespace nORM.Core
+{
+    public sealed class SetPropertyCalls<T>
+    {
+        public SetPropertyCalls<T> SetProperty<TProperty>(Expression<Func<T, TProperty>> property, TProperty value) => this;
+    }
+}

--- a/tests/BatchCudTests.cs
+++ b/tests/BatchCudTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using nORM.Core;
+using nORM.Providers;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class BatchCudTests
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public bool Archived { get; set; }
+    }
+
+    [Fact]
+    public async Task ExecuteDeleteAsync_deletes_rows_matching_filter()
+    {
+        using var cn = new SqliteConnection("Data Source=:memory:");
+        cn.Open();
+        using (var cmd = cn.CreateCommand())
+        {
+            cmd.CommandText = "CREATE TABLE User(Id INTEGER, Name TEXT, Archived INTEGER);" +
+                             "INSERT INTO User VALUES(1,'A',0);" +
+                             "INSERT INTO User VALUES(2,'B',0);";
+            cmd.ExecuteNonQuery();
+        }
+        using var ctx = new DbContext(cn, new SqliteProvider());
+        await ctx.Query<User>().Where(u => u.Name == "A").ExecuteDeleteAsync();
+        using var check = cn.CreateCommand();
+        check.CommandText = "SELECT COUNT(*) FROM User";
+        var remaining = Convert.ToInt64(check.ExecuteScalar());
+        Assert.Equal(1, remaining);
+    }
+
+    [Fact]
+    public async Task ExecuteUpdateAsync_updates_rows_matching_filter()
+    {
+        using var cn = new SqliteConnection("Data Source=:memory:");
+        cn.Open();
+        using (var cmd = cn.CreateCommand())
+        {
+            cmd.CommandText = "CREATE TABLE User(Id INTEGER, Name TEXT, Archived INTEGER);" +
+                             "INSERT INTO User VALUES(1,'A',0);" +
+                             "INSERT INTO User VALUES(2,'B',0);";
+            cmd.ExecuteNonQuery();
+        }
+        using var ctx = new DbContext(cn, new SqliteProvider());
+        await ctx.Query<User>()
+            .Where(u => u.Id == 1)
+            .ExecuteUpdateAsync(s => s.SetProperty(p => p.Archived, true));
+        var users = await ctx.Query<User>().ToListAsync();
+        Assert.True(users.Single(u => u.Id == 1).Archived);
+    }
+}


### PR DESCRIPTION
## Summary
- add ExecuteDeleteAsync and ExecuteUpdateAsync for bulk operations
- support update setters via SetPropertyCalls expression
- provide tests for batch update and delete

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b8169ff2b8832c8dfdcec2b9a621fa