### PR TITLE
Adopt TimeoutConfiguration in benchmarks and nORM core

### DIFF
--- a/benchmarks/FastNormBenchmarks.cs
+++ b/benchmarks/FastNormBenchmarks.cs
@@ -73,7 +73,7 @@ namespace nORM.Benchmarks
             var options = new nORM.Configuration.DbContextOptions
             {
                 BulkBatchSize = 50, // Optimized for SQLite parameter limits
-                CommandTimeout = TimeSpan.FromSeconds(30)
+                TimeoutConfiguration = { BaseTimeout = TimeSpan.FromSeconds(30) }
             };
             
             _context = new nORM.Core.DbContext(_connection, new SqliteProvider(), options);

--- a/benchmarks/JoinVerificationTest.cs
+++ b/benchmarks/JoinVerificationTest.cs
@@ -26,7 +26,7 @@ namespace nORM.Benchmarks
             var options = new nORM.Configuration.DbContextOptions
             {
                 BulkBatchSize = 50,
-                CommandTimeout = TimeSpan.FromSeconds(30)
+                TimeoutConfiguration = { BaseTimeout = TimeSpan.FromSeconds(30) }
             };
             
             using var context = new nORM.Core.DbContext(connection, new SqliteProvider(), options);

--- a/benchmarks/OrmBenchmarks.cs
+++ b/benchmarks/OrmBenchmarks.cs
@@ -150,7 +150,7 @@ namespace nORM.Benchmarks
             var options = new nORM.Configuration.DbContextOptions
             {
                 BulkBatchSize = 50, // Optimized for SQLite parameter limits
-                CommandTimeout = TimeSpan.FromSeconds(30)
+                TimeoutConfiguration = { BaseTimeout = TimeSpan.FromSeconds(30) }
             };
 
             using var context = new nORM.Core.DbContext(connection, new SqliteProvider(), options);

--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -254,7 +254,7 @@ namespace nORM.Core
                 var isolationLevel = DetermineIsolationLevel(changedEntries);
                 transaction = await Connection.BeginTransactionAsync(isolationLevel, ct);
 
-                timeoutCts = new CancellationTokenSource(Options.CommandTimeout);
+                timeoutCts = new CancellationTokenSource(Options.TimeoutConfiguration.BaseTimeout);
                 linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
                 ct = linkedCts.Token;
             }
