### PR TITLE
Handle provider parameter limits in bulk deletes

### DIFF
--- a/src/nORM/Providers/SqliteProvider.cs
+++ b/src/nORM/Providers/SqliteProvider.cs
@@ -221,7 +221,11 @@ namespace nORM.Providers
                 throw new System.Exception($"Cannot delete from '{m.EscTable}': no key columns defined.");
             
             var totalDeleted = 0;
-            var batchSize = 100; // Reasonable batch size for IN clauses
+            // Respect provider parameter limits when batching deletes
+            var batchSize = ctx.Options.BulkBatchSize;
+            if (MaxParameters != int.MaxValue)
+                batchSize = Math.Min(batchSize, MaxParameters);
+            if (batchSize <= 0) batchSize = 1;
             
             await using var transaction = await ctx.Connection.BeginTransactionAsync(ct);
             try


### PR DESCRIPTION
## Summary
- respect provider MaxParameters when batching deletes
- ensure SQLite bulk delete uses provider-based batch size

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b8858aba98832cadbbccd0ef167096