### PR TITLE
feat: allow specifying principal key for relationships

### DIFF
--- a/src/nORM/Configuration/EntityTypeBuilder.cs
+++ b/src/nORM/Configuration/EntityTypeBuilder.cs
@@ -159,10 +159,14 @@ namespace nORM.Configuration
                     _dependentNavigation = dependentNavigation;
                 }
 
-                public EntityTypeBuilder<TEntity> HasForeignKey(Expression<Func<TDependent, object>> foreignKeyExpression)
+                public EntityTypeBuilder<TEntity> HasForeignKey(
+                    Expression<Func<TDependent, object>> foreignKeyExpression,
+                    Expression<Func<TEntity, object>>? principalKeyExpression = null)
                 {
                     var fkProp = _parent.GetProperty(foreignKeyExpression);
-                    var principalKey = _parent._config.KeyProperty;
+                    var principalKey = principalKeyExpression != null
+                        ? _parent.GetProperty(principalKeyExpression)
+                        : _parent._config.KeyProperty;
                     _parent._config.AddRelationship(new RelationshipConfiguration(_principalNavigation, typeof(TDependent), _dependentNavigation, principalKey, fkProp));
                     return _parent;
                 }


### PR DESCRIPTION
## Summary
- add optional principal key expression for configuring relationships
- test explicit principal key usage

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a12a2eb0832cbebbedf07fc2c127