### PR TITLE
Support composite primary keys

### DIFF
--- a/src/nORM/Configuration/IEntityTypeConfiguration.cs
+++ b/src/nORM/Configuration/IEntityTypeConfiguration.cs
@@ -9,7 +9,7 @@ namespace nORM.Configuration
     public interface IEntityTypeConfiguration
     {
         string? TableName { get; }
-        PropertyInfo? KeyProperty { get; }
+        List<PropertyInfo> KeyProperties { get; }
         Dictionary<PropertyInfo, string> ColumnNames { get; }
         Type? TableSplitWith { get; }
         Dictionary<PropertyInfo, OwnedNavigation> OwnedNavigations { get; }

--- a/src/nORM/Mapping/Column.cs
+++ b/src/nORM/Mapping/Column.cs
@@ -32,7 +32,7 @@ namespace nORM.Mapping
             var colName = fluentColName ?? pi.GetCustomAttribute<ColumnAttribute>()?.Name ?? PropName;
             EscCol = p.Escape(colName);
 
-            IsKey = fluentConfig?.KeyProperty == pi || pi.GetCustomAttribute<KeyAttribute>() != null;
+            IsKey = (fluentConfig?.KeyProperties.Contains(pi) ?? false) || pi.GetCustomAttribute<KeyAttribute>() != null;
             IsTimestamp = pi.GetCustomAttribute<TimestampAttribute>() != null;
             IsDbGenerated = pi.GetCustomAttribute<DatabaseGeneratedAttribute>()?.DatabaseGeneratedOption == DatabaseGeneratedOption.Identity;
             ForeignKeyPrincipalTypeName = pi.GetCustomAttribute<ForeignKeyAttribute>()?.Name;

--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -254,9 +254,9 @@ namespace nORM.Providers
                     .Select(c => $"{c.EscCol}={ParamPrefix}{c.PropName}"));
 
                 var whereCols = m.KeyColumns
-                    .Select(c => $"{c.EscCol}={ParamPrefix}{c.PropName}");
+                    .Select(c => $"{c.EscCol}={ParamPrefix}{c.PropName}").ToList();
                 if (m.TimestampColumn != null)
-                    whereCols = whereCols.Append($"{m.TimestampColumn.EscCol}={ParamPrefix}{m.TimestampColumn.PropName}");
+                    whereCols.Add($"{m.TimestampColumn.EscCol}={ParamPrefix}{m.TimestampColumn.PropName}");
                 var where = string.Join(" AND ", whereCols);
 
                 return $"UPDATE {m.EscTable} SET {set} WHERE {where}";
@@ -268,9 +268,9 @@ namespace nORM.Providers
             return _sqlCache.GetOrAdd((m.Type, "DELETE"), _ =>
             {
                 var whereCols = m.KeyColumns
-                    .Select(c => $"{c.EscCol}={ParamPrefix}{c.PropName}");
+                    .Select(c => $"{c.EscCol}={ParamPrefix}{c.PropName}").ToList();
                 if (m.TimestampColumn != null)
-                    whereCols = whereCols.Append($"{m.TimestampColumn.EscCol}={ParamPrefix}{m.TimestampColumn.PropName}");
+                    whereCols.Add($"{m.TimestampColumn.EscCol}={ParamPrefix}{m.TimestampColumn.PropName}");
                 var where = string.Join(" AND ", whereCols);
 
                 return $"DELETE FROM {m.EscTable} WHERE {where}";

--- a/tests/CompositeKeyTests.cs
+++ b/tests/CompositeKeyTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.Data.Sqlite;
+using nORM.Configuration;
+using nORM.Core;
+using nORM.Providers;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class CompositeKeyTests
+{
+    public class CompositeEntity
+    {
+        public int KeyPart1 { get; set; }
+        public int KeyPart2 { get; set; }
+        public string Value { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void BuildUpdate_and_Delete_use_all_key_columns()
+    {
+        using var cn = new SqliteConnection("Data Source=:memory:");
+        cn.Open();
+
+        var options = new DbContextOptions
+        {
+            OnModelCreating = mb =>
+                mb.Entity<CompositeEntity>().HasKey(e => new { e.KeyPart1, e.KeyPart2 })
+        };
+
+        using var ctx = new DbContext(cn, new SqliteProvider(), options);
+        var mapping = ctx.GetMapping(typeof(CompositeEntity));
+
+        var updateSql = ctx.Provider.BuildUpdate(mapping);
+        var deleteSql = ctx.Provider.BuildDelete(mapping);
+
+        Assert.Contains("KeyPart1", updateSql);
+        Assert.Contains("KeyPart2", updateSql);
+        Assert.Contains(" AND ", updateSql);
+
+        Assert.Contains("KeyPart1", deleteSql);
+        Assert.Contains("KeyPart2", deleteSql);
+        Assert.Contains(" AND ", deleteSql);
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow configuring composite keys via `HasKey(e => new { e.Part1, e.Part2 })`
- propagate composite keys through mappings and SQL generation
- verify update and delete SQL contains all key columns

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b8abb21f94832c8bdb1347cc694444