### PR TITLE
Default to ReadCommitted transaction isolation

### DIFF
--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -258,7 +258,7 @@ namespace nORM.Core
             if (ownsTransaction)
             {
                 await EnsureConnectionAsync(ct);
-                var isolationLevel = DetermineIsolationLevel(changedEntries);
+                var isolationLevel = IsolationLevel.ReadCommitted; // Use a safe default.
                 transaction = await Connection.BeginTransactionAsync(isolationLevel, ct);
 
                 timeoutCts = new CancellationTokenSource(Options.TimeoutConfiguration.BaseTimeout);
@@ -336,13 +336,6 @@ namespace nORM.Core
                 default:
                     return 0;
             }
-        }
-
-        private static IsolationLevel DetermineIsolationLevel(IEnumerable<EntityEntry> entries)
-        {
-            return entries.Any(e => e.State == EntityState.Deleted)
-                ? IsolationLevel.Serializable
-                : IsolationLevel.ReadCommitted;
         }
 
         private static bool IsRetryableException(Exception ex)


### PR DESCRIPTION
## Summary
- avoid automatic escalation to Serializable when deleting entities
- default SaveChanges to ReadCommitted transactions and remove unused helper

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b951e35b90832c9a4c4fd66ece8d17