### PR TITLE
Optimize SQL generation with pooled builder

### DIFF
--- a/src/nORM/Query/OptimizedSqlBuilder.cs
+++ b/src/nORM/Query/OptimizedSqlBuilder.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.ObjectPool;
+using nORM.Mapping;
+
+namespace nORM.Query
+{
+    /// <summary>
+    /// A pooled SQL builder that reduces allocations during query generation.
+    /// Wraps a <see cref="StringBuilder"/> obtained from an object pool and caches
+    /// common SQL fragments and parameter values.
+    /// </summary>
+    internal sealed class OptimizedSqlBuilder : IDisposable
+    {
+        private static readonly ObjectPool<StringBuilder> _stringBuilderPool =
+            new DefaultObjectPool<StringBuilder>(new StringBuilderPooledObjectPolicy());
+
+        private static readonly ConcurrentDictionary<string, string> _fragmentCache = new();
+
+        // Common fragments that are frequently used in SQL generation.
+        private static readonly string[] CommonFragments =
+        {
+            " WHERE ", " ORDER BY ", " GROUP BY ", " HAVING ", " JOIN ", " LEFT JOIN ",
+            " INNER JOIN ", " ON ", " AND ", " OR ", " IN ", " LIKE ", " IS NULL ",
+            " IS NOT NULL ", " COUNT(*)", " SUM(", " AVG(", " MIN(", " MAX("
+        };
+
+        static OptimizedSqlBuilder()
+        {
+            foreach (var frag in CommonFragments)
+                _fragmentCache.TryAdd(frag, frag);
+        }
+
+        private readonly StringBuilder _buffer;
+        private readonly Dictionary<string, string> _parameterCache = new();
+        private bool _hasWhere;
+
+        public OptimizedSqlBuilder(int estimatedLength = 512)
+        {
+            _buffer = _stringBuilderPool.Get();
+            _buffer.Clear();
+            if (_buffer.Capacity < estimatedLength)
+                _buffer.Capacity = estimatedLength;
+        }
+
+        /// <summary>Length of the underlying buffer.</summary>
+        public int Length => _buffer.Length;
+
+        /// <summary>Exposes the underlying <see cref="StringBuilder"/> for interop.</summary>
+        public StringBuilder InnerBuilder => _buffer;
+
+        public OptimizedSqlBuilder Append(string? value)
+        {
+            _buffer.Append(value);
+            return this;
+        }
+
+        public OptimizedSqlBuilder Append(char value)
+        {
+            _buffer.Append(value);
+            return this;
+        }
+
+        public OptimizedSqlBuilder Append(ReadOnlySpan<char> value)
+        {
+            _buffer.Append(value);
+            return this;
+        }
+
+        public OptimizedSqlBuilder AppendFragment(string fragment)
+        {
+            _buffer.Append(_fragmentCache.GetOrAdd(fragment, static f => f));
+            return this;
+        }
+
+        public OptimizedSqlBuilder Insert(int index, string value)
+        {
+            _buffer.Insert(index, value);
+            return this;
+        }
+
+        public OptimizedSqlBuilder Remove(int start, int length)
+        {
+            _buffer.Remove(start, length);
+            return this;
+        }
+
+        public string ToString(int start, int length) => _buffer.ToString(start, length);
+
+        public void Clear()
+        {
+            _buffer.Clear();
+            _parameterCache.Clear();
+            _hasWhere = false;
+        }
+
+        public void AppendSelect(string columns, string table, string? alias = null)
+        {
+            _buffer.Append("SELECT ").Append(columns).Append(" FROM ").Append(table);
+            if (alias != null)
+                _buffer.Append(' ').Append(alias);
+        }
+
+        public void AppendWhere(ReadOnlySpan<char> condition)
+        {
+            if (condition.IsEmpty) return;
+            if (!_hasWhere)
+            {
+                _buffer.Append(" WHERE ");
+                _hasWhere = true;
+            }
+            else
+            {
+                _buffer.Append(" AND ");
+            }
+            _buffer.Append(condition);
+        }
+
+        public OptimizedSqlBuilder AppendParameterizedValue(string parameterName, object? value, Dictionary<string, object> parameters)
+        {
+            var valueHash = value?.GetHashCode() ?? 0;
+            var cacheKey = $"{value?.GetType().Name}_{valueHash}";
+            if (_parameterCache.TryGetValue(cacheKey, out var existing))
+            {
+                _buffer.Append(existing);
+                return this;
+            }
+
+            parameters[parameterName] = value ?? DBNull.Value;
+            _parameterCache[cacheKey] = parameterName;
+            _buffer.Append(parameterName);
+            return this;
+        }
+
+        public void AppendStandardSelect(TableMapping mapping, bool distinct = false)
+        {
+            var fragmentKey = $"SELECT_{mapping.Type.Name}_{distinct}";
+            if (_fragmentCache.TryGetValue(fragmentKey, out var cached))
+            {
+                _buffer.Append(cached);
+                return;
+            }
+
+            var sb = new StringBuilder(256);
+            sb.Append(distinct ? "SELECT DISTINCT " : "SELECT ");
+            var first = true;
+            foreach (var col in mapping.Columns)
+            {
+                if (!first) sb.Append(", ");
+                sb.Append(col.EscCol);
+                first = false;
+            }
+            sb.Append(" FROM ").Append(mapping.EscTable);
+            var result = sb.ToString();
+            _fragmentCache.TryAdd(fragmentKey, result);
+            _buffer.Append(result);
+        }
+
+        public string ToSqlString() => _buffer.ToString();
+
+        public override string ToString() => _buffer.ToString();
+
+        public void Dispose()
+        {
+            Clear();
+            _stringBuilderPool.Return(_buffer);
+        }
+    }
+}
+

--- a/src/nORM/Query/SqlClauseBuilder.cs
+++ b/src/nORM/Query/SqlClauseBuilder.cs
@@ -1,16 +1,16 @@
+using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace nORM.Query
 {
     /// <summary>
-    /// Simple container for the various SQL clause builders used by <see cref="QueryTranslator"/>.
+    /// Container for the various SQL clause builders used by <see cref="QueryTranslator"/>.
     /// </summary>
-    internal sealed class SqlClauseBuilder
+    internal sealed class SqlClauseBuilder : IDisposable
     {
-        public StringBuilder Sql { get; } = new();
-        public StringBuilder Where { get; } = new();
-        public StringBuilder Having { get; } = new();
+        public OptimizedSqlBuilder Sql { get; } = new();
+        public OptimizedSqlBuilder Where { get; } = new();
+        public OptimizedSqlBuilder Having { get; } = new();
         public List<(string col, bool asc)> OrderBy { get; } = new();
         public List<string> GroupBy { get; } = new();
         public int? Take { get; set; }
@@ -18,5 +18,12 @@ namespace nORM.Query
         public string? TakeParam { get; set; }
         public string? SkipParam { get; set; }
         public bool IsDistinct { get; set; }
+
+        public void Dispose()
+        {
+            Sql.Dispose();
+            Where.Dispose();
+            Having.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- introduce `OptimizedSqlBuilder` using pooled `StringBuilder` and fragment caching
- refactor query translation to use pooled builder and avoid extra string allocations
- streamline parameter handling in `ExpressionToSqlVisitor`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9218db448832ca691a8670f91e5b8