### PR TITLE
Add connection string DbContext constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,13 @@ using nORM.Core;
 using nORM.Providers;
 using Microsoft.Data.SqlClient;
 
-// Create connection and context
-var connection = new SqlConnection("Server=.;Database=MyApp;Trusted_Connection=true");
+// Create context and let it manage the connection
 var provider = new SqlServerProvider();
-var context = new DbContext(connection, provider);
+var context = new DbContext("Server=.;Database=MyApp;Trusted_Connection=true", provider);
+
+// Or create and pass an existing connection
+// using var connection = new SqlConnection("Server=.;Database=MyApp;Trusted_Connection=true");
+// var context = new DbContext(connection, provider);
 
 // Define your entities
 public class User


### PR DESCRIPTION
## Summary
- add DbContext constructor accepting connection string to manage connection lifecycle
- document connection string usage in README

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b03a342c832cb9bc5e888203a186