### PR TITLE
Use ConcurrentDictionary for shadow property store

### DIFF
--- a/src/nORM/Internal/ShadowPropertyStore.cs
+++ b/src/nORM/Internal/ShadowPropertyStore.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 
 #nullable enable
@@ -8,7 +8,7 @@ namespace nORM.Internal
 {
     internal static class ShadowPropertyStore
     {
-        private static readonly ConditionalWeakTable<object, Dictionary<string, object?>> _values = new();
+        private static readonly ConditionalWeakTable<object, ConcurrentDictionary<string, object?>> _values = new();
 
         public static void Set(object entity, string name, object? value)
         {


### PR DESCRIPTION
## Summary
- switch `ShadowPropertyStore` backing store to `ConcurrentDictionary` for thread-safe writes

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9500d1674832c8a6feeb0c2529272