### PR TITLE
Polish CLI tooling with expanded provider support

### DIFF
--- a/src/dotnet-norm/Program.cs
+++ b/src/dotnet-norm/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.CommandLine;
+using System.Data;
 using System.Data.Common;
 using System.IO;
 using System.Collections.Generic;
@@ -14,11 +15,11 @@ using nORM.Migration;
 using nORM.Providers;
 using nORM.Scaffolding;
 
-var root = new RootCommand("nORM command line tools");
+var root = new RootCommand("Command line tools for the nORM ORM framework");
 
-var scaffold = new Command("scaffold", "Scaffold entity classes and a DbContext from an existing database");
-var connOpt = new Option<string>("--connection", description: "Connection string") { IsRequired = true };
-var providerOpt = new Option<string>("--provider", description: "Database provider (sqlserver, sqlite)") { IsRequired = true };
+var scaffold = new Command("scaffold", "Scaffold entity classes and a DbContext from an existing database.\nExample:\n  norm scaffold --connection \"Server=.;Database=AppDb;Trusted_Connection=True;\" --provider sqlserver --output Models");
+var connOpt = new Option<string>("--connection", description: "Database connection string. e.g. 'Server=.;Database=AppDb;Trusted_Connection=True;'") { IsRequired = true };
+var providerOpt = new Option<string>("--provider", description: "Database provider (sqlserver, sqlite, postgres, mysql)") { IsRequired = true };
 var outputOpt = new Option<string>("--output", () => ".", "Output directory for generated code");
 var nsOpt = new Option<string>("--namespace", () => "Scaffolded", "Namespace for generated classes");
 var ctxOpt = new Option<string>("--context", () => "AppDbContext", "DbContext class name");
@@ -30,49 +31,127 @@ scaffold.AddOption(ctxOpt);
 
 scaffold.SetHandler(async (conn, prov, output, ns, ctx) =>
 {
-    using var connection = CreateConnection(prov, conn);
-    var provider = CreateProvider(prov);
-    await DatabaseScaffolder.ScaffoldAsync(connection, provider, output!, ns!, ctx!);
-    Console.WriteLine($"Scaffolding completed. Files written to {output}.");
+    try
+    {
+        using var connection = CreateConnection(prov, conn);
+        await connection.OpenAsync();
+        var provider = CreateProvider(prov);
+        await DatabaseScaffolder.ScaffoldAsync(connection, provider, output!, ns!, ctx!);
+        Console.WriteLine($"Scaffolding completed. Files written to {output}.");
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Error: {ex.Message}");
+    }
 }, connOpt, providerOpt, outputOpt, nsOpt, ctxOpt);
 
 root.AddCommand(scaffold);
 
 var database = new Command("database", "Database related commands");
