### PR TITLE
Use thread-local QueryTranslator to prevent shared state

### DIFF
--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -596,7 +596,7 @@ namespace nORM.Core
                     paramDict[pName] = parameters[i];
                 }
 
-                var materializer = new Query.QueryTranslator(this).CreateMaterializer(GetMapping(typeof(T)), typeof(T));
+                var materializer = Query.QueryTranslator.Rent(this).CreateMaterializer(GetMapping(typeof(T)), typeof(T));
                 var list = new List<T>();
                 await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(this, CommandBehavior.Default, token);
                 while (await reader.ReadAsync(token)) list.Add((T)await materializer(reader, token));
@@ -626,7 +626,7 @@ namespace nORM.Core
                     }
                 }
 
-                var materializer = new Query.QueryTranslator(this).CreateMaterializer(GetMapping(typeof(T)), typeof(T));
+                var materializer = Query.QueryTranslator.Rent(this).CreateMaterializer(GetMapping(typeof(T)), typeof(T));
                 var list = new List<T>();
                 await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(this, CommandBehavior.Default, token);
                 while (await reader.ReadAsync(token)) list.Add((T)await materializer(reader, token));

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -344,7 +344,7 @@ namespace nORM.Navigation
             cmd.CommandText = $"SELECT * FROM {mapping.EscTable} WHERE {foreignKey.EscCol} = {paramName}";
             cmd.AddParam(paramName, keyValue);
 
-            var materializer = new Query.QueryTranslator(context).CreateMaterializer(mapping, entityType);
+            var materializer = Query.QueryTranslator.Rent(context).CreateMaterializer(mapping, entityType);
             var results = new List<object>();
 
             using var reader = await cmd.ExecuteReaderWithInterceptionAsync(context, CommandBehavior.Default, ct);
@@ -375,7 +375,7 @@ namespace nORM.Navigation
             context.Provider.ApplyPaging(sql, 1, null, null, null);
             cmd.CommandText = sql.ToString();
 
-            var materializer = new Query.QueryTranslator(context).CreateMaterializer(mapping, entityType);
+            var materializer = Query.QueryTranslator.Rent(context).CreateMaterializer(mapping, entityType);
 
             using var reader = await cmd.ExecuteReaderWithInterceptionAsync(context, CommandBehavior.Default, ct);
             if (await reader.ReadAsync(ct))

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -364,7 +364,7 @@ namespace nORM.Query
             var elementType = GetElementType(filtered);
             var key = new QueryPlanCacheKey(filtered, _ctx.Options.TenantProvider?.GetCurrentTenantId(), elementType);
             var local = filtered;
-            return _planCache.GetOrAdd(key, _ => new QueryTranslator(_ctx).Translate(local));
+            return _planCache.GetOrAdd(key, _ => QueryTranslator.Rent(_ctx).Translate(local));
         }
 
         private string BuildCacheKey<TResult>(Expression expression, IReadOnlyDictionary<string, object> parameters)


### PR DESCRIPTION
## Summary
- make QueryTranslator instances thread-local via ThreadLocal and resettable state
- update query and materializer pipelines to rent translators per thread

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b8b41f3404832cb798c37be6d62398