### PR TITLE
Add transaction savepoint support

### DIFF
--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -14,6 +14,8 @@ using nORM.Providers;
 using nORM.Internal;
 using nORM.Navigation;
 using System.Reflection;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.Sqlite;
 
 #nullable enable
 
@@ -359,6 +361,72 @@ namespace nORM.Core
 
         public Task<int> BulkDeleteAsync<T>(IEnumerable<T> entities, CancellationToken ct = default) where T : class
             => _executionStrategy.ExecuteAsync((ctx, token) => _p.BulkDeleteAsync(ctx, GetMapping(typeof(T)), entities, token), ct);
+        #endregion
+
+        #region Transaction Savepoints
+        public Task CreateSavepointAsync(DbTransaction transaction, string name, CancellationToken ct = default)
+        {
+            if (transaction == null)
+                throw new InvalidOperationException("No active transaction.");
+
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Savepoint name cannot be null or empty.", nameof(name));
+
+            switch (transaction)
+            {
+                case SqlTransaction sqlTransaction:
+                    sqlTransaction.Save(name);
+                    break;
+                case SqliteTransaction sqliteTransaction:
+                    sqliteTransaction.Save(name);
+                    break;
+                default:
+                    var saveMethod = transaction.GetType().GetMethod("Save", new[] { typeof(string) });
+                    if (saveMethod != null)
+                    {
+                        saveMethod.Invoke(transaction, new object[] { name });
+                    }
+                    else
+                    {
+                        throw new NotSupportedException($"Savepoints are not supported for transactions of type {transaction.GetType().FullName}.");
+                    }
+                    break;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task RollbackToSavepointAsync(DbTransaction transaction, string name, CancellationToken ct = default)
+        {
+            if (transaction == null)
+                throw new InvalidOperationException("No active transaction.");
+
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Savepoint name cannot be null or empty.", nameof(name));
+
+            switch (transaction)
+            {
+                case SqlTransaction sqlTransaction:
+                    sqlTransaction.Rollback(name);
+                    break;
+                case SqliteTransaction sqliteTransaction:
+                    sqliteTransaction.Rollback(name);
+                    break;
+                default:
+                    var rollbackMethod = transaction.GetType().GetMethod("Rollback", new[] { typeof(string) });
+                    if (rollbackMethod != null)
+                    {
+                        rollbackMethod.Invoke(transaction, new object[] { name });
+                    }
+                    else
+                    {
+                        throw new NotSupportedException($"Savepoints are not supported for transactions of type {transaction.GetType().FullName}.");
+                    }
+                    break;
+            }
+
+            return Task.CompletedTask;
+        }
         #endregion
 
         #region Raw SQL & Stored Procedures

--- a/tests/TransactionSavepointTests.cs
+++ b/tests/TransactionSavepointTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using nORM.Core;
+using nORM.Providers;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class TransactionSavepointTests
+{
+    private class Item
+    {
+        [System.ComponentModel.DataAnnotations.Key]
+        [System.ComponentModel.DataAnnotations.Schema.DatabaseGenerated(System.ComponentModel.DataAnnotations.Schema.DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public async Task RollbackToSavepoint_RemovesSubsequentChanges()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        // Create schema
+        await using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "CREATE TABLE Item (Id INTEGER PRIMARY KEY AUTOINCREMENT, Name TEXT);";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var provider = new SqliteProvider();
+        using var ctx = new DbContext(connection, provider);
+
+        await using var tx = await connection.BeginTransactionAsync();
+
+        await ctx.InsertAsync(new Item { Name = "first" }, tx);
+        await ctx.CreateSavepointAsync(tx, "sp1");
+        await ctx.InsertAsync(new Item { Name = "second" }, tx);
+        await ctx.RollbackToSavepointAsync(tx, "sp1");
+        await tx.CommitAsync();
+
+        await using var countCmd = connection.CreateCommand();
+        countCmd.CommandText = "SELECT COUNT(*) FROM Item";
+        var countObj = await countCmd.ExecuteScalarAsync();
+        var count = countObj is null ? 0L : Convert.ToInt64(countObj);
+        Assert.Equal(1L, count);
+    }
+}


### PR DESCRIPTION
## Summary
- add CreateSavepointAsync and RollbackToSavepointAsync to DbContext for manual transaction savepoints
- test rollback to savepoint using SQLite

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b81d66977c832c94a2328b8b064414