### PR TITLE
Refactor query core into modular components

### DIFF
--- a/src/nORM/Query/BulkCudBuilder.cs
+++ b/src/nORM/Query/BulkCudBuilder.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using nORM.Core;
+using nORM.Mapping;
+
+namespace nORM.Query
+{
+    /// <summary>
+    /// Builds SQL fragments for bulk update and delete operations.
+    /// </summary>
+    internal sealed class BulkCudBuilder
+    {
+        private readonly DbContext _ctx;
+
+        public BulkCudBuilder(DbContext ctx) => _ctx = ctx;
+
+        public void ValidateCudPlan(string sql)
+        {
+            if (sql.IndexOf(" GROUP BY ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                sql.IndexOf(" ORDER BY ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                sql.IndexOf(" HAVING ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                sql.IndexOf(" JOIN ", StringComparison.OrdinalIgnoreCase) >= 0)
+                throw new NotSupportedException("ExecuteUpdate/Delete does not support grouped, ordered, joined or aggregated queries.");
+        }
+
+        public string ExtractWhereClause(string sql, string escTable)
+        {
+            var upper = sql.ToUpperInvariant();
+            var fromIndex = upper.IndexOf("FROM " + escTable.ToUpperInvariant(), StringComparison.Ordinal);
+            string? alias = null;
+            if (fromIndex >= 0)
+            {
+                var after = sql.Substring(fromIndex + ("FROM " + escTable).Length);
+                var tokens = after.TrimStart().Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                if (tokens.Length > 0)
+                    alias = tokens[0];
+            }
+            var whereIndex = upper.IndexOf(" WHERE", StringComparison.Ordinal);
+            if (whereIndex < 0) return string.Empty;
+            var where = sql.Substring(whereIndex);
+            if (!string.IsNullOrEmpty(alias))
+                where = where.Replace(alias + ".", "");
+            return where;
+        }
+
+        public (string Sql, Dictionary<string, object> Params) BuildSetClause<T>(TableMapping mapping, Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> set)
+        {
+            var assigns = new List<(string Column, object? Value)>();
+            var call = set.Body as MethodCallExpression;
+            while (call != null)
+            {
+                var lambda = (LambdaExpression)StripQuotes(call.Arguments[0]);
+                var member = (MemberExpression)lambda.Body;
+                var column = mapping.Columns.First(c => c.Prop.Name == member.Member.Name).EscCol;
+                var value = Expression.Lambda(call.Arguments[1]).Compile().DynamicInvoke();
+                assigns.Add((column, value));
+                call = call.Object as MethodCallExpression;
+            }
+            assigns.Reverse();
+            var sb = new StringBuilder();
+            var parameters = new Dictionary<string, object>();
+            for (int i = 0; i < assigns.Count; i++)
+            {
+                if (i > 0) sb.Append(", ");
+                var pName = _ctx.Provider.ParamPrefix + "u" + i;
+                sb.Append($"{assigns[i].Column} = {pName}");
+                parameters[pName] = assigns[i].Value ?? DBNull.Value;
+            }
+            return (sb.ToString(), parameters);
+        }
+
+        private static Expression StripQuotes(Expression e)
+        {
+            while (e.NodeType == ExpressionType.Quote) e = ((UnaryExpression)e).Operand;
+            return e;
+        }
+    }
+}

--- a/src/nORM/Query/IncludeProcessor.cs
+++ b/src/nORM/Query/IncludeProcessor.cs
@@ -1,0 +1,85 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using nORM.Core;
+using nORM.Mapping;
+using nORM.Navigation;
+
+namespace nORM.Query
+{
+    /// <summary>
+    /// Handles eager loading of navigation properties.
+    /// </summary>
+    internal sealed class IncludeProcessor
+    {
+        private readonly DbContext _ctx;
+        private readonly MaterializerFactory _materializerFactory = new();
+
+        public IncludeProcessor(DbContext ctx) => _ctx = ctx;
+
+        public async Task EagerLoadAsync(IncludePlan include, IList parents, CancellationToken ct, bool noTracking)
+        {
+            IList current = parents;
+            foreach (var relation in include.Path)
+            {
+                current = await EagerLoadLevelAsync(relation, current, ct, noTracking);
+                if (current.Count == 0) break;
+            }
+        }
+
+        private async Task<IList> EagerLoadLevelAsync(TableMapping.Relation relation, IList parents, CancellationToken ct, bool noTracking)
+        {
+            var resultChildren = new List<object>();
+            if (parents.Count == 0) return resultChildren;
+
+            var childMap = _ctx.GetMapping(relation.DependentType);
+            var keys = parents.Cast<object>().Select(relation.PrincipalKey.Getter).Where(k => k != null).Distinct().ToList();
+            if (keys.Count == 0) return resultChildren;
+
+            var paramNames = new List<string>();
+            await using var cmd = _ctx.Connection.CreateCommand();
+            cmd.CommandTimeout = (int)_ctx.Options.CommandTimeout.TotalSeconds;
+            for (int i = 0; i < keys.Count; i++)
+            {
+                var paramName = $"{_ctx.Provider.ParamPrefix}fk{i}";
+                paramNames.Add(paramName);
+                cmd.AddParam(paramName, keys[i]!);
+            }
+            cmd.CommandText = $"SELECT * FROM {childMap.EscTable} WHERE {relation.ForeignKey.EscCol} IN ({string.Join(",", paramNames)})";
+
+            var childMaterializer = _materializerFactory.CreateMaterializer(childMap, childMap.Type);
+            await using (var reader = await cmd.ExecuteReaderWithInterceptionAsync(_ctx, CommandBehavior.Default, ct))
+            {
+                while (await reader.ReadAsync(ct))
+                {
+                    var child = await childMaterializer(reader, ct);
+                    if (!noTracking)
+                    {
+                        NavigationPropertyExtensions.EnableLazyLoading(child, _ctx);
+                        _ctx.ChangeTracker.Track(child, EntityState.Unchanged, childMap);
+                    }
+                    resultChildren.Add(child);
+                }
+            }
+
+            var childGroups = resultChildren.GroupBy(relation.ForeignKey.Getter).ToDictionary(g => g.Key!, g => g.ToList());
+            foreach (var p in parents.Cast<object>())
+            {
+                var pk = relation.PrincipalKey.Getter(p);
+                if (pk != null && childGroups.TryGetValue(pk, out var c))
+                {
+                    var listType = typeof(List<>).MakeGenericType(relation.DependentType);
+                    var childList = (IList)System.Activator.CreateInstance(listType)!;
+                    foreach (var item in c) childList.Add(item);
+                    relation.NavProp.SetValue(p, childList);
+                }
+            }
+
+            return resultChildren;
+        }
+    }
+}

--- a/src/nORM/Query/MaterializerFactory.cs
+++ b/src/nORM/Query/MaterializerFactory.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading;
+using System.Threading.Tasks;
+using nORM.Internal;
+using nORM.Mapping;
+using nORM.SourceGeneration;
+
+namespace nORM.Query
+{
+    /// <summary>
+    /// Creates and caches materializers used to project <see cref="DbDataReader"/> rows into objects.
+    /// </summary>
+    internal sealed class MaterializerFactory
+    {
+        private static readonly ConcurrentLruCache<(Type MappingType, Type TargetType, string? ProjectionKey), Func<DbDataReader, CancellationToken, Task<object>>> _cache = new(maxSize: 1000);
+
+        public Func<DbDataReader, CancellationToken, Task<object>> CreateMaterializer(TableMapping mapping, Type targetType, LambdaExpression? projection = null)
+        {
+            var projectionKey = projection?.ToString();
+            var cacheKey = (mapping.Type, targetType, projectionKey);
+
+            if (projection == null && CompiledMaterializerStore.TryGet(targetType, out var precompiled))
+            {
+                _cache.GetOrAdd(cacheKey, _ => precompiled);
+                return precompiled;
+            }
+
+            return _cache.GetOrAdd(cacheKey, _ =>
+            {
+                var sync = CreateMaterializerInternal(mapping, targetType, projection);
+                return (reader, ct) => Task.FromResult(sync(reader));
+            });
+        }
+
+        private Func<DbDataReader, object> CreateMaterializerInternal(TableMapping mapping, Type targetType, LambdaExpression? projection = null, bool ignoreTph = false)
+        {
+            if (!ignoreTph && mapping.DiscriminatorColumn != null && mapping.TphMappings.Count > 0 && projection == null)
+            {
+                var discIndex = Array.IndexOf(mapping.Columns, mapping.DiscriminatorColumn);
+                var baseMat = CreateMaterializerInternal(mapping, targetType, null, true);
+                var derivedMats = mapping.TphMappings.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp =>
+                    {
+                        var dmap = kvp.Value;
+                        var indices = dmap.Columns.Select(c => Array.FindIndex(mapping.Columns, bc => bc.Prop.Name == c.Prop.Name)).ToArray();
+                        return (Func<DbDataReader, object>)(reader =>
+                        {
+                            var entity = Activator.CreateInstance(dmap.Type)!;
+                            for (int i = 0; i < dmap.Columns.Length; i++)
+                            {
+                                var col = dmap.Columns[i];
+                                var idx = indices[i];
+                                if (reader.IsDBNull(idx)) continue;
+                                var readerMethod = Methods.GetReaderMethod(col.Prop.PropertyType);
+                                var value = readerMethod.Invoke(reader, new object[] { idx });
+                                if (readerMethod == Methods.GetValue)
+                                    value = Convert.ChangeType(value!, col.Prop.PropertyType);
+                                col.Setter(entity, value);
+                            }
+                            return entity;
+                        });
+                    });
+                return reader =>
+                {
+                    var disc = reader.GetValue(discIndex);
+                    if (disc != null && derivedMats.TryGetValue(disc, out var mat))
+                        return mat(reader);
+                    return baseMat(reader);
+                };
+            }
+
+            var dm = new DynamicMethod("mat_" + Guid.NewGuid().ToString("N"), typeof(object), new[] { typeof(DbDataReader) }, targetType.Module, true);
+            var il = dm.GetILGenerator();
+
+            if (targetType.IsPrimitive || targetType == typeof(decimal) || targetType == typeof(string))
+            {
+                var read = Methods.GetReaderMethod(targetType);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.EmitCall(OpCodes.Callvirt, read, null);
+                if (read.ReturnType == typeof(object))
+                    il.Emit(OpCodes.Unbox_Any, targetType);
+                else if (read.ReturnType != targetType)
+                    il.Emit(OpCodes.Box, read.ReturnType);
+                if (targetType.IsValueType)
+                    il.Emit(OpCodes.Box, targetType);
+                il.Emit(OpCodes.Ret);
+                return (Func<DbDataReader, object>)dm.CreateDelegate(typeof(Func<DbDataReader, object>));
+            }
+
+            var ctor = targetType.GetConstructor(Type.EmptyTypes) ?? throw new InvalidOperationException($"Type {targetType} must have a parameterless constructor");
+            il.Emit(OpCodes.Newobj, ctor);
+            var entity = il.DeclareLocal(targetType);
+            il.Emit(OpCodes.Stloc, entity);
+
+            var columns = projection == null
+                ? mapping.Columns
+                : ExtractColumnsFromProjection(mapping, projection);
+
+            for (int i = 0; i < columns.Length; i++)
+            {
+                var col = columns[i];
+                var propType = col.Prop.PropertyType;
+                var read = Methods.GetReaderMethod(propType);
+                il.Emit(OpCodes.Ldloc, entity);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_I4, i);
+                il.EmitCall(OpCodes.Callvirt, read, null);
+                if (read.ReturnType == typeof(object))
+                {
+                    il.Emit(OpCodes.Unbox_Any, propType);
+                }
+                else if (read.ReturnType != propType)
+                {
+                    il.Emit(OpCodes.Box, read.ReturnType);
+                    il.Emit(OpCodes.Unbox_Any, propType);
+                }
+                il.Emit(OpCodes.Callvirt, col.Prop.SetMethod!);
+            }
+
+            il.Emit(OpCodes.Ldloc, entity);
+            if (targetType.IsValueType)
+                il.Emit(OpCodes.Box, targetType);
+            il.Emit(OpCodes.Ret);
+            return (Func<DbDataReader, object>)dm.CreateDelegate(typeof(Func<DbDataReader, object>));
+        }
+
+        private static Column[] ExtractColumnsFromProjection(TableMapping mapping, LambdaExpression projection)
+        {
+            if (projection.Body is NewExpression newExpr)
+            {
+                return newExpr.Arguments
+                    .OfType<MemberExpression>()
+                    .Select(m => mapping.Columns.First(c => c.Prop.Name == m.Member.Name))
+                    .ToArray();
+            }
+            return mapping.Columns;
+        }
+
+        private static bool IsScalarType(Type type) =>
+            type.IsPrimitive || type == typeof(string) || type == typeof(decimal);
+    }
+}

--- a/src/nORM/Query/QueryExecutor.cs
+++ b/src/nORM/Query/QueryExecutor.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using nORM.Core;
+using nORM.Mapping;
+using nORM.Navigation;
+
+namespace nORM.Query
+{
+    /// <summary>
+    /// Executes <see cref="DbCommand"/> instances and materializes results.
+    /// </summary>
+    internal sealed class QueryExecutor
+    {
+        private readonly DbContext _ctx;
+        private readonly IncludeProcessor _includeProcessor;
+
+        public QueryExecutor(DbContext ctx, IncludeProcessor includeProcessor)
+        {
+            _ctx = ctx;
+            _includeProcessor = includeProcessor;
+        }
+
+        public async Task<IList> MaterializeAsync(QueryPlan plan, DbCommand cmd, CancellationToken ct)
+        {
+            if (plan.GroupJoinInfo != null)
+                return await MaterializeGroupJoinAsync(plan, cmd, ct);
+
+            var listType = typeof(List<>).MakeGenericType(plan.ElementType);
+            var list = (IList)Activator.CreateInstance(listType)!;
+
+            var trackable = !plan.NoTracking &&
+                             plan.ElementType.IsClass &&
+                             !plan.ElementType.Name.StartsWith("<>") &&
+                             plan.ElementType.GetConstructor(Type.EmptyTypes) != null;
+            TableMapping? entityMap = trackable ? _ctx.GetMapping(plan.ElementType) : null;
+
+            await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(_ctx, CommandBehavior.SequentialAccess, ct);
+            while (await reader.ReadAsync(ct))
+            {
+                var entity = await plan.Materializer(reader, ct);
+
+                if (trackable)
+                {
+                    NavigationPropertyExtensions.EnableLazyLoading(entity, _ctx);
+                    var actualMap = _ctx.GetMapping(entity.GetType());
+                    _ctx.ChangeTracker.Track(entity, EntityState.Unchanged, actualMap);
+                }
+
+                list.Add(entity);
+            }
+
+            foreach (var include in plan.Includes)
+            {
+                await _includeProcessor.EagerLoadAsync(include, list, ct, plan.NoTracking);
+            }
+
+            return list;
+        }
+
+        private async Task<IList> MaterializeGroupJoinAsync(QueryPlan plan, DbCommand cmd, CancellationToken ct)
+        {
+            var info = plan.GroupJoinInfo!;
+
+            var listType = typeof(List<>).MakeGenericType(info.ResultType);
+            var resultList = (IList)Activator.CreateInstance(listType)!;
+
+            var trackOuter = !plan.NoTracking && info.OuterType.IsClass && !info.OuterType.Name.StartsWith("<>") && info.OuterType.GetConstructor(Type.EmptyTypes) != null;
+            var trackInner = !plan.NoTracking && info.InnerType.IsClass && !info.InnerType.Name.StartsWith("<>") && info.InnerType.GetConstructor(Type.EmptyTypes) != null;
+
+            var outerMap = _ctx.GetMapping(info.OuterType);
+            var innerMap = _ctx.GetMapping(info.InnerType);
+
+            var innerKeyIndex = outerMap.Columns.Length + Array.IndexOf(innerMap.Columns, info.InnerKeyColumn);
+
+            var groups = new Dictionary<object, (object outer, List<object> children)>();
+
+            await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(_ctx, CommandBehavior.SequentialAccess, ct);
+            while (await reader.ReadAsync(ct))
+            {
+                var tuple = (ValueTuple<object, object>)await plan.Materializer(reader, ct);
+                var outer = tuple.Item1;
+                var key = info.OuterKeySelector(outer) ?? DBNull.Value;
+
+                if (!groups.TryGetValue(key, out var entry))
+                {
+                    if (trackOuter)
+                    {
+                        NavigationPropertyExtensions.EnableLazyLoading(outer, _ctx);
+                        var actualMap = _ctx.GetMapping(outer.GetType());
+                        _ctx.ChangeTracker.Track(outer, EntityState.Unchanged, actualMap);
+                    }
+                    entry = (outer, new List<object>());
+                    groups[key] = entry;
+                }
+
+                if (!reader.IsDBNull(innerKeyIndex))
+                {
+                    var inner = tuple.Item2;
+                    if (trackInner)
+                    {
+                        NavigationPropertyExtensions.EnableLazyLoading(inner, _ctx);
+                        var actualMap = _ctx.GetMapping(inner.GetType());
+                        _ctx.ChangeTracker.Track(inner, EntityState.Unchanged, actualMap);
+                    }
+                    entry.children.Add(inner);
+                }
+            }
+
+            foreach (var entry in groups.Values)
+            {
+                var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(info.InnerType))!;
+                foreach (var child in entry.children) list.Add(child);
+                var result = info.ResultSelector(entry.outer, list);
+                resultList.Add(result);
+            }
+
+            return resultList;
+        }
+    }
+}

--- a/src/nORM/Query/SqlClauseBuilder.cs
+++ b/src/nORM/Query/SqlClauseBuilder.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace nORM.Query
+{
+    /// <summary>
+    /// Simple container for the various SQL clause builders used by <see cref="QueryTranslator"/>.
+    /// </summary>
+    internal sealed class SqlClauseBuilder
+    {
+        public StringBuilder Sql { get; } = new();
+        public StringBuilder Where { get; } = new();
+        public StringBuilder Having { get; } = new();
+        public List<(string col, bool asc)> OrderBy { get; } = new();
+        public List<string> GroupBy { get; } = new();
+        public int? Take { get; set; }
+        public int? Skip { get; set; }
+        public bool IsDistinct { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract materializer creation into MaterializerFactory
- Introduce SqlClauseBuilder and wire into QueryTranslator
- Split NormQueryProvider execution, includes and CUD logic into dedicated helpers

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8305b0680832cbe055f778dfd0f01