### PR TITLE
Support constructor materialization and fix compiled query caching

### DIFF
--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -370,7 +370,7 @@ namespace nORM.Navigation
             
             // Apply LIMIT 1 for single result
             var sql = new System.Text.StringBuilder(cmd.CommandText);
-            context.Provider.ApplyPaging(sql, 1, null);
+            context.Provider.ApplyPaging(sql, 1, null, null, null);
             cmd.CommandText = sql.ToString();
 
             var materializer = new Query.QueryTranslator(context).CreateMaterializer(mapping, entityType);

--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -20,7 +20,7 @@ namespace nORM.Providers
         
         public string ParamPrefix { get; protected init; } = "@";
         public abstract string Escape(string id);
-        public abstract void ApplyPaging(StringBuilder sb, int? limit, int? offset);
+        public abstract void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam);
         public abstract string GetIdentityRetrievalString(TableMapping m);
         public abstract DbParameter CreateParameter(string name, object? value);
         public abstract string? TranslateFunction(string name, Type declaringType, params string[] args);

--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -19,9 +19,15 @@ namespace nORM.Providers
         private static readonly ConcurrentLruCache<Type, DataTable> _tableSchemas = new(maxSize: 100);
         public override string Escape(string id) => $"`{id}`";
         
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset)
+        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam)
         {
-            if (limit.HasValue) sb.Append($" LIMIT {offset ?? 0}, {limit}");
+            if (limitParam != null || limit.HasValue)
+            {
+                sb.Append(" LIMIT ");
+                sb.Append(offsetParam ?? (offset ?? 0).ToString());
+                sb.Append(", ");
+                sb.Append(limitParam ?? limit!.Value.ToString());
+            }
         }
         
         public override string GetIdentityRetrievalString(TableMapping m) => "; SELECT LAST_INSERT_ID();";

--- a/src/nORM/Providers/PostgresProvider.cs
+++ b/src/nORM/Providers/PostgresProvider.cs
@@ -18,10 +18,17 @@ namespace nORM.Providers
     {
         public override string Escape(string id) => $"\"{id}\"";
         
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset)
+        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam)
         {
-            if (limit.HasValue) sb.Append($" LIMIT {limit}");
-            if (offset.HasValue) sb.Append($" OFFSET {offset}");
+            if (limitParam != null)
+                sb.Append(" LIMIT ").Append(limitParam);
+            else if (limit.HasValue)
+                sb.Append($" LIMIT {limit}");
+
+            if (offsetParam != null)
+                sb.Append(" OFFSET ").Append(offsetParam);
+            else if (offset.HasValue)
+                sb.Append($" OFFSET {offset}");
         }
         
         public override string GetIdentityRetrievalString(TableMapping m)

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -21,12 +21,16 @@ namespace nORM.Providers
         private static readonly ConcurrentLruCache<Type, DataTable> _keyTableSchemas = new(maxSize: 100);
         public override string Escape(string id) => $"[{id}]";
         
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset)
+        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam)
         {
-            if (offset.HasValue || limit.HasValue)
+            if (offset.HasValue || offsetParam != null || limit.HasValue || limitParam != null)
             {
                 if (!sb.ToString().Contains("ORDER BY")) sb.Append(" ORDER BY (SELECT NULL)");
-                sb.Append($" OFFSET {offset ?? 0} ROWS FETCH NEXT {limit ?? int.MaxValue} ROWS ONLY");
+                sb.Append(" OFFSET ");
+                sb.Append(offsetParam ?? (offset ?? 0).ToString());
+                sb.Append(" ROWS FETCH NEXT ");
+                sb.Append(limitParam ?? (limit ?? int.MaxValue).ToString());
+                sb.Append(" ROWS ONLY");
             }
         }
         

--- a/src/nORM/Providers/SqliteProvider.cs
+++ b/src/nORM/Providers/SqliteProvider.cs
@@ -20,10 +20,17 @@ namespace nORM.Providers
     {
         public override string Escape(string id) => $"\"{id}\"";
         
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset)
+        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam)
         {
-            if (limit.HasValue) sb.Append($" LIMIT {limit}");
-            if (offset.HasValue) sb.Append($" OFFSET {offset}");
+            if (limitParam != null)
+                sb.Append(" LIMIT ").Append(limitParam);
+            else if (limit.HasValue)
+                sb.Append($" LIMIT {limit}");
+
+            if (offsetParam != null)
+                sb.Append(" OFFSET ").Append(offsetParam);
+            else if (offset.HasValue)
+                sb.Append($" OFFSET {offset}");
         }
         
         public override string GetIdentityRetrievalString(TableMapping m) => "; SELECT last_insert_rowid();";

--- a/src/nORM/Query/IncludeProcessor.cs
+++ b/src/nORM/Query/IncludeProcessor.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using nORM.Core;
+using nORM.Internal;
 using nORM.Mapping;
 using nORM.Navigation;
 

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -353,17 +353,6 @@ namespace nORM.Query
                 cache.Set(cacheKey, cacheList ?? new List<T>(), _ctx.Options.CacheExpiration, plan.Tables);
         }
 
