### PR TITLE
Fix offset-only paging in MySqlProvider

### DIFF
--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -27,14 +27,21 @@ namespace nORM.Providers
             EnsureValidParameterName(limitParameterName, nameof(limitParameterName));
             EnsureValidParameterName(offsetParameterName, nameof(offsetParameterName));
 
-            if (limitParameterName != null)
+            // MySQL uses a single LIMIT clause for both limit and offset in the form
+            // "LIMIT offset, limit". The previous implementation only emitted the clause
+            // when a limit was present which meant that queries using only Skip() would
+            // ignore the offset. MySQL requires a limit value when an offset is specified,
+            // so when only an offset is provided we use the maximum unsigned BIGINT value
+            // to effectively indicate "no limit".
+            if (limitParameterName != null || offsetParameterName != null)
             {
                 sb.Append(" LIMIT ");
                 if (offsetParameterName != null)
                 {
                     sb.Append(offsetParameterName).Append(", ");
                 }
-                sb.Append(limitParameterName);
+
+                sb.Append(limitParameterName ?? "18446744073709551615");
             }
         }
         

--- a/tests/MySqlProviderTests.cs
+++ b/tests/MySqlProviderTests.cs
@@ -1,0 +1,18 @@
+using System.Text;
+using nORM.Providers;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class MySqlProviderTests
+{
+    [Fact]
+    public void ApplyPaging_with_only_offset_adds_max_limit()
+    {
+        var provider = new MySqlProvider();
+        var sb = new StringBuilder("SELECT * FROM `Product`");
+        var offsetParam = provider.ParamPrefix + "p0";
+        provider.ApplyPaging(sb, null, 20, null, offsetParam);
+        Assert.Equal($"SELECT * FROM `Product` LIMIT {offsetParam}, 18446744073709551615", sb.ToString());
+    }
+}

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -29,6 +29,7 @@ public abstract class TestBase
         {
             ProviderKind.Sqlite => (CreateOpenConnection(), new SqliteProvider()),
             ProviderKind.SqlServer => (CreateOpenConnection(), new SqlServerProvider()),
+            ProviderKind.MySql => (CreateOpenConnection(), new MySqlProvider()),
             _ => throw new NotSupportedException()
         };
     }
@@ -61,5 +62,6 @@ public abstract class TestBase
 public enum ProviderKind
 {
     Sqlite,
-    SqlServer
+    SqlServer,
+    MySql
 }


### PR DESCRIPTION
## Summary
- handle Skip() without Take() in MySqlProvider by always emitting LIMIT clause and using max limit when only offset is supplied
- expose MySql provider in test infrastructure
- add unit test for MySql offset-only paging

## Testing
- `dotnet test --filter MySqlProviderTests`

------
https://chatgpt.com/codex/tasks/task_e_68b93fdbb438832c9466b841884a5155