### PR TITLE
Fix EF Core data seeding in OrmBenchmarks

### DIFF
--- a/benchmarks/OrmBenchmarks.cs
+++ b/benchmarks/OrmBenchmarks.cs
@@ -126,10 +126,15 @@ namespace nORM.Benchmarks
             _efContext = new EfCoreContext(_efConnectionString);
             await _efContext.Database.OpenConnectionAsync();
             await _efContext.Database.EnsureCreatedAsync();
-
+            
+            // 1. Add and save the users FIRST. This generates their IDs.
             _efContext.Users.AddRange(_testUsers);
+            await _efContext.SaveChangesAsync();
+
+            // 2. Now that users exist, add and save the orders.
             _efContext.Orders.AddRange(_testOrders);
             await _efContext.SaveChangesAsync();
+
             _efContext.ChangeTracker.Clear();
         }
 


### PR DESCRIPTION
## Summary
- Ensure EF Core benchmark saves users before orders so order foreign keys reference generated IDs

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9413fc888832c8ec6b0f8022a16b4