### PR TITLE
Ensure navigation properties initialized with empty lists

### DIFF
--- a/src/nORM/Query/IncludeProcessor.cs
+++ b/src/nORM/Query/IncludeProcessor.cs
@@ -67,17 +67,22 @@ namespace nORM.Query
                 }
             }
 
-            var childGroups = resultChildren.GroupBy(relation.ForeignKey.Getter).ToDictionary(g => g.Key!, g => g.ToList());
+            var childGroups = resultChildren
+                .GroupBy(relation.ForeignKey.Getter)
+                .ToDictionary(g => g.Key!, g => g.ToList());
+
             foreach (var p in parents.Cast<object>())
             {
                 var pk = relation.PrincipalKey.Getter(p);
+                var listType = typeof(List<>).MakeGenericType(relation.DependentType);
+                var childList = (IList)System.Activator.CreateInstance(listType)!;
+
                 if (pk != null && childGroups.TryGetValue(pk, out var c))
                 {
-                    var listType = typeof(List<>).MakeGenericType(relation.DependentType);
-                    var childList = (IList)System.Activator.CreateInstance(listType)!;
                     foreach (var item in c) childList.Add(item);
-                    relation.NavProp.SetValue(p, childList);
                 }
+
+                relation.NavProp.SetValue(p, childList);
             }
 
             return resultChildren;


### PR DESCRIPTION
## Summary
- Avoid leaving null collection navigation properties during eager loading
- Always assign an empty child list when no matching rows are found

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8513da1c8832c8bfa4fd5d7b33c94