### PR TITLE
Add compiled query support

### DIFF
--- a/src/nORM/Core/Norm.cs
+++ b/src/nORM/Core/Norm.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using nORM.Internal;
+using nORM.Query;
+
+#nullable enable
+
+namespace nORM.Core
+{
+    public static class Norm
+    {
+        public static Func<TContext, TParam, Task<List<T>>> CompileQuery<TContext, TParam, T>(Expression<Func<TContext, TParam, IQueryable<T>>> queryExpression)
+            where TContext : DbContext
+        {
+            if (queryExpression == null) throw new ArgumentNullException(nameof(queryExpression));
+
+            var ctxParameter = queryExpression.Parameters[0];
+            var valueParameter = queryExpression.Parameters[1];
+
+            QueryPlan? cachedPlan = null;
+            string? paramName = null;
+
+            return async (ctx, value) =>
+            {
+                if (cachedPlan == null)
+                {
+                    var body = new ParameterReplacer(ctxParameter, Expression.Constant(ctx)).Visit(queryExpression.Body)!;
+                    body = new ParameterReplacer(valueParameter, Expression.Constant(value, typeof(TParam))).Visit(body)!;
+                    var provider = new NormQueryProvider(ctx);
+                    cachedPlan = provider.GetPlan(body, out _);
+                    paramName = cachedPlan.Parameters.Keys.FirstOrDefault();
+                }
+
+                var parameters = cachedPlan.Parameters.ToDictionary(k => k.Key, v => v.Value);
+                if (paramName != null)
+                    parameters[paramName] = value!;
+
+                var execProvider = new NormQueryProvider(ctx);
+                return await execProvider.ExecuteCompiledAsync<List<T>>(cachedPlan, parameters, default);
+            };
+        }
+    }
+}
+

--- a/tests/CompiledQueryTests.cs
+++ b/tests/CompiledQueryTests.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using nORM.Core;
+using nORM.Providers;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class CompiledQueryTests
+{
+    public class Person
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public async Task Compiled_query_executes_with_different_parameters()
+    {
+        using var cn = new SqliteConnection("Data Source=:memory:");
+        cn.Open();
+        using (var cmd = cn.CreateCommand())
+        {
+            cmd.CommandText = "CREATE TABLE Person(Id INTEGER, Name TEXT);" +
+                             "INSERT INTO Person VALUES(1,'Alice');" +
+                             "INSERT INTO Person VALUES(2,'Bob');";
+            cmd.ExecuteNonQuery();
+        }
+
+        var compiled = Norm.CompileQuery((DbContext ctx, int id) => ctx.Query<Person>().Where(p => p.Id == id));
+
+        using var ctx = new DbContext(cn, new SqliteProvider());
+        var result1 = await compiled(ctx, 1);
+        Assert.Single(result1);
+        Assert.Equal("Alice", result1[0].Name);
+
+        var result2 = await compiled(ctx, 2);
+        Assert.Single(result2);
+        Assert.Equal("Bob", result2[0].Name);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Norm.CompileQuery to pre-translate reusable queries
- allow executing prebuilt QueryPlan with new parameters
- test compiled queries with SQLite

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b826989348832ca41a2bc8229c1970