### PR TITLE
Add ambient transaction support to DbContext operations

### DIFF
--- a/src/nORM/Core/DatabaseFacade.cs
+++ b/src/nORM/Core/DatabaseFacade.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace nORM.Core
+{
+    public class DatabaseFacade
+    {
+        private readonly DbContext _context;
+
+        internal DatabaseFacade(DbContext context)
+        {
+            _context = context;
+        }
+
+        public DbTransaction? CurrentTransaction => _context.CurrentTransaction;
+
+        public async Task<DbContextTransaction> BeginTransactionAsync(CancellationToken ct = default)
+        {
+            if (_context.CurrentTransaction != null)
+                throw new InvalidOperationException("A transaction is already active.");
+
+            var transaction = await _context.Connection.BeginTransactionAsync(ct);
+            _context.CurrentTransaction = transaction;
+            return new DbContextTransaction(transaction, _context);
+        }
+    }
+}

--- a/src/nORM/Core/DbContextTransaction.cs
+++ b/src/nORM/Core/DbContextTransaction.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace nORM.Core
+{
+    public sealed class DbContextTransaction : IAsyncDisposable, IDisposable
+    {
+        private readonly DbTransaction _transaction;
+        private readonly DbContext _context;
+        private bool _completed;
+
+        internal DbContextTransaction(DbTransaction transaction, DbContext context)
+        {
+            _transaction = transaction;
+            _context = context;
+        }
+
+        public DbTransaction Transaction => _transaction;
+
+        public void Commit()
+        {
+            _transaction.Commit();
+            Dispose();
+        }
+
+        public async Task CommitAsync(CancellationToken ct = default)
+        {
+            await _transaction.CommitAsync(ct);
+            await DisposeAsync();
+        }
+
+        public void Rollback()
+        {
+            _transaction.Rollback();
+            Dispose();
+        }
+
+        public async Task RollbackAsync(CancellationToken ct = default)
+        {
+            await _transaction.RollbackAsync(ct);
+            await DisposeAsync();
+        }
+
+        public void Dispose()
+        {
+            if (!_completed)
+            {
+                _completed = true;
+                _transaction.Dispose();
+                _context.ClearTransaction(_transaction);
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (!_completed)
+            {
+                _completed = true;
+                await _transaction.DisposeAsync();
+                _context.ClearTransaction(_transaction);
+            }
+        }
+    }
+}

--- a/tests/TransactionScopingTests.cs
+++ b/tests/TransactionScopingTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using nORM.Core;
+using nORM.Providers;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class TransactionScopingTests
+{
+    private class Item
+    {
+        [System.ComponentModel.DataAnnotations.Key]
+        [System.ComponentModel.DataAnnotations.Schema.DatabaseGenerated(System.ComponentModel.DataAnnotations.Schema.DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public async Task AmbientTransaction_RollsBackAllOperations()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        await using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "CREATE TABLE Item (Id INTEGER PRIMARY KEY AUTOINCREMENT, Name TEXT);";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var provider = new SqliteProvider();
+        using var ctx = new DbContext(connection, provider);
+
+        await using var tx = await ctx.Database.BeginTransactionAsync();
+
+        await ctx.InsertAsync(new Item { Name = "first" });
+        ctx.Add(new Item { Name = "second" });
+        await ctx.SaveChangesAsync();
+
+        await tx.RollbackAsync();
+
+        await using var countCmd = connection.CreateCommand();
+        countCmd.CommandText = "SELECT COUNT(*) FROM Item";
+        var countObj = await countCmd.ExecuteScalarAsync();
+        var count = countObj is null ? 0L : Convert.ToInt64(countObj);
+        Assert.Equal(0L, count);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Database` facade with `BeginTransactionAsync` for transaction control
- track active transactions in `DbContext` and reuse them in writes and `SaveChangesAsync`
- cover transaction scoping with tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b8a3a094d8832c883f0d4ae96d6658