-var update = new Command("update", "Apply pending migrations to the database");
-var migConnOpt = new Option<string>("--connection", description: "Connection string") { IsRequired = true };
-var migProvOpt = new Option<string>("--provider", description: "Database provider (sqlserver)") { IsRequired = true };
-var assemblyOpt = new Option<string>("--assembly", description: "Path to migrations assembly") { IsRequired = true };
+var update = new Command("update", "Apply pending migrations to the database.\nExample:\n  norm database update --connection \"...\" --provider sqlserver --assembly Migrations.dll");
+var migConnOpt = new Option<string>("--connection", "Database connection string") { IsRequired = true };
+var migProvOpt = new Option<string>("--provider", "Database provider. Currently only 'sqlserver' is supported for applying migrations.") { IsRequired = true };
+var assemblyOpt = new Option<string>("--assembly", "Path to migrations assembly (e.g. ./bin/Debug/net8.0/App.Migrations.dll)") { IsRequired = true };
 update.AddOption(migConnOpt);
 update.AddOption(migProvOpt);
 update.AddOption(assemblyOpt);
 update.SetHandler(async (conn, prov, asmPath) =>
 {
-    using var connection = CreateConnection(prov, conn);
-    var assembly = Assembly.LoadFrom(asmPath!);
-    IMigrationRunner runner = prov.ToLowerInvariant() switch
+    try
     {
-        "sqlserver" => new SqlServerMigrationRunner(connection, assembly),
-        _ => throw new ArgumentException($"Provider '{prov}' does not support migrations.")
-    };
+        if (!File.Exists(asmPath!))
+        {
+            Console.Error.WriteLine($"Assembly '{asmPath}' not found.");
+            return;
+        }
+        using var connection = CreateConnection(prov, conn);
+        await connection.OpenAsync();
+        var assembly = Assembly.LoadFrom(asmPath!);
+        IMigrationRunner runner = prov.ToLowerInvariant() switch
+        {
+            "sqlserver" => new SqlServerMigrationRunner(connection, assembly),
+            _ => throw new ArgumentException($"Provider '{prov}' does not support migrations.")
+        };
 
-    if (!await runner.HasPendingMigrationsAsync())
-    {
-        Console.WriteLine("No pending migrations found.");
-        return;
+        if (!await runner.HasPendingMigrationsAsync())
+        {
+            Console.WriteLine("No pending migrations found.");
+            return;
+        }
+
+        await runner.ApplyMigrationsAsync();
+        Console.WriteLine("Migrations applied successfully.");
     }
-
-    await runner.ApplyMigrationsAsync();
-    Console.WriteLine("Migrations applied successfully.");
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Error: {ex.Message}");
+    }
 }, migConnOpt, migProvOpt, assemblyOpt);
 
+var drop = new Command("drop", "Drop the target database or all tables. Useful for resetting test databases.\nExample:\n  norm database drop --connection \"...\" --provider postgres");
+var dropConnOpt = new Option<string>("--connection", "Database connection string") { IsRequired = true };
+var dropProvOpt = new Option<string>("--provider", "Database provider (sqlserver, sqlite, postgres, mysql)") { IsRequired = true };
+drop.AddOption(dropConnOpt);
+drop.AddOption(dropProvOpt);
+drop.SetHandler(async (conn, prov) =>
+{
+    try
+    {
+        if (prov.Equals("sqlite", StringComparison.OrdinalIgnoreCase))
+        {
+            var builder = new SqliteConnectionStringBuilder(conn);
+            var file = builder.DataSource;
+            if (File.Exists(file))
+            {
+                File.Delete(file);
+                Console.WriteLine($"Database '{file}' deleted.");
+            }
+            else
+            {
+                Console.WriteLine($"Database file '{file}' not found.");
+            }
+            return;
+        }
+
+        using var connection = CreateConnection(prov, conn);
+        await connection.OpenAsync();
+        var provider = CreateProvider(prov);
+        var schema = connection.GetSchema("Tables");
+        foreach (DataRow row in schema.Rows)
+        {
+            var tableSchema = row["TABLE_SCHEMA"]?.ToString();
+            var tableName = row["TABLE_NAME"]?.ToString();
+            if (string.IsNullOrEmpty(tableName)) continue;
+            var full = string.IsNullOrEmpty(tableSchema)
+                ? provider.Escape(tableName)
+                : $"{provider.Escape(tableSchema!)}.{provider.Escape(tableName!)}";
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"DROP TABLE {full}";
+            try
+            {
+                await cmd.ExecuteNonQueryAsync();
+            }
+            catch (DbException)
+            {
+                // ignore failures due to dependencies
+            }
+        }
+        Console.WriteLine("Database dropped successfully.");
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Error: {ex.Message}");
+    }
+}, dropConnOpt, dropProvOpt);
+
 database.AddCommand(update);
+database.AddCommand(drop);
 root.AddCommand(database);
 
 var migrations = new Command("migrations", "Migration management commands");
-var add = new Command("add", "Add a new migration");
+var add = new Command("add", "Add a new migration based on model changes.\nExample:\n  norm migrations add InitialCreate --provider sqlserver --assembly App.dll");
 var migNameArg = new Argument<string>("name", description: "Migration name");