-                {
-                    var listType = typeof(List<>).MakeGenericType(relation.DependentType);
-                    var childList = (IList)Activator.CreateInstance(listType)!;
-                    foreach (var item in c) childList.Add(item);
-                    relation.NavProp.SetValue(p, childList);
-                }
-            }
-
-            return resultChildren;
-        }
-
         internal QueryPlan GetPlan(Expression expression, out Expression filtered)
         {
             filtered = ApplyGlobalFilters(expression);

--- a/src/nORM/Query/QueryExecutor.cs
+++ b/src/nORM/Query/QueryExecutor.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using nORM.Core;
+using nORM.Internal;
 using nORM.Mapping;
 using nORM.Navigation;
 
@@ -116,7 +117,7 @@ namespace nORM.Query
             {
                 var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(info.InnerType))!;
                 foreach (var child in entry.children) list.Add(child);
-                var result = info.ResultSelector(entry.outer, list);
+                var result = info.ResultSelector(entry.outer, list.Cast<object>());
                 resultList.Add(result);
             }
 

--- a/src/nORM/Query/QueryPlan.cs
+++ b/src/nORM/Query/QueryPlan.cs
@@ -11,10 +11,11 @@ using nORM.Mapping;
 namespace nORM.Query
 {
     internal sealed record QueryPlan(
-        string Sql, 
-        IReadOnlyDictionary<string, object> Parameters, 
+        string Sql,
+        IReadOnlyDictionary<string, object> Parameters,
+        IReadOnlyList<string> CompiledParameters,
         Func<DbDataReader, CancellationToken, Task<object>> Materializer,
-        Type ElementType, 
+        Type ElementType,
         bool IsScalar,
         bool SingleResult,
         bool NoTracking,

--- a/src/nORM/Query/SqlClauseBuilder.cs
+++ b/src/nORM/Query/SqlClauseBuilder.cs
@@ -15,6 +15,8 @@ namespace nORM.Query
         public List<string> GroupBy { get; } = new();
         public int? Take { get; set; }
         public int? Skip { get; set; }
+        public string? TakeParam { get; set; }
+        public string? SkipParam { get; set; }
         public bool IsDistinct { get; set; }
     }
 }

--- a/tests/QueryTranslatorCrossProviderTests.cs
+++ b/tests/QueryTranslatorCrossProviderTests.cs
@@ -107,7 +107,7 @@ public class QueryTranslatorCrossProviderTests : TestBase
         var provider = setup.Provider;
         var (sql, _, _) = TranslateQuery<Product, Product>(q => q.Take(5), connection, provider);
         var sb = new StringBuilder(BaseSelect(provider));
-        provider.ApplyPaging(sb, 5, null);
+        provider.ApplyPaging(sb, 5, null, null, null);
         var expected = sb.ToString();
         Assert.Equal(expected, sql);
     }
@@ -121,7 +121,7 @@ public class QueryTranslatorCrossProviderTests : TestBase
         var provider = setup.Provider;
         var (sql, _, _) = TranslateQuery<Product, Product>(q => q.Skip(10), connection, provider);
         var sb = new StringBuilder(BaseSelect(provider));
-        provider.ApplyPaging(sb, null, 10);
+        provider.ApplyPaging(sb, null, 10, null, null);
         var expected = sb.ToString();
         Assert.Equal(expected, sql);
     }
@@ -135,7 +135,7 @@ public class QueryTranslatorCrossProviderTests : TestBase
         var provider = setup.Provider;
         var (sql, _, _) = TranslateQuery<Product, Product>(q => q.OrderBy(p => p.Id).Skip(20).Take(10), connection, provider);
         var sb = new StringBuilder($"{BaseSelect(provider, true)} ORDER BY T0.{provider.Escape("Id")} ASC");
-        provider.ApplyPaging(sb, 10, 20);
+        provider.ApplyPaging(sb, 10, 20, null, null);
         var expected = sb.ToString();
         Assert.Equal(expected, sql);
     }

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -17,7 +17,7 @@ public abstract class TestBase
         var getMapping = typeof(DbContext).GetMethod("GetMapping", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
         var mapping = getMapping.Invoke(ctx, new object[] { typeof(T) });
         var visitorType = typeof(DbContext).Assembly.GetType("nORM.Query.ExpressionToSqlVisitor", true)!;
-        var visitor = Activator.CreateInstance(visitorType, ctx, mapping, ctx.Provider, expr.Parameters[0], "T0", null)!;
+        var visitor = Activator.CreateInstance(visitorType, ctx, mapping, ctx.Provider, expr.Parameters[0], "T0", null, null, null)!;
         var sql = (string)visitorType.GetMethod("Translate")!.Invoke(visitor, new object[] { expr.Body })!;
         var parameters = (Dictionary<string, object>)visitorType.GetMethod("GetParameters")!.Invoke(visitor, null)!;
         return (sql, parameters);


### PR DESCRIPTION
## Summary
- Handle types without parameterless constructors and initialize owned properties during materialization
- Compile queries with context-bound `Query` calls and parameter placeholders
- Expose `QueryTranslator.CreateMaterializer` publicly for source-generated materializers

## Testing
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68b83a30e5d4832cb74a3c0fe752744b