### PR TITLE
feat: add AsSplitQuery support

### DIFF
--- a/src/nORM/Core/NormQueryable.cs
+++ b/src/nORM/Core/NormQueryable.cs
@@ -29,6 +29,7 @@ namespace nORM.Core
     {
         INormIncludableQueryable<T, TProperty> Include<TProperty>(Expression<Func<T, TProperty>> navigationPropertyPath);
         INormQueryable<T> AsNoTracking();
+        INormQueryable<T> AsSplitQuery();
         IAsyncEnumerable<T> AsAsyncEnumerable(CancellationToken ct = default);
         Task<List<T>> ToListAsync(CancellationToken ct = default);
         Task<T[]> ToArrayAsync(CancellationToken ct = default);
@@ -88,6 +89,17 @@ namespace nORM.Core
             var expression = Expression.Call(
                 typeof(INormQueryable<>).MakeGenericType(typeof(T)),
                 nameof(AsNoTracking),
+                Type.EmptyTypes,
+                Expression
+            );
+            return new NormQueryableImpl<T>(Provider, expression);
+        }
+
+        public INormQueryable<T> AsSplitQuery()
+        {
+            var expression = Expression.Call(
+                typeof(INormQueryable<>).MakeGenericType(typeof(T)),
+                nameof(AsSplitQuery),
                 Type.EmptyTypes,
                 Expression
             );
@@ -166,6 +178,17 @@ namespace nORM.Core
             var expression = Expression.Call(
                 typeof(INormQueryable<>).MakeGenericType(typeof(T)),
                 nameof(INormQueryable<T>.AsNoTracking),
+                Type.EmptyTypes,
+                Expression
+            );
+            return new NormQueryableImpl<T>(Provider, expression);
+        }
+
+        public INormQueryable<T> AsSplitQuery()
+        {
+            var expression = Expression.Call(
+                typeof(INormQueryable<>).MakeGenericType(typeof(T)),
+                nameof(INormQueryable<T>.AsSplitQuery),
                 Type.EmptyTypes,
                 Expression
             );

--- a/src/nORM/Query/QueryExecutor.cs
+++ b/src/nORM/Query/QueryExecutor.cs
@@ -56,9 +56,12 @@ namespace nORM.Query
                 list.Add(entity);
             }
 
-            foreach (var include in plan.Includes)
+            if (plan.SplitQuery)
             {
-                await _includeProcessor.EagerLoadAsync(include, list, ct, plan.NoTracking);
+                foreach (var include in plan.Includes)
+                {
+                    await _includeProcessor.EagerLoadAsync(include, list, ct, plan.NoTracking);
+                }
             }
 
             return list;

--- a/src/nORM/Query/QueryPlan.cs
+++ b/src/nORM/Query/QueryPlan.cs
@@ -22,7 +22,8 @@ namespace nORM.Query
         string MethodName,
         List<IncludePlan> Includes,
         GroupJoinInfo? GroupJoinInfo,
-        IReadOnlyCollection<string> Tables
+        IReadOnlyCollection<string> Tables,
+        bool SplitQuery
     );
 
     internal sealed record IncludePlan(List<TableMapping.Relation> Path);

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -42,6 +42,7 @@ namespace nORM.Query
         private DatabaseProvider _provider;
         private bool _singleResult = false;
         private bool _noTracking = false;
+        private bool _splitQuery = false;
         private readonly HashSet<string> _tables;
 
         private StringBuilder _sql => _clauses.Sql;
@@ -188,7 +189,7 @@ namespace nORM.Query
 
             var elementType = _groupJoinInfo?.ResultType ?? materializerType;
 
-            var plan = new QueryPlan(_sql.ToString(), _params, _compiledParams, materializer, elementType, isScalar, singleResult, _noTracking, _methodName, _includes, _groupJoinInfo, _tables.ToArray());
+            var plan = new QueryPlan(_sql.ToString(), _params, _compiledParams, materializer, elementType, isScalar, singleResult, _noTracking, _methodName, _includes, _groupJoinInfo, _tables.ToArray(), _splitQuery);
             QueryPlanValidator.Validate(plan, _provider);
             return plan;
         }
@@ -525,6 +526,10 @@ namespace nORM.Query
 
                 case "AsNoTracking":
                     _noTracking = true;
+                    return Visit(node.Arguments[0]);
+
+                case "AsSplitQuery":
+                    _splitQuery = true;
                     return Visit(node.Arguments[0]);
 
                 default:

--- a/tests/QueryPlanValidatorTests.cs
+++ b/tests/QueryPlanValidatorTests.cs
@@ -12,7 +12,7 @@ namespace nORM.Tests;
 public class QueryPlanValidatorTests
 {
     private static QueryPlan CreatePlan(string sql, Dictionary<string, object> parameters)
-        => new(sql, parameters, new List<string>(), Materializer, typeof(int), false, false, false, string.Empty, new List<IncludePlan>(), null, Array.Empty<string>());
+        => new(sql, parameters, new List<string>(), Materializer, typeof(int), false, false, false, string.Empty, new List<IncludePlan>(), null, Array.Empty<string>(), true);
 
     private static Task<object> Materializer(DbDataReader _, CancellationToken __) => Task.FromResult<object>(0);
 


### PR DESCRIPTION
## Summary
- add AsSplitQuery operator to queryable interfaces
- track split query requests during translation
- execute includes in separate queries when split mode is enabled

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b8a9e766d4832cbc365e5f116e1e25