-var addProvOpt = new Option<string>("--provider", description: "Database provider (sqlserver)") { IsRequired = true };
+var addProvOpt = new Option<string>("--provider", description: "Database provider (sqlserver, sqlite, postgres, mysql)") { IsRequired = true };
 var addAsmOpt = new Option<string>("--assembly", description: "Path to assembly containing DbContext and entities") { IsRequired = true };
 var addOutOpt = new Option<string>("--output", () => "Migrations", "Output directory for migrations");
 add.AddArgument(migNameArg);
@@ -82,50 +161,65 @@ add.AddOption(addOutOpt);
 
 add.SetHandler((string name, string prov, string asmPath, string output) =>
 {
-    var assembly = Assembly.LoadFrom(asmPath);
-
-    var snapshotPath = Path.Combine(output, "schema.snapshot.json");
-    SchemaSnapshot oldSnap = File.Exists(snapshotPath)
-        ? JsonSerializer.Deserialize<SchemaSnapshot>(File.ReadAllText(snapshotPath)) ?? new SchemaSnapshot()
-        : new SchemaSnapshot();
-
-    var newSnap = SchemaSnapshotBuilder.Build(assembly);
-    var diff = SchemaDiffer.Diff(oldSnap, newSnap);
-    if (!diff.HasChanges)
+    try
     {
-        Console.WriteLine("No changes detected.");
-        return;
+        if (!File.Exists(asmPath))
+        {
+            Console.Error.WriteLine($"Assembly '{asmPath}' not found.");
+            return;
+        }
+        var assembly = Assembly.LoadFrom(asmPath);
+
+        var snapshotPath = Path.Combine(output, "schema.snapshot.json");
+        SchemaSnapshot oldSnap = File.Exists(snapshotPath)
+            ? JsonSerializer.Deserialize<SchemaSnapshot>(File.ReadAllText(snapshotPath)) ?? new SchemaSnapshot()
+            : new SchemaSnapshot();
+
+        var newSnap = SchemaSnapshotBuilder.Build(assembly);
+        var diff = SchemaDiffer.Diff(oldSnap, newSnap);
+        if (!diff.HasChanges)
+        {
+            Console.WriteLine("No changes detected.");
+            return;
+        }
+
+        IMigrationSqlGenerator generator = prov.ToLowerInvariant() switch
+        {
+            "sqlserver" => new SqlServerMigrationSqlGenerator(),
+            "sqlite" => new SqliteMigrationSqlGenerator(),
+            "postgres" or "postgresql" => new PostgresMigrationSqlGenerator(),
+            "mysql" => new MySqlMigrationSqlGenerator(),
+            _ => throw new ArgumentException($"Provider '{prov}' not supported.")
+        };
+
+        var sql = generator.GenerateSql(diff);
+
+        Directory.CreateDirectory(output);
+
+        var version = long.Parse(DateTime.UtcNow.ToString("yyyyMMddHHmmss"));
+        var className = $"{version}_{name}";
+        var filePath = Path.Combine(output, className + ".cs");
+
+        var sb = new StringBuilder();
+        sb.AppendLine("using System.Data.Common;");
+        sb.AppendLine("using nORM.Migration;");
+        sb.AppendLine();
+        sb.AppendLine($"public class {className} : Migration");
+        sb.AppendLine("{");
+        sb.AppendLine($"    public {className}() : base({version}, \"{name}\") {{ }}");
+        AppendMethod("Up", sql.Up, sb);
+        AppendMethod("Down", sql.Down, sb);
+        sb.AppendLine("}");
+        File.WriteAllText(filePath, sb.ToString());
+
+        var snapJson = JsonSerializer.Serialize(newSnap, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(snapshotPath, snapJson);
+        Console.WriteLine($"Migration '{className}' generated at {filePath}.");
     }
-
-    IMigrationSqlGenerator generator = prov.ToLowerInvariant() switch
+    catch (Exception ex)
     {
-        "sqlserver" => new SqlServerMigrationSqlGenerator(),
-        _ => throw new ArgumentException($"Provider '{prov}' not supported.")
-    };
-
-    var sql = generator.GenerateSql(diff);
-
-    Directory.CreateDirectory(output);
-
-    var version = long.Parse(DateTime.UtcNow.ToString("yyyyMMddHHmmss"));
-    var className = $"{version}_{name}";
-    var filePath = Path.Combine(output, className + ".cs");
-
-    var sb = new StringBuilder();
-    sb.AppendLine("using System.Data.Common;");
-    sb.AppendLine("using nORM.Migration;");
-    sb.AppendLine();
-    sb.AppendLine($"public class {className} : Migration");
-    sb.AppendLine("{");
-    sb.AppendLine($"    public {className}() : base({version}, \"{name}\") {{ }}");
-    AppendMethod("Up", sql.Up, sb);
-    AppendMethod("Down", sql.Down, sb);
-    sb.AppendLine("}");
-    File.WriteAllText(filePath, sb.ToString());
-
-    var snapJson = JsonSerializer.Serialize(newSnap, new JsonSerializerOptions { WriteIndented = true });
-    File.WriteAllText(snapshotPath, snapJson);
-    Console.WriteLine($"Migration '{className}' generated at {filePath}.");
+        Console.Error.WriteLine($"Error: {ex.Message}");
+    }
 }, migNameArg, addProvOpt, addAsmOpt, addOutOpt);
 
 migrations.AddCommand(add);