@@ -416,7 +416,7 @@ namespace nORM.Core
             {
                 await using var cmd = Connection.CreateCommand();
                 cmd.Transaction = currentTransaction;
-                cmd.CommandTimeout = (int)Options.CommandTimeout.TotalSeconds;
+                cmd.CommandTimeout = (int)Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
 
                 cmd.CommandText = operation switch
                 {
@@ -635,7 +635,7 @@ namespace nORM.Core
                 await ctx.EnsureConnectionAsync(token);
                 var sw = Stopwatch.StartNew();
                 await using var cmd = ctx.Connection.CreateCommand();
-                cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
+                cmd.CommandTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
                 cmd.CommandText = sql;
                 var paramDict = new Dictionary<string, object>();
                 for (int i = 0; i < parameters.Length; i++)
@@ -689,7 +689,7 @@ namespace nORM.Core
                 await ctx.EnsureConnectionAsync(token);
                 var sw = Stopwatch.StartNew();
                 await using var cmd = ctx.Connection.CreateCommand();
-                cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
+                cmd.CommandTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
                 cmd.CommandText = sql;
                 var paramDict = new Dictionary<string, object>();
                 for (int i = 0; i < parameters.Length; i++)
@@ -716,7 +716,7 @@ namespace nORM.Core
                 await ctx.EnsureConnectionAsync(token);
                 var sw = Stopwatch.StartNew();
                 await using var cmd = ctx.Connection.CreateCommand();
-                cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
+                cmd.CommandTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
                 cmd.CommandText = procedureName;
                 cmd.CommandType = CommandType.StoredProcedure;
                 var paramDict = new Dictionary<string, object>();

--- a/src/nORM/Navigation/BatchedNavigationLoader.cs
+++ b/src/nORM/Navigation/BatchedNavigationLoader.cs
@@ -111,7 +111,7 @@ namespace nORM.Navigation
             var mapping = _context.GetMapping(relation.DependentType);
             await _context.EnsureConnectionAsync(default).ConfigureAwait(false);
             using var cmd = _context.Connection.CreateCommand();
-            cmd.CommandTimeout = (int)_context.Options.CommandTimeout.TotalSeconds;
+            cmd.CommandTimeout = (int)_context.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
 
             var paramNames = new List<string>();
             for (int i = 0; i < keys.Count; i++)

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -354,7 +354,7 @@ namespace nORM.Navigation
         {
             await context.EnsureConnectionAsync(ct);
             using var cmd = context.Connection.CreateCommand();
-            cmd.CommandTimeout = (int)context.Options.CommandTimeout.TotalSeconds;
+            cmd.CommandTimeout = (int)context.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
             
             var paramName = context.Provider.ParamPrefix + "fk";
             cmd.CommandText = $"SELECT * FROM {mapping.EscTable} WHERE {foreignKey.EscCol} = {paramName}";

--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -187,7 +187,7 @@ namespace nORM.Providers
                     var batch = entityList.Skip(i).Take(batchSize).ToList();
                     await using var cmd = ctx.Connection.CreateCommand();
                     cmd.Transaction = transaction;
-                    cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
+                    cmd.CommandTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
 
                     var paramNames = new List<string>();
                     var paramIndex = 0;

--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -132,7 +132,7 @@ namespace nORM.Providers
             {
                 dynamic bulkCopy = Activator.CreateInstance(bulkCopyType, ctx.Connection)!;
                 bulkCopy.DestinationTableName = m.EscTable.Trim('`');
-                bulkCopy.BulkCopyTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
+                bulkCopy.BulkCopyTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
 
                 var totalInserted = 0;
                 for (int i = 0; i < entityList.Count; i += sizing.OptimalBatchSize)
@@ -170,7 +170,7 @@ namespace nORM.Providers
             var colDefs = string.Join(", ", m.Columns.Select(c => $"{c.EscCol} {GetSqlType(c.Prop.PropertyType)}"));
             await using (var cmd = ctx.Connection.CreateCommand())
             {
-                cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
+                cmd.CommandTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
                 cmd.CommandText = $"CREATE TEMPORARY TABLE {tempTableName} ({colDefs})";
                 await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
             }
@@ -182,7 +182,7 @@ namespace nORM.Providers
             var joinClause = string.Join(" AND ", m.KeyColumns.Select(c => $"T1.{c.EscCol} = T2.{c.EscCol}"));
             await using (var cmd = ctx.Connection.CreateCommand())
             {
-                cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
+                cmd.CommandTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
                 cmd.CommandText = $"UPDATE {m.EscTable} T1 JOIN {tempTableName} T2 ON {joinClause} SET {setClause}";
                 var updatedCount = await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
                 ctx.Options.Logger?.LogBulkOperation(nameof(BulkUpdateAsync), m.EscTable, updatedCount, sw.Elapsed);

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -141,7 +141,7 @@ namespace nORM.Providers
                         DestinationTableName = m.EscTable,
                         BatchSize = batch.Count,
                         EnableStreaming = true,
-                        BulkCopyTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds
+                        BulkCopyTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds
                     };
 
                     foreach (var col in insertableCols)
@@ -179,7 +179,7 @@ namespace nORM.Providers
             var colDefs = string.Join(", ", m.Columns.Select(c => $"{c.EscCol} {GetSqlType(c.Prop.PropertyType)}"));
             await using (var cmd = ctx.Connection.CreateCommand())
             {
-                cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
+                cmd.CommandTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
                 cmd.CommandText = $"CREATE TABLE {tempTableName} ({colDefs})";
                 await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
             }
@@ -190,7 +190,7 @@ namespace nORM.Providers
             var joinClause = string.Join(" AND ", m.KeyColumns.Select(c => $"T1.{c.EscCol} = T2.{c.EscCol}"));
             await using (var cmd = ctx.Connection.CreateCommand())
             {
-                cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
+                cmd.CommandTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
                 cmd.CommandText = $"UPDATE T1 SET {setClause} FROM {m.EscTable} T1 JOIN {tempTableName} T2 ON {joinClause}";
                 var updatedCount = await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
                 ctx.Options.Logger?.LogBulkOperation(nameof(BulkUpdateAsync), m.EscTable, updatedCount, sw.Elapsed);
@@ -216,7 +216,7 @@ namespace nORM.Providers
                     DestinationTableName = destinationTableName,
                     BatchSize = batch.Count,
                     EnableStreaming = true,
-                    BulkCopyTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds
+                    BulkCopyTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds
                 };
 
                 foreach (var col in insertableCols)
@@ -244,7 +244,7 @@ namespace nORM.Providers
 
             await using (var cmd = ctx.Connection.CreateCommand())
             {
-                cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
+                cmd.CommandTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
                 cmd.CommandText = $"CREATE TABLE {tempTableName} ({keyColDefs})";
                 await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
             }
@@ -276,7 +276,7 @@ namespace nORM.Providers
             var joinClause = string.Join(" AND ", m.KeyColumns.Select(c => $"T1.{c.EscCol} = T2.{c.EscCol}"));
             await using (var cmd = ctx.Connection.CreateCommand())
             {
-                cmd.CommandTimeout = (int)ctx.Options.CommandTimeout.TotalSeconds;
+                cmd.CommandTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
                 cmd.CommandText = $"DELETE T1 FROM {m.EscTable} T1 JOIN {tempTableName} T2 ON {joinClause}";
                 var deletedCount = await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
                 ctx.Options.Logger?.LogBulkOperation(nameof(BulkDeleteAsync), m.EscTable, deletedCount, sw.Elapsed);

--- a/src/nORM/Query/IncludeProcessor.cs
+++ b/src/nORM/Query/IncludeProcessor.cs
@@ -44,7 +44,7 @@ namespace nORM.Query
             var paramNames = new List<string>();
             await _ctx.EnsureConnectionAsync(ct);
             await using var cmd = _ctx.Connection.CreateCommand();
-            cmd.CommandTimeout = (int)_ctx.Options.CommandTimeout.TotalSeconds;
+            cmd.CommandTimeout = (int)_ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
             for (int i = 0; i < keys.Count; i++)
             {
                 var paramName = $"{_ctx.Provider.ParamPrefix}fk{i}";

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -126,7 +126,7 @@ namespace nORM.Query
             _params = new Dictionary<string, object>();
             _clauses.Dispose();
             _clauses = new SqlClauseBuilder();
-            _estimatedTimeout = ctx.Options.CommandTimeout;
+            _estimatedTimeout = ctx.Options.TimeoutConfiguration.BaseTimeout;
         }
 
         public Func<DbDataReader, CancellationToken, Task<object>> CreateMaterializer(TableMapping mapping, Type targetType, LambdaExpression? projection = null)
@@ -160,7 +160,7 @@ namespace nORM.Query
             }
 
             var timeoutMultiplier = Math.Max(1.0, complexityInfo.EstimatedCost / 1000.0);
-            var adjustedTimeout = TimeSpan.FromMilliseconds(_ctx.Options.CommandTimeout.TotalMilliseconds * timeoutMultiplier);
+            var adjustedTimeout = TimeSpan.FromMilliseconds(_ctx.Options.TimeoutConfiguration.BaseTimeout.TotalMilliseconds * timeoutMultiplier);
             _estimatedTimeout = adjustedTimeout;
 
             // Determine root query type and handle TPH discriminator filters


### PR DESCRIPTION
## Summary
- Update benchmark projects to use TimeoutConfiguration.BaseTimeout
- Replace deprecated CommandTimeout usages across DbContext, query translation, navigation, and provider layers

## Testing
- `dotnet build benchmarks/nORM.Benchmarks.csproj -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b942333bac832cb9e3016f7c0c9f0e