### PR TITLE
Fix query plan generation hang

### DIFF
--- a/src/nORM/Query/QueryComplexityAnalyzer.cs
+++ b/src/nORM/Query/QueryComplexityAnalyzer.cs
@@ -72,7 +72,9 @@ namespace nORM.Query
 
             protected override Expression VisitConstant(ConstantExpression node)
             {
-                if (node.Value is System.Collections.IEnumerable enumerable && node.Value is not string)
+                if (node.Value is System.Collections.IEnumerable enumerable &&
+                    node.Value is not string &&
+                    node.Value is not IQueryable)
                 {
                     var count = 0;
                     foreach (var _ in enumerable)

--- a/src/nORM/Query/QueryTranslator.MethodTranslators.cs
+++ b/src/nORM/Query/QueryTranslator.MethodTranslators.cs
@@ -117,6 +117,7 @@ namespace nORM.Query
         {
             public Expression Translate(QueryTranslator t, MethodCallExpression node)
             {
+                var source = t.Visit(node.Arguments[0]);
                 if (node.Arguments[1] is ParameterExpression tp)
                 {
                     if (!t._paramMap.TryGetValue(tp, out var tName))
@@ -135,7 +136,7 @@ namespace nORM.Query
                     t._take = take;
                     t._takeParam = pName;
                 }
-                return t.Visit(node.Arguments[0]);
+                return source;
             }
         }
 
@@ -143,6 +144,7 @@ namespace nORM.Query
         {
             public Expression Translate(QueryTranslator t, MethodCallExpression node)
             {
+                var source = t.Visit(node.Arguments[0]);
                 if (node.Arguments[1] is ParameterExpression sp)
                 {
                     if (!t._paramMap.TryGetValue(sp, out var sName))
@@ -161,7 +163,7 @@ namespace nORM.Query
                     t._skip = skip;
                     t._skipParam = pName;
                 }
-                return t.Visit(node.Arguments[0]);
+                return source;
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid enumerating IQueryable constants in QueryComplexityAnalyzer
- ensure Skip/Take translators visit source before assigning parameters

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b93d9747d4832c9a150fd34b8c5855