@@ -134,18 +228,47 @@ root.AddCommand(migrations);
 return await root.InvokeAsync(args);
 
 static DbConnection CreateConnection(string provider, string connectionString)
-    => provider.ToLowerInvariant() switch
+{
+    try
     {
-        "sqlserver" => new SqlConnection(connectionString),
-        "sqlite" => new SqliteConnection(connectionString),
-        _ => throw new ArgumentException($"Unsupported provider '{provider}'.")
-    };
+        return provider.ToLowerInvariant() switch
+        {
+            "sqlserver" => new SqlConnection(connectionString),
+            "sqlite" => new SqliteConnection(connectionString),
+            "postgres" or "postgresql" => CreateConnectionFromType("Npgsql.NpgsqlConnection, Npgsql", "PostgreSQL", connectionString),
+            "mysql" => CreateConnectionFromType(new[] { "MySql.Data.MySqlClient.MySqlConnection, MySql.Data", "MySqlConnector.MySqlConnection, MySqlConnector" }, "MySQL", connectionString),
+            _ => throw new ArgumentException($"Unsupported provider '{provider}'.")
+        };
+    }
+    catch (Exception ex) when (ex is ArgumentException or InvalidOperationException or TypeLoadException)
+    {
+        throw new InvalidOperationException($"Failed to create connection: {ex.Message}", ex);
+    }
+}
+
+static DbConnection CreateConnectionFromType(string typeName, string friendly, string connString)
+    => CreateConnectionFromType(new[] { typeName }, friendly, connString);
+
+static DbConnection CreateConnectionFromType(string[] typeNames, string friendly, string connString)
+{
+    foreach (var name in typeNames)
+    {
+        var type = Type.GetType(name);
+        if (type != null)
+        {
+            return (DbConnection)Activator.CreateInstance(type, connString)!;
+        }
+    }
+    throw new InvalidOperationException($"{friendly} provider assembly not found. Ensure the appropriate package is referenced.");
+}
 
 static DatabaseProvider CreateProvider(string provider)
     => provider.ToLowerInvariant() switch
     {
         "sqlserver" => new SqlServerProvider(),
         "sqlite" => new SqliteProvider(),
+        "postgres" or "postgresql" => new PostgresProvider(),
+        "mysql" => new MySqlProvider(),
         _ => throw new ArgumentException($"Unsupported provider '{provider}'.")
     };
 

