### PR TITLE
Validate and sanitize connection strings

### DIFF
--- a/src/dotnet-norm/ConnectionStringValidator.cs
+++ b/src/dotnet-norm/ConnectionStringValidator.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Data.Common;
+
+namespace nORM.Security
+{
+    public static class ConnectionStringValidator
+    {
+        private static readonly string[] ForbiddenKeywords =
+        {
+            "xp_cmdshell", "sp_configure", "openrowset", "opendatasource"
+        };
+
+        private static readonly string[] RequiredSqlServerSettings =
+        {
+            "Encrypt=True", "TrustServerCertificate=False"
+        };
+
+        public static string ValidateAndSanitize(string connectionString, string provider)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+                throw new ArgumentException("Connection string cannot be null or empty");
+
+            // Check for injection patterns
+            var upperConnectionString = connectionString.ToUpperInvariant();
+            foreach (var forbidden in ForbiddenKeywords)
+            {
+                if (upperConnectionString.Contains(forbidden.ToUpperInvariant()))
+                    throw new ArgumentException($"Connection string contains forbidden keyword: {forbidden}");
+            }
+
+            // Validate connection string format
+            try
+            {
+                var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
+
+                // Remove sensitive information from potential logs
+                var sanitized = new DbConnectionStringBuilder();
+                foreach (string key in builder.Keys)
+                {
+                    if (!IsSensitiveKey(key))
+                        sanitized[key] = builder[key];
+                    else
+                        sanitized[key] = "***";
+                }
+
+                // Enforce security requirements for SQL Server
+                if (provider.Equals("sqlserver", StringComparison.OrdinalIgnoreCase))
+                {
+                    EnforceSqlServerSecurity(builder);
+                }
+
+                return builder.ConnectionString;
+            }
+            catch (Exception ex)
+            {
+                throw new ArgumentException("Invalid connection string format", ex);
+            }
+        }
+
+        private static bool IsSensitiveKey(string key)
+        {
+            return key.ToLowerInvariant() switch
+            {
+                "password" or "pwd" or "user id" or "uid" => true,
+                _ => false
+            };
+        }
+
+        private static void EnforceSqlServerSecurity(DbConnectionStringBuilder builder)
+        {
+            // Enforce encryption
+            if (!builder.ContainsKey("Encrypt") || !bool.Parse(builder["Encrypt"].ToString()!))
+            {
+                builder["Encrypt"] = "True";
+            }
+
+            // Enforce certificate validation in production
+            if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") != "Development")
+            {
+                builder["TrustServerCertificate"] = "False";
+            }
+        }
+    }
+}
+

--- a/src/dotnet-norm/Program.cs
+++ b/src/dotnet-norm/Program.cs
@@ -16,6 +16,7 @@ using nORM.Configuration;
 using nORM.Migration;
 using nORM.Providers;
 using nORM.Scaffolding;
+using nORM.Security;
 
 var root = new RootCommand("Command line tools for the nORM ORM framework");
 
@@ -33,8 +34,8 @@ scaffold.Add(nsOpt);
 scaffold.Add(ctxOpt);
 scaffold.SetAction(async (ParseResult result, CancellationToken _) =>
 {
-    var conn = result.GetValue(connOpt)!;
     var prov = result.GetValue(providerOpt)!;
+    var conn = ConnectionStringValidator.ValidateAndSanitize(result.GetValue(connOpt)!, prov);
     var output = result.GetValue(outputOpt)!;
     var ns = result.GetValue(nsOpt)!;
     var ctx = result.GetValue(ctxOpt)!;
@@ -65,8 +66,8 @@ update.Add(migProvOpt);
 update.Add(assemblyOpt);
 update.SetAction(async (ParseResult result, CancellationToken _) =>
 {
-    var conn = result.GetValue(migConnOpt)!;
     var prov = result.GetValue(migProvOpt)!;
+    var conn = ConnectionStringValidator.ValidateAndSanitize(result.GetValue(migConnOpt)!, prov);
     var asmPath = result.GetValue(assemblyOpt)!;
     try
     {
@@ -104,8 +105,8 @@ drop.Add(dropConnOpt);
 drop.Add(dropProvOpt);
 drop.SetAction(async (ParseResult result, CancellationToken _) =>
 {
-    var conn = result.GetValue(dropConnOpt)!;
     var prov = result.GetValue(dropProvOpt)!;
+    var conn = ConnectionStringValidator.ValidateAndSanitize(result.GetValue(dropConnOpt)!, prov);
     try
     {
         if (prov.Equals("sqlite", StringComparison.OrdinalIgnoreCase))

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -250,7 +250,7 @@ namespace nORM.Navigation
             {
                 // Collection navigation property
                 var loader = _navigationLoaders.GetValue(context.DbContext, ctx => new BatchedNavigationLoader(ctx));
-                var results = await loader.LoadNavigationAsync<List<object>>(entity, property.Name, ct);
+                var results = await loader.LoadNavigationAsync(entity, property.Name, ct);
 
                 var collectionType = typeof(List<>).MakeGenericType(relation.DependentType);
                 var collection = (IList)Activator.CreateInstance(collectionType)!;
@@ -319,7 +319,7 @@ namespace nORM.Navigation
                 if (property.PropertyType.IsGenericType && typeof(IEnumerable).IsAssignableFrom(property.PropertyType))
                 {
                     // Collection
-                    var results = await loader.LoadNavigationAsync<List<object>>(entity, property.Name, ct);
+                    var results = await loader.LoadNavigationAsync(entity, property.Name, ct);
 
                     var collectionType = typeof(List<>).MakeGenericType(targetType);
                     var collection = (IList)Activator.CreateInstance(collectionType)!;
@@ -333,7 +333,7 @@ namespace nORM.Navigation
                 else
                 {
                     // Reference
-                    var list = await loader.LoadNavigationAsync<List<object>>(entity, property.Name, ct);
+                    var list = await loader.LoadNavigationAsync(entity, property.Name, ct);
                     var result = list.FirstOrDefault();
 
                     if (property.PropertyType.IsGenericType &&


### PR DESCRIPTION
## Summary
- ensure CLI connection strings are validated and sanitized before use
- add reusable ConnectionStringValidator that enforces SQL Server security defaults
- fix generic navigation loader usage to resolve CS0308 compile error

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b91ae88024832c831967db37d7be9b