### PR TITLE
Add query plan validation

### DIFF
--- a/src/Internals.cs
+++ b/src/Internals.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("nORM.Tests")]

--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -19,6 +19,8 @@ namespace nORM.Providers
         private static readonly ConcurrentLruCache<(Type Type, string Operation), string> _sqlCache = new(maxSize: 1000);
         
         public string ParamPrefix { get; protected init; } = "@";
+        public virtual int MaxSqlLength => int.MaxValue;
+        public virtual int MaxParameters => int.MaxValue;
         public abstract string Escape(string id);
         public abstract void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam);
         public abstract string GetIdentityRetrievalString(TableMapping m);

--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -17,6 +17,8 @@ namespace nORM.Providers
     public sealed class MySqlProvider : DatabaseProvider
     {
         private static readonly ConcurrentLruCache<Type, DataTable> _tableSchemas = new(maxSize: 100);
+        public override int MaxSqlLength => 4_194_304;
+        public override int MaxParameters => 65_535;
         public override string Escape(string id) => $"`{id}`";
         
         public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam)

--- a/src/nORM/Providers/PostgresProvider.cs
+++ b/src/nORM/Providers/PostgresProvider.cs
@@ -16,6 +16,8 @@ namespace nORM.Providers
 {
     public sealed class PostgresProvider : DatabaseProvider
     {
+        public override int MaxSqlLength => int.MaxValue;
+        public override int MaxParameters => 32_767;
         public override string Escape(string id) => $"\"{id}\"";
         
         public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam)

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -19,6 +19,8 @@ namespace nORM.Providers
     {
         private static readonly ConcurrentLruCache<Type, DataTable> _tableSchemas = new(maxSize: 100);
         private static readonly ConcurrentLruCache<Type, DataTable> _keyTableSchemas = new(maxSize: 100);
+        public override int MaxSqlLength => 8_000;
+        public override int MaxParameters => 2_100;
         public override string Escape(string id) => $"[{id}]";
         
         public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam)

--- a/src/nORM/Providers/SqliteProvider.cs
+++ b/src/nORM/Providers/SqliteProvider.cs
@@ -18,6 +18,8 @@ namespace nORM.Providers
 {
     public sealed class SqliteProvider : DatabaseProvider
     {
+        public override int MaxSqlLength => 1_000_000;
+        public override int MaxParameters => 999;
         public override string Escape(string id) => $"\"{id}\"";
         
         public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam)

--- a/src/nORM/Query/QueryPlanValidator.cs
+++ b/src/nORM/Query/QueryPlanValidator.cs
@@ -1,0 +1,17 @@
+using System;
+using nORM.Providers;
+
+namespace nORM.Query
+{
+    internal static class QueryPlanValidator
+    {
+        public static void Validate(QueryPlan plan, DatabaseProvider provider)
+        {
+            if (plan.Sql.Length > provider.MaxSqlLength)
+                throw new InvalidOperationException($"Generated SQL exceeds maximum length of {provider.MaxSqlLength}");
+
+            if (plan.Parameters.Count > provider.MaxParameters)
+                throw new InvalidOperationException($"Too many parameters in query. Maximum is {provider.MaxParameters}");
+        }
+    }
+}

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -188,7 +188,9 @@ namespace nORM.Query
 
             var elementType = _groupJoinInfo?.ResultType ?? materializerType;
 
-            return new QueryPlan(_sql.ToString(), _params, _compiledParams, materializer, elementType, isScalar, singleResult, _noTracking, _methodName, _includes, _groupJoinInfo, _tables.ToArray());
+            var plan = new QueryPlan(_sql.ToString(), _params, _compiledParams, materializer, elementType, isScalar, singleResult, _noTracking, _methodName, _includes, _groupJoinInfo, _tables.ToArray());
+            QueryPlanValidator.Validate(plan, _provider);
+            return plan;
         }
 
         private TableMapping TrackMapping(Type type)

--- a/tests/QueryPlanValidatorTests.cs
+++ b/tests/QueryPlanValidatorTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using nORM.Providers;
+using nORM.Query;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class QueryPlanValidatorTests
+{
+    private static QueryPlan CreatePlan(string sql, Dictionary<string, object> parameters)
+        => new(sql, parameters, new List<string>(), Materializer, typeof(int), false, false, false, string.Empty, new List<IncludePlan>(), null, Array.Empty<string>());
+
+    private static Task<object> Materializer(DbDataReader _, CancellationToken __) => Task.FromResult<object>(0);
+
+    public static IEnumerable<object[]> Providers()
+    {
+        yield return new object[] { new SqlServerProvider() };
+        yield return new object[] { new SqliteProvider() };
+        yield return new object[] { new PostgresProvider() };
+        yield return new object[] { new MySqlProvider() };
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void Throws_when_sql_exceeds(DatabaseProvider provider)
+    {
+        if (provider.MaxSqlLength == int.MaxValue)
+            return;
+
+        var sql = new string('x', provider.MaxSqlLength + 1);
+        var plan = CreatePlan(sql, new Dictionary<string, object>());
+        Assert.Throws<InvalidOperationException>(() => QueryPlanValidator.Validate(plan, provider));
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void Throws_when_too_many_params(DatabaseProvider provider)
+    {
+        var paramCount = provider.MaxParameters + 1;
+        var parameters = new Dictionary<string, object>(paramCount);
+        for (int i = 0; i < paramCount; i++)
+            parameters[$"{provider.ParamPrefix}p{i}"] = i;
+
+        var plan = CreatePlan("SELECT 1", parameters);
+        Assert.Throws<InvalidOperationException>(() => QueryPlanValidator.Validate(plan, provider));
+    }
+}


### PR DESCRIPTION
## Summary
- add QueryPlanValidator to enforce provider-specific SQL and parameter limits
- expose max SQL length and parameter count on DatabaseProvider and overrides for each provider
- validate plans during translation and add tests for all providers

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b86abf5d20832cb464a3960e07d4f0