--- a/src/nORM/Migration/MySqlMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/MySqlMigrationSqlGenerator.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace nORM.Migration
+{
+    public class MySqlMigrationSqlGenerator : IMigrationSqlGenerator
+    {
+        private static readonly Dictionary<string, string> TypeMap = new()
+        {
+            { typeof(int).FullName!, "INT" },
+            { typeof(long).FullName!, "BIGINT" },
+            { typeof(short).FullName!, "SMALLINT" },
+            { typeof(byte).FullName!, "TINYINT" },
+            { typeof(bool).FullName!, "TINYINT(1)" },
+            { typeof(string).FullName!, "LONGTEXT" },
+            { typeof(DateTime).FullName!, "DATETIME" },
+            { typeof(decimal).FullName!, "DECIMAL(18,2)" },
+            { typeof(double).FullName!, "DOUBLE" },
+            { typeof(float).FullName!, "FLOAT" },
+            { typeof(Guid).FullName!, "CHAR(36)" }
+        };
+
+        public MigrationSqlStatements GenerateSql(SchemaDiff diff)
+        {
+            var up = new List<string>();
+            var down = new List<string>();
+
+            foreach (var table in diff.AddedTables)
+            {
+                var cols = table.Columns.Select(c =>
+                    $"`{c.Name}` {GetSqlType(c)} {(c.IsNullable ? "NULL" : "NOT NULL")}");
+                up.Add($"CREATE TABLE `{table.Name}` ({string.Join(", ", cols)})");
+                down.Add($"DROP TABLE `{table.Name}`");
+            }
+
+            foreach (var (table, column) in diff.AddedColumns)
+            {
+                var colDef = $"`{column.Name}` {GetSqlType(column)} {(column.IsNullable ? "NULL" : "NOT NULL")}";
+                up.Add($"ALTER TABLE `{table.Name}` ADD COLUMN {colDef}");
+                down.Add($"ALTER TABLE `{table.Name}` DROP COLUMN `{column.Name}`");
+            }
+
+            foreach (var (table, newCol, oldCol) in diff.AlteredColumns)
+            {
+                var newDef = $"`{newCol.Name}` {GetSqlType(newCol)} {(newCol.IsNullable ? "NULL" : "NOT NULL")}";
+                up.Add($"ALTER TABLE `{table.Name}` MODIFY COLUMN {newDef}");
+                var oldDef = $"`{oldCol.Name}` {GetSqlType(oldCol)} {(oldCol.IsNullable ? "NULL" : "NOT NULL")}";
+                down.Add($"ALTER TABLE `{table.Name}` MODIFY COLUMN {oldDef}");
+            }
+
+            return new MigrationSqlStatements(up, down);
+        }
+
+        private static string GetSqlType(ColumnSchema column)
+            => TypeMap.TryGetValue(column.ClrType, out var sql) ? sql : "LONGTEXT";
+    }
+}

--- a/src/nORM/Migration/PostgresMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/PostgresMigrationSqlGenerator.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace nORM.Migration
+{
+    public class PostgresMigrationSqlGenerator : IMigrationSqlGenerator
+    {
+        private static readonly Dictionary<string, string> TypeMap = new()
+        {
+            { typeof(int).FullName!, "INTEGER" },
+            { typeof(long).FullName!, "BIGINT" },
+            { typeof(short).FullName!, "SMALLINT" },
+            { typeof(byte).FullName!, "SMALLINT" },
+            { typeof(bool).FullName!, "BOOLEAN" },
+            { typeof(string).FullName!, "TEXT" },
+            { typeof(DateTime).FullName!, "TIMESTAMP" },
+            { typeof(decimal).FullName!, "DECIMAL(18,2)" },
+            { typeof(double).FullName!, "DOUBLE PRECISION" },
+            { typeof(float).FullName!, "REAL" },
+            { typeof(Guid).FullName!, "UUID" }
+        };
+
+        public MigrationSqlStatements GenerateSql(SchemaDiff diff)
+        {
+            var up = new List<string>();
+            var down = new List<string>();
+
+            foreach (var table in diff.AddedTables)
+            {
+                var cols = table.Columns.Select(c =>
+                    $"\"{c.Name}\" {GetSqlType(c)} {(c.IsNullable ? "NULL" : "NOT NULL")}");
+                up.Add($"CREATE TABLE \"{table.Name}\" ({string.Join(", ", cols)})");
+                down.Add($"DROP TABLE \"{table.Name}\"");
+            }
+
+            foreach (var (table, column) in diff.AddedColumns)
+            {
+                var colDef = $"\"{column.Name}\" {GetSqlType(column)} {(column.IsNullable ? "NULL" : "NOT NULL")}";
+                up.Add($"ALTER TABLE \"{table.Name}\" ADD COLUMN {colDef}");
+                down.Add($"ALTER TABLE \"{table.Name}\" DROP COLUMN \"{column.Name}\"");
+            }
+
+            foreach (var (table, newCol, oldCol) in diff.AlteredColumns)
+            {
+                var newDef = $"\"{newCol.Name}\" {GetSqlType(newCol)} {(newCol.IsNullable ? "NULL" : "NOT NULL")}";
+                up.Add($"ALTER TABLE \"{table.Name}\" ALTER COLUMN {newDef}");
+                var oldDef = $"\"{oldCol.Name}\" {GetSqlType(oldCol)} {(oldCol.IsNullable ? "NULL" : "NOT NULL")}";
+                down.Add($"ALTER TABLE \"{table.Name}\" ALTER COLUMN {oldDef}");
+            }
+
+            return new MigrationSqlStatements(up, down);
+        }
+
+        private static string GetSqlType(ColumnSchema column)
+            => TypeMap.TryGetValue(column.ClrType, out var sql) ? sql : "TEXT";
+    }
+}

