### PR TITLE
fix: open database connection per operation

### DIFF
--- a/src/nORM/Core/DatabaseFacade.cs
+++ b/src/nORM/Core/DatabaseFacade.cs
@@ -20,7 +20,7 @@ namespace nORM.Core
         {
             if (_context.CurrentTransaction != null)
                 throw new InvalidOperationException("A transaction is already active.");
-
+            await _context.EnsureConnectionAsync(ct);
             var transaction = await _context.Connection.BeginTransactionAsync(ct);
             _context.CurrentTransaction = transaction;
             return new DbContextTransaction(transaction, _context);

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -336,6 +336,7 @@ namespace nORM.Navigation
 
         private static async Task<List<object>> ExecuteCollectionQueryAsync(DbContext context, TableMapping mapping, Column foreignKey, object keyValue, Type entityType, CancellationToken ct)
         {
+            await context.EnsureConnectionAsync(ct);
             using var cmd = context.Connection.CreateCommand();
             cmd.CommandTimeout = (int)context.Options.CommandTimeout.TotalSeconds;
             
@@ -361,6 +362,7 @@ namespace nORM.Navigation
 
         private static async Task<object?> ExecuteSingleQueryAsync(DbContext context, TableMapping mapping, Column foreignKey, object keyValue, Type entityType, CancellationToken ct)
         {
+            await context.EnsureConnectionAsync(ct);
             using var cmd = context.Connection.CreateCommand();
             cmd.CommandTimeout = (int)context.Options.CommandTimeout.TotalSeconds;
             

--- a/src/nORM/Query/IncludeProcessor.cs
+++ b/src/nORM/Query/IncludeProcessor.cs
@@ -42,6 +42,7 @@ namespace nORM.Query
             if (keys.Count == 0) return resultChildren;
 
             var paramNames = new List<string>();
+            await _ctx.EnsureConnectionAsync(ct);
             await using var cmd = _ctx.Connection.CreateCommand();
             cmd.CommandTimeout = (int)_ctx.Options.CommandTimeout.TotalSeconds;
             for (int i = 0; i < keys.Count; i++)

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -118,6 +118,7 @@ namespace nORM.Query
                     return cached!;
             }
 
+            await _ctx.EnsureConnectionAsync(ct);
             await using var cmd = _ctx.Connection.CreateCommand();
             cmd.CommandTimeout = (int)_ctx.Options.CommandTimeout.TotalSeconds;
             cmd.CommandText = plan.Sql;
@@ -182,6 +183,7 @@ namespace nORM.Query
                     return cached!;
             }
 
+            await _ctx.EnsureConnectionAsync(ct);
             await using var cmd = _ctx.Connection.CreateCommand();
             cmd.CommandTimeout = (int)_ctx.Options.CommandTimeout.TotalSeconds;
             cmd.CommandText = plan.Sql;
@@ -255,6 +257,7 @@ namespace nORM.Query
             _cudBuilder.ValidateCudPlan(plan.Sql);
             var whereClause = _cudBuilder.ExtractWhereClause(plan.Sql, mapping.EscTable);
 
+            await _ctx.EnsureConnectionAsync(ct);
             await using var cmd = _ctx.Connection.CreateCommand();
             cmd.CommandTimeout = (int)_ctx.Options.CommandTimeout.TotalSeconds;
             var finalSql = $"DELETE FROM {mapping.EscTable}{whereClause}";
@@ -281,6 +284,7 @@ namespace nORM.Query
             var whereClause = _cudBuilder.ExtractWhereClause(plan.Sql, mapping.EscTable);
             var (setClause, setParams) = _cudBuilder.BuildSetClause(mapping, set);
 
+            await _ctx.EnsureConnectionAsync(ct);
             await using var cmd = _ctx.Connection.CreateCommand();
             cmd.CommandTimeout = (int)_ctx.Options.CommandTimeout.TotalSeconds;
             var finalSql = $"UPDATE {mapping.EscTable} SET {setClause}{whereClause}";
@@ -317,6 +321,7 @@ namespace nORM.Query
             }
 
             var sw = Stopwatch.StartNew();
+            await _ctx.EnsureConnectionAsync(ct);
             await using var cmd = _ctx.Connection.CreateCommand();
             cmd.CommandTimeout = (int)_ctx.Options.CommandTimeout.TotalSeconds;
             cmd.CommandText = plan.Sql;

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -27,10 +27,17 @@ public abstract class TestBase
     {
         return kind switch
         {
-            ProviderKind.Sqlite => (new SqliteConnection("Data Source=:memory:"), new SqliteProvider()),
-            ProviderKind.SqlServer => (new SqliteConnection("Data Source=:memory:"), new SqlServerProvider()),
+            ProviderKind.Sqlite => (CreateOpenConnection(), new SqliteProvider()),
+            ProviderKind.SqlServer => (CreateOpenConnection(), new SqlServerProvider()),
             _ => throw new NotSupportedException()
         };
+    }
+
+    private static DbConnection CreateOpenConnection()
+    {
+        var cn = new SqliteConnection("Data Source=:memory:");
+        cn.Open();
+        return cn;
     }
 
     protected (string Sql, Dictionary<string, object> Params, Type ElementType) TranslateQuery<T, TResult>(


### PR DESCRIPTION
## Summary
- remove eager connection open from DbContext
- add EnsureConnectionAsync and use it across operations and query components
- open test connections when creating provider setups

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b1e0f4b4832cb25045a743ab627a