### PR TITLE
Fix memory leak in navigation property tracking

### DIFF
--- a/src/nORM/Core/ChangeTracker.cs
+++ b/src/nORM/Core/ChangeTracker.cs
@@ -24,7 +24,14 @@ namespace nORM.Core
             return entry;
         }
 
-        internal void Remove(object entity) => _entries.Remove(entity);
+        internal void Remove(object entity)
+        {
+            if (_entries.TryGetValue(entity, out var entry))
+            {
+                entry.DetachEntity();
+                _entries.Remove(entity);
+            }
+        }
 
         public IEnumerable<EntityEntry> Entries => _entries.Values;
 

--- a/src/nORM/Core/EntityEntry.cs
+++ b/src/nORM/Core/EntityEntry.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using nORM.Mapping;
+using nORM.Navigation;
 
 #nullable enable
 
@@ -69,6 +70,12 @@ namespace nORM.Core
             CaptureOriginalValues();
             State = EntityState.Unchanged;
             _hasNotifiedChange = false;
+        }
+
+        internal void DetachEntity()
+        {
+            State = EntityState.Detached;
+            NavigationPropertyExtensions.CleanupNavigationContext(Entity);
         }
     }
 }

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -42,6 +42,17 @@ namespace nORM.Navigation
         }
 
         /// <summary>
+        /// Removes navigation context tracking for an entity and cleans up lazy proxies.
+        /// </summary>
+        public static void CleanupNavigationContext<T>(T entity) where T : class
+        {
+            if (entity != null && _navigationContexts.TryGetValue(entity, out _))
+            {
+                _navigationContexts.Remove(entity);
+            }
+        }
+
+        /// <summary>
         /// Loads a navigation property explicitly
         /// </summary>
         public static async Task LoadAsync<T, TProperty>(this T entity, 


### PR DESCRIPTION
## Summary
- add cleanup helper to remove navigation contexts when entities detach
- ensure ChangeTracker removes navigation proxies during entity detachment

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68b8b60c6f68832ca7cd484ccc451113