### PR TITLE
Validate paging parameter names

### DIFF
--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -23,7 +23,7 @@ namespace nORM.Providers
         public virtual int MaxSqlLength => int.MaxValue;
         public virtual int MaxParameters => int.MaxValue;
         public abstract string Escape(string id);
-        public abstract void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam);
+        public abstract void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName);
         public abstract string GetIdentityRetrievalString(TableMapping m);
         public abstract DbParameter CreateParameter(string name, object? value);
         public abstract string? TranslateFunction(string name, Type declaringType, params string[] args);
@@ -43,6 +43,12 @@ namespace nORM.Providers
         {
             if (connection.State != ConnectionState.Open)
                 throw new InvalidOperationException($"Connection must be open for {GetType().Name}");
+        }
+
+        protected void EnsureValidParameterName(string? parameterName, string argumentName)
+        {
+            if (parameterName != null && !parameterName.StartsWith(ParamPrefix, StringComparison.Ordinal))
+                throw new ArgumentException($"Parameter name must start with '{ParamPrefix}'", argumentName);
         }
 
         public virtual Task<bool> IsAvailableAsync()

--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -22,14 +22,17 @@ namespace nORM.Providers
         public override int MaxParameters => 65_535;
         public override string Escape(string id) => $"`{id}`";
         
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam)
+        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
         {
-            if (limitParam != null || limit.HasValue)
+            EnsureValidParameterName(limitParameterName, nameof(limitParameterName));
+            EnsureValidParameterName(offsetParameterName, nameof(offsetParameterName));
+
+            if (limitParameterName != null || limit.HasValue)
             {
                 sb.Append(" LIMIT ");
-                sb.Append(offsetParam ?? (offset ?? 0).ToString());
+                sb.Append(offsetParameterName ?? (offset ?? 0).ToString());
                 sb.Append(", ");
-                sb.Append(limitParam ?? limit!.Value.ToString());
+                sb.Append(limitParameterName ?? limit!.Value.ToString());
             }
         }
         

--- a/src/nORM/Providers/PostgresProvider.cs
+++ b/src/nORM/Providers/PostgresProvider.cs
@@ -21,15 +21,18 @@ namespace nORM.Providers
         public override int MaxParameters => 32_767;
         public override string Escape(string id) => $"\"{id}\"";
         
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam)
+        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
         {
-            if (limitParam != null)
-                sb.Append(" LIMIT ").Append(limitParam);
+            EnsureValidParameterName(limitParameterName, nameof(limitParameterName));
+            EnsureValidParameterName(offsetParameterName, nameof(offsetParameterName));
+
+            if (limitParameterName != null)
+                sb.Append(" LIMIT ").Append(limitParameterName);
             else if (limit.HasValue)
                 sb.Append($" LIMIT {limit}");
 
-            if (offsetParam != null)
-                sb.Append(" OFFSET ").Append(offsetParam);
+            if (offsetParameterName != null)
+                sb.Append(" OFFSET ").Append(offsetParameterName);
             else if (offset.HasValue)
                 sb.Append($" OFFSET {offset}");
         }

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -24,15 +24,18 @@ namespace nORM.Providers
         public override int MaxParameters => 2_100;
         public override string Escape(string id) => $"[{id}]";
         
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam)
+        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
         {
-            if (offset.HasValue || offsetParam != null || limit.HasValue || limitParam != null)
+            EnsureValidParameterName(limitParameterName, nameof(limitParameterName));
+            EnsureValidParameterName(offsetParameterName, nameof(offsetParameterName));
+
+            if (offset.HasValue || offsetParameterName != null || limit.HasValue || limitParameterName != null)
             {
                 if (!sb.ToString().Contains("ORDER BY")) sb.Append(" ORDER BY (SELECT NULL)");
                 sb.Append(" OFFSET ");
-                sb.Append(offsetParam ?? (offset ?? 0).ToString());
+                sb.Append(offsetParameterName ?? (offset ?? 0).ToString());
                 sb.Append(" ROWS FETCH NEXT ");
-                sb.Append(limitParam ?? (limit ?? int.MaxValue).ToString());
+                sb.Append(limitParameterName ?? (limit ?? int.MaxValue).ToString());
                 sb.Append(" ROWS ONLY");
             }
         }

--- a/src/nORM/Providers/SqliteProvider.cs
+++ b/src/nORM/Providers/SqliteProvider.cs
@@ -22,15 +22,18 @@ namespace nORM.Providers
         public override int MaxParameters => 999;
         public override string Escape(string id) => $"\"{id}\"";
         
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParam, string? offsetParam)
+        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
         {
-            if (limitParam != null)
-                sb.Append(" LIMIT ").Append(limitParam);
+            EnsureValidParameterName(limitParameterName, nameof(limitParameterName));
+            EnsureValidParameterName(offsetParameterName, nameof(offsetParameterName));
+
+            if (limitParameterName != null)
+                sb.Append(" LIMIT ").Append(limitParameterName);
             else if (limit.HasValue)
                 sb.Append($" LIMIT {limit}");
 
-            if (offsetParam != null)
-                sb.Append(" OFFSET ").Append(offsetParam);
+            if (offsetParameterName != null)
+                sb.Append(" OFFSET ").Append(offsetParameterName);
             else if (offset.HasValue)
                 sb.Append($" OFFSET {offset}");
         }

--- a/tests/QueryTranslatorCrossProviderTests.cs
+++ b/tests/QueryTranslatorCrossProviderTests.cs
@@ -142,6 +142,17 @@ public class QueryTranslatorCrossProviderTests : TestBase
 
     [Theory]
     [MemberData(nameof(Providers))]
+    public void ApplyPaging_throws_on_invalid_parameter_name(ProviderKind providerKind)
+    {
+        var setup = CreateProvider(providerKind);
+        using var connection = setup.Connection;
+        var provider = setup.Provider;
+        var sb = new StringBuilder(BaseSelect(provider));
+        Assert.Throws<ArgumentException>(() => provider.ApplyPaging(sb, 5, null, "p0", null));
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
     public void SelectMany_creates_cross_join(ProviderKind providerKind)
     {
         var setup = CreateProvider(providerKind);


### PR DESCRIPTION
## Summary
- Rename ApplyPaging parameters to limitParameterName and offsetParameterName
- Validate paging parameter names start with provider prefix to avoid injection
- Add unit test ensuring invalid parameter names throw

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b8896cea40832cb68ee8f7211df723