### PR TITLE
Implement efficient GroupJoin handling

### DIFF
--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -592,15 +592,13 @@ namespace nORM.Query
                 joinSqlG.Append($"SELECT {string.Join(", ", outerColumns.Concat(innerColumns))} ");
                 joinSqlG.Append($"FROM {_mapping.EscTable} {outerAlias} ");
                 joinSqlG.Append($"LEFT JOIN {innerMapping.EscTable} {innerAliasG} ON {outerKeySqlG} = {innerKeySqlG}");
+                joinSqlG.Append($" ORDER BY {outerKeySqlG}");
 
                 _sql.Clear();
                 _sql.Append(joinSqlG.ToString());
 
-                var tupleCtor = typeof(ValueTuple<object, object>).GetConstructor(new[] { typeof(object), typeof(object) })!;
-                var tupleExpr = Expression.New(tupleCtor,
-                    Expression.Convert(outerKeySelector.Parameters[0], typeof(object)),
-                    Expression.Convert(innerKeySelector.Parameters[0], typeof(object)));
-                _projection = Expression.Lambda(tupleExpr, outerKeySelector.Parameters[0], innerKeySelector.Parameters[0]);
+                // Reset projection so outer entities are materialized directly
+                _projection = null;
 
                 var innerKeyColumn = innerMapping.Columns.FirstOrDefault(c =>
                     ExtractPropertyName(innerKeySelector.Body) == c.PropName);

--- a/tests/GroupJoinTests.cs
+++ b/tests/GroupJoinTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Sqlite;
+using nORM.Core;
+using nORM.Providers;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class GroupJoinTests
+{
+    private class Person
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private class Pet
+    {
+        public int Id { get; set; }
+        public int OwnerId { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void GroupJoin_returns_grouped_results()
+    {
+        using var cn = new SqliteConnection("Data Source=:memory:");
+        cn.Open();
+        using (var cmd = cn.CreateCommand())
+        {
+            cmd.CommandText =
+                "CREATE TABLE Person(Id INTEGER, Name TEXT);" +
+                "CREATE TABLE Pet(Id INTEGER, OwnerId INTEGER, Name TEXT);" +
+                "INSERT INTO Person VALUES(1,'Alice');" +
+                "INSERT INTO Person VALUES(2,'Bob');" +
+                "INSERT INTO Pet VALUES(1,1,'Fido');" +
+                "INSERT INTO Pet VALUES(2,1,'Rex');" +
+                "INSERT INTO Pet VALUES(3,2,'Whiskers');";
+            cmd.ExecuteNonQuery();
+        }
+
+        using var ctx = new DbContext(cn, new SqliteProvider());
+        var results = ctx.Query<Person>()
+            .GroupJoin(ctx.Query<Pet>(), p => p.Id, pet => pet.OwnerId,
+                (p, pets) => new { Person = p, Pets = pets.ToList() })
+            .ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("Alice", results[0].Person.Name);
+        Assert.Equal(2, results[0].Pets.Count);
+        Assert.Equal("Bob", results[1].Person.Name);
+        Assert.Single(results[1].Pets);
+    }
+}


### PR DESCRIPTION
## Summary
- translate GroupJoin queries into LEFT JOIN SQL with proper ordering and no tuple projection
- stream LEFT JOIN results to rebuild groups without intermediate tuples
- add coverage for GroupJoin materialization

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b8879c70a0832cb4e78c4943c1008b