### PR TITLE
feat: make materializers asynchronous

### DIFF
--- a/src/SourceGeneration/CompiledMaterializerStore.cs
+++ b/src/SourceGeneration/CompiledMaterializerStore.cs
@@ -1,20 +1,22 @@
 using System;
 using System.Collections.Concurrent;
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace nORM.SourceGeneration
 {
     public static class CompiledMaterializerStore
     {
-        private static readonly ConcurrentDictionary<Type, (Delegate Typed, Func<DbDataReader, object> Untyped)> _map = new();
+        private static readonly ConcurrentDictionary<Type, (Delegate Typed, Func<DbDataReader, CancellationToken, Task<object>> Untyped)> _map = new();
 
         public static void Add(Type type, Func<DbDataReader, object> materializer)
-            => _map[type] = (materializer, materializer);
+            => _map[type] = (materializer, (reader, ct) => Task.FromResult(materializer(reader)));
 
         public static void Add<T>(Func<DbDataReader, T> materializer)
-            => _map[typeof(T)] = (materializer, reader => materializer(reader)!);
+            => _map[typeof(T)] = (materializer, (reader, ct) => Task.FromResult((object)materializer(reader)!));
 
-        public static bool TryGet(Type type, out Func<DbDataReader, object> materializer)
+        public static bool TryGet(Type type, out Func<DbDataReader, CancellationToken, Task<object>> materializer)
         {
             if (_map.TryGetValue(type, out var entry))
             {
@@ -25,7 +27,7 @@ namespace nORM.SourceGeneration
             return false;
         }
 
-        public static Func<DbDataReader, T> Get<T>()
-            => (Func<DbDataReader, T>)_map[typeof(T)].Typed;
+        public static Func<DbDataReader, CancellationToken, Task<T>> Get<T>()
+            => (reader, ct) => Task.FromResult(((Func<DbDataReader, T>)_map[typeof(T)].Typed)(reader));
     }
 }

--- a/src/nORM.SourceGenerators/MaterializerQueryGenerator.cs
+++ b/src/nORM.SourceGenerators/MaterializerQueryGenerator.cs
@@ -241,7 +241,7 @@ namespace nORM.SourceGenerators
             sb.AppendLine($"        await using var reader = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, {ctParam});");
             sb.AppendLine($"        while (await reader.ReadAsync({ctParam}))");
             sb.AppendLine("        {");
-            sb.AppendLine("            list.Add(materializer(reader));");
+            sb.AppendLine($"            list.Add(await materializer(reader, {ctParam}));");
             sb.AppendLine("        }");
             sb.AppendLine("        return list;");
             sb.AppendLine("    }");

--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -513,7 +513,7 @@ namespace nORM.Core
                 var materializer = new Query.QueryTranslator(this).CreateMaterializer(GetMapping(typeof(T)), typeof(T));
                 var list = new List<T>();
                 await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(this, CommandBehavior.Default, token);
-                while (await reader.ReadAsync(token)) list.Add((T)materializer(reader));
+                while (await reader.ReadAsync(token)) list.Add((T)await materializer(reader, token));
 
                 ctx.Options.Logger?.LogQuery(sql, paramDict, sw.Elapsed, list.Count);
                 return list;
@@ -542,7 +542,7 @@ namespace nORM.Core
                 var materializer = new Query.QueryTranslator(this).CreateMaterializer(GetMapping(typeof(T)), typeof(T));
                 var list = new List<T>();
                 await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(this, CommandBehavior.Default, token);
-                while (await reader.ReadAsync(token)) list.Add((T)materializer(reader));
+                while (await reader.ReadAsync(token)) list.Add((T)await materializer(reader, token));
 
                 ctx.Options.Logger?.LogQuery(procedureName, paramDict, sw.Elapsed, list.Count);
                 return list;

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -345,11 +345,11 @@ namespace nORM.Navigation
 
             var materializer = new Query.QueryTranslator(context).CreateMaterializer(mapping, entityType);
             var results = new List<object>();
-            
+
             using var reader = await cmd.ExecuteReaderWithInterceptionAsync(context, CommandBehavior.Default, ct);
             while (await reader.ReadAsync(ct))
             {
-                var entity = materializer(reader);
+                var entity = await materializer(reader, ct);
                 // Enable lazy loading for the loaded entity
                 _navigationContexts.GetValue(entity, _ => new NavigationContext(context, entityType));
                 context.ChangeTracker.Track(entity, EntityState.Unchanged, mapping);
@@ -374,11 +374,11 @@ namespace nORM.Navigation
             cmd.CommandText = sql.ToString();
 
             var materializer = new Query.QueryTranslator(context).CreateMaterializer(mapping, entityType);
-            
+
             using var reader = await cmd.ExecuteReaderWithInterceptionAsync(context, CommandBehavior.Default, ct);
             if (await reader.ReadAsync(ct))
             {
-                var entity = materializer(reader);
+                var entity = await materializer(reader, ct);
                 // Enable lazy loading for the loaded entity
                 _navigationContexts.GetValue(entity, _ => new NavigationContext(context, entityType));
                 context.ChangeTracker.Track(entity, EntityState.Unchanged, mapping);

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -387,7 +387,7 @@ namespace nORM.Query
             await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(_ctx, CommandBehavior.SequentialAccess, ct);
             while (await reader.ReadAsync(ct))
             {
-                var entity = (T)plan.Materializer(reader);
+                var entity = (T)await plan.Materializer(reader, ct);
                 if (trackable)
                 {
                     NavigationPropertyExtensions.EnableLazyLoading((object)entity!, _ctx);
@@ -421,7 +421,7 @@ namespace nORM.Query
             await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(_ctx, CommandBehavior.SequentialAccess, ct);
             while (await reader.ReadAsync(ct))
             {
-                var entity = plan.Materializer(reader);
+                var entity = await plan.Materializer(reader, ct);
 
                 if (trackable)
                 {
@@ -461,7 +461,7 @@ namespace nORM.Query
             await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(_ctx, CommandBehavior.SequentialAccess, ct);
             while (await reader.ReadAsync(ct))
             {
-                var tuple = (ValueTuple<object, object>)plan.Materializer(reader);
+                var tuple = (ValueTuple<object, object>)await plan.Materializer(reader, ct);
                 var outer = tuple.Item1;
                 var key = info.OuterKeySelector(outer) ?? DBNull.Value;
 
@@ -533,7 +533,7 @@ namespace nORM.Query
             {
                 while (await reader.ReadAsync(ct))
                 {
-                    var child = childMaterializer(reader);
+                    var child = await childMaterializer(reader, ct);
                     if (!noTracking)
                     {
                         NavigationPropertyExtensions.EnableLazyLoading(child, _ctx);

--- a/src/nORM/Query/QueryPlan.cs
+++ b/src/nORM/Query/QueryPlan.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
 using nORM.Mapping;
 
 #nullable enable
@@ -11,7 +13,7 @@ namespace nORM.Query
     internal sealed record QueryPlan(
         string Sql, 
         IReadOnlyDictionary<string, object> Parameters, 
-        Func<DbDataReader, object> Materializer, 
+        Func<DbDataReader, CancellationToken, Task<object>> Materializer,
         Type ElementType, 
         bool IsScalar,
         bool SingleResult,

--- a/tests/MaterializerGeneratorTests.cs
+++ b/tests/MaterializerGeneratorTests.cs
@@ -3,6 +3,8 @@ using Microsoft.Data.Sqlite;
 using nORM.Mapping;
 using nORM.SourceGeneration;
 using Xunit;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace nORM.Tests
 {
@@ -37,7 +39,7 @@ namespace nORM.Tests
     public class MaterializerGeneratorTests
     {
         [Fact]
-        public void Generated_materializer_reads_data_correctly()
+        public async Task Generated_materializer_reads_data_correctly()
         {
             Assert.True(CompiledMaterializerStore.TryGet(typeof(Materialized), out _));
 
@@ -50,7 +52,7 @@ namespace nORM.Tests
             using var reader = cmd.ExecuteReader();
             Assert.True(reader.Read());
             var mat = CompiledMaterializerStore.Get<Materialized>();
-            var entity = mat(reader);
+            var entity = await mat(reader, CancellationToken.None);
             Assert.Null(entity.Created);
             Assert.Equal(g, entity.Guid);
             Assert.Equal(1, entity.Id);
@@ -61,7 +63,7 @@ namespace nORM.Tests
         }
 
         [Fact]
-        public void Generated_materializer_reads_owned_data_correctly()
+        public async Task Generated_materializer_reads_owned_data_correctly()
         {
             Assert.True(CompiledMaterializerStore.TryGet(typeof(MaterializedOwned), out _));
 
@@ -72,7 +74,7 @@ namespace nORM.Tests
             using var reader = cmd.ExecuteReader();
             Assert.True(reader.Read());
             var mat = CompiledMaterializerStore.Get<MaterializedOwned>();
-            var entity = mat(reader);
+            var entity = await mat(reader, CancellationToken.None);
             Assert.NotNull(entity.Address);
             Assert.Equal("Main", entity.Address.Street);
             Assert.Equal("Metro", entity.Address.City);

--- a/tests/SourceGeneratorIntegrationTests.cs
+++ b/tests/SourceGeneratorIntegrationTests.cs
@@ -5,6 +5,8 @@ using nORM.Core;
 using nORM.Providers;
 using nORM.SourceGeneration;
 using Xunit;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace nORM.Tests
 {
@@ -20,7 +22,7 @@ namespace nORM.Tests
             var getMapping = typeof(DbContext).GetMethod("GetMapping", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
             var mapping = getMapping.Invoke(ctx, new object[] { typeof(Materialized) });
             var create = translatorType.GetMethod("CreateMaterializer")!;
-            var materializer = (Func<DbDataReader, object>)create.Invoke(translator, new object?[] { mapping!, typeof(Materialized), null })!;
+            var materializer = (Func<DbDataReader, CancellationToken, Task<object>>)create.Invoke(translator, new object?[] { mapping!, typeof(Materialized), null })!;
             Assert.True(CompiledMaterializerStore.TryGet(typeof(Materialized), out var precompiled));
             Assert.Same(precompiled, materializer);
         }


### PR DESCRIPTION
## Summary
- switch materializer delegate to asynchronous Task-based signature
- await materializer invocation throughout query materialization pipeline
- update generated and compiled materializer support and tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b82e69b4a8832c9ab06796949251b0