--- a/src/nORM/Migration/SqliteMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/SqliteMigrationSqlGenerator.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace nORM.Migration
+{
+    public class SqliteMigrationSqlGenerator : IMigrationSqlGenerator
+    {
+        private static readonly Dictionary<string, string> TypeMap = new()
+        {
+            { typeof(int).FullName!, "INTEGER" },
+            { typeof(long).FullName!, "INTEGER" },
+            { typeof(short).FullName!, "INTEGER" },
+            { typeof(byte).FullName!, "INTEGER" },
+            { typeof(bool).FullName!, "INTEGER" },
+            { typeof(string).FullName!, "TEXT" },
+            { typeof(DateTime).FullName!, "TEXT" },
+            { typeof(decimal).FullName!, "NUMERIC" },
+            { typeof(double).FullName!, "REAL" },
+            { typeof(float).FullName!, "REAL" },
+            { typeof(Guid).FullName!, "TEXT" }
+        };
+
+        public MigrationSqlStatements GenerateSql(SchemaDiff diff)
+        {
+            var up = new List<string>();
+            var down = new List<string>();
+
+            foreach (var table in diff.AddedTables)
+            {
+                var cols = table.Columns.Select(c =>
+                    $"\"{c.Name}\" {GetSqlType(c)} {(c.IsNullable ? "NULL" : "NOT NULL")}");
+                up.Add($"CREATE TABLE \"{table.Name}\" ({string.Join(", ", cols)})");
+                down.Add($"DROP TABLE IF EXISTS \"{table.Name}\"");
+            }
+
+            foreach (var (table, column) in diff.AddedColumns)
+            {
+                var colDef = $"\"{column.Name}\" {GetSqlType(column)} {(column.IsNullable ? "NULL" : "NOT NULL")}";
+                up.Add($"ALTER TABLE \"{table.Name}\" ADD COLUMN {colDef}");
+                // SQLite does not support dropping columns prior to version 3.35
+                down.Add($"-- SQLite does not support dropping column '{column.Name}'");
+            }
+
+            foreach (var (table, newCol, oldCol) in diff.AlteredColumns)
+            {
+                up.Add($"-- SQLite does not support altering column '{newCol.Name}' in table '{table.Name}'");
+                down.Add($"-- SQLite does not support altering column '{oldCol.Name}' in table '{table.Name}'");
+            }
+
+            return new MigrationSqlStatements(up, down);
+        }
+
+        private static string GetSqlType(ColumnSchema column)
+            => TypeMap.TryGetValue(column.ClrType, out var sql) ? sql : "TEXT";
+    }
+}


### PR DESCRIPTION
## Summary
- add migration SQL generators for PostgreSQL, MySQL, and SQLite
- introduce database drop command and improve help text and error handling across CLI
- support additional providers via reflection-based connection creation

## Testing
- `dotnet build` *(fails: Unable to load Analyzer assembly nORM.SourceGenerators.dll)*

------
https://chatgpt.com/codex/tasks/task_e_68b827fa5630832c973b1350385d7ff2