### PR TITLE
Pool ExpressionToSqlVisitor to reduce allocations

### DIFF
--- a/src/nORM.csproj
+++ b/src/nORM.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/nORM/Query/ExpressionVisitorPool.cs
+++ b/src/nORM/Query/ExpressionVisitorPool.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.Extensions.ObjectPool;
+using nORM.Core;
+using nORM.Mapping;
+using nORM.Providers;
+
+namespace nORM.Query;
+
+internal static class ExpressionVisitorPool
+{
+    private static readonly ObjectPool<ExpressionToSqlVisitor> _pool =
+        new DefaultObjectPool<ExpressionToSqlVisitor>(new VisitorPooledObjectPolicy());
+
+    public static ExpressionToSqlVisitor Get(
+        DbContext ctx,
+        TableMapping mapping,
+        DatabaseProvider provider,
+        ParameterExpression parameter,
+        string tableAlias,
+        Dictionary<ParameterExpression, (TableMapping Mapping, string Alias)>? correlated = null,
+        List<string>? compiledParams = null,
+        Dictionary<ParameterExpression, string>? paramMap = null)
+    {
+        var visitor = _pool.Get();
+        visitor.Initialize(ctx, mapping, provider, parameter, tableAlias, correlated, compiledParams, paramMap);
+        return visitor;
+    }
+
+    public static void Return(ExpressionToSqlVisitor visitor) => _pool.Return(visitor);
+}
+
+internal sealed class VisitorPooledObjectPolicy : PooledObjectPolicy<ExpressionToSqlVisitor>
+{
+    public override ExpressionToSqlVisitor Create() => new ExpressionToSqlVisitor();
+
+    public override bool Return(ExpressionToSqlVisitor obj)
+    {
+        obj.Reset();
+        return true;
+    }
+}

--- a/src/nORM/Query/QueryTranslator.MethodTranslators.cs
+++ b/src/nORM/Query/QueryTranslator.MethodTranslators.cs
@@ -70,7 +70,7 @@ namespace nORM.Query
                     var alias = "T" + t._joinCounter;
                     if (!t._correlatedParams.ContainsKey(param))
                         t._correlatedParams[param] = (t._mapping, alias);
-                    var visitor = new ExpressionToSqlVisitor(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var visitor = ExpressionVisitorPool.Get(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
                     var sql = visitor.Translate(body);
                     var isGrouping = node.Arguments[0] is MethodCallExpression mc && mc.Method.Name == "GroupBy";
                     var target = isGrouping ? t._having : t._where;
@@ -78,6 +78,7 @@ namespace nORM.Query
                     target.Append($"({sql})");
                     foreach (var kvp in visitor.GetParameters())
                         t._params[kvp.Key] = kvp.Value;
+                    ExpressionVisitorPool.Return(visitor);
                 }
                 return t.Visit(node.Arguments[0]);
             }
@@ -103,9 +104,10 @@ namespace nORM.Query
                     var alias = "T" + t._joinCounter;
                     if (!t._correlatedParams.ContainsKey(param))
                         t._correlatedParams[param] = (t._mapping, alias);
-                    var visitor = new ExpressionToSqlVisitor(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var visitor = ExpressionVisitorPool.Get(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
                     var sql = visitor.Translate(keySelector.Body);
                     t._orderBy.Add((sql, !t._methodName.Contains("Descending")));
+                    ExpressionVisitorPool.Return(visitor);
                 }
                 return source;
             }
@@ -288,12 +290,13 @@ namespace nORM.Query
                     var alias = "T" + t._joinCounter;
                     if (!t._correlatedParams.ContainsKey(param))
                         t._correlatedParams[param] = (t._mapping, alias);
-                    var visitor = new ExpressionToSqlVisitor(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var visitor = ExpressionVisitorPool.Get(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
                     var sql = visitor.Translate(predicate.Body);
                     if (t._where.Length > 0) t._where.Append(" AND ");
                     t._where.Append($"({sql})");
                     foreach (var kvp in visitor.GetParameters())
                         t._params[kvp.Key] = kvp.Value;
+                    ExpressionVisitorPool.Return(visitor);
                 }
                 t._take = 1;
                 t._singleResult = t._methodName == "First" || t._methodName == "Single";
@@ -311,12 +314,13 @@ namespace nORM.Query
                     var alias = "T" + t._joinCounter;
                     if (!t._correlatedParams.ContainsKey(param))
                         t._correlatedParams[param] = (t._mapping, alias);
-                    var visitor = new ExpressionToSqlVisitor(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var visitor = ExpressionVisitorPool.Get(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
                     var sql = visitor.Translate(lastPredicate.Body);
                     if (t._where.Length > 0) t._where.Append(" AND ");
                     t._where.Append($"({sql})");
                     foreach (var kvp in visitor.GetParameters())
                         t._params[kvp.Key] = kvp.Value;
+                    ExpressionVisitorPool.Return(visitor);
                 }
                 var lastSrc = t.Visit(node.Arguments[0]);
                 if (t._orderBy.Count > 0)
@@ -351,12 +355,13 @@ namespace nORM.Query
                     var alias = "T" + t._joinCounter;
                     if (!t._correlatedParams.ContainsKey(param))
                         t._correlatedParams[param] = (t._mapping, alias);
-                    var visitor = new ExpressionToSqlVisitor(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var visitor = ExpressionVisitorPool.Get(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
                     var sql = visitor.Translate(countPredicate.Body);
                     if (t._where.Length > 0) t._where.Append(" AND ");
                     t._where.Append($"({sql})");
                     foreach (var kvp in visitor.GetParameters())
                         t._params[kvp.Key] = kvp.Value;
+                    ExpressionVisitorPool.Return(visitor);
                 }
                 return t.Visit(node.Arguments[0]);
             }


### PR DESCRIPTION
## Summary
- add Microsoft.Extensions.ObjectPool and implement ExpressionVisitorPool
- reuse ExpressionToSqlVisitor instances via pooling
- update query translators to borrow and return visitors

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c00cbe88832c9275d136093114fb