### PR TITLE
Avoid eager enumeration in complexity analyzer

### DIFF
--- a/src/nORM/Query/QueryComplexityAnalyzer.cs
+++ b/src/nORM/Query/QueryComplexityAnalyzer.cs
@@ -76,9 +76,22 @@ namespace nORM.Query
                     node.Value is not string &&
                     node.Value is not IQueryable)
                 {
-                    var count = 0;
-                    foreach (var _ in enumerable)
-                        count++;
+                    int count;
+                    if (enumerable is System.Collections.ICollection collection)
+                    {
+                        count = collection.Count;
+                    }
+                    else
+                    {
+                        count = 0;
+                        foreach (var _ in enumerable)
+                        {
+                            count++;
+                            if (count > MaxParameterCount)
+                                break;
+                        }
+                    }
+
                     _complexity.ParameterCount += count;
                     if (_complexity.ParameterCount > MaxParameterCount)
                         throw new NormQueryTranslationException($"Query exceeds maximum parameter count of {MaxParameterCount}");

--- a/tests/QueryComplexityAnalyzerTests.cs
+++ b/tests/QueryComplexityAnalyzerTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Xunit;
 using nORM.Core;
 
@@ -11,6 +13,48 @@ public class QueryComplexityAnalyzerTests : TestBase
     private class Product
     {
         public int Id { get; set; }
+    }
+
+    private class CountingEnumerable : IEnumerable<int>
+    {
+        public int IterationCount { get; private set; }
+        private readonly int _limit;
+
+        public CountingEnumerable(int limit) => _limit = limit;
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            while (true)
+            {
+                IterationCount++;
+                if (IterationCount > _limit)
+                    throw new InvalidOperationException("Enumeration exceeded limit");
+                yield return 0;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private class CountingCollection : IEnumerable<int>, ICollection
+    {
+        private readonly int _count;
+        public int EnumerationCount { get; private set; }
+
+        public CountingCollection(int count) => _count = count;
+
+        public int Count => _count;
+        public object SyncRoot => this;
+        public bool IsSynchronized => false;
+        public void CopyTo(Array array, int index) => throw new NotImplementedException();
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            EnumerationCount++;
+            return Enumerable.Range(0, _count).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     private static IQueryable<Product> BuildDeepJoins(IQueryable<Product> q)
@@ -32,5 +76,35 @@ public class QueryComplexityAnalyzerTests : TestBase
         var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() =>
             analyzeMethod.Invoke(null, new object[] { query.Expression }));
         Assert.IsType<NormQueryTranslationException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void Large_IEnumerable_parameter_is_not_fully_enumerated()
+    {
+        const int MaxParameterCount = 2000;
+        var ids = new CountingEnumerable(5000);
+        var expr = Expression.Constant(ids);
+        var analyzerType = typeof(nORM.Query.QueryTranslator).Assembly.GetType("nORM.Query.QueryComplexityAnalyzer", true)!;
+        var analyzeMethod = analyzerType.GetMethod("AnalyzeQuery", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!;
+
+        var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() =>
+            analyzeMethod.Invoke(null, new object[] { expr }));
+        Assert.IsType<NormQueryTranslationException>(ex.InnerException);
+        Assert.True(ids.IterationCount <= MaxParameterCount + 1);
+    }
+
+    [Fact]
+    public void ICollection_parameter_uses_count_property()
+    {
+        var ids = new CountingCollection(5);
+        var expr = Expression.Constant(ids);
+        var analyzerType = typeof(nORM.Query.QueryTranslator).Assembly.GetType("nORM.Query.QueryComplexityAnalyzer", true)!;
+        var analyzeMethod = analyzerType.GetMethod("AnalyzeQuery", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!;
+
+        var result = analyzeMethod.Invoke(null, new object[] { expr })!;
+        var paramCount = (int)result.GetType().GetProperty("ParameterCount")!.GetValue(result)!;
+
+        Assert.Equal(5, paramCount);
+        Assert.Equal(0, ids.EnumerationCount);
     }
 }


### PR DESCRIPTION
## Summary
- avoid enumerating whole parameter collections by using `ICollection.Count` when available and capping manual enumeration
- add tests covering large `IEnumerable` constants and `ICollection` count usage

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b9528a7dfc832cb20f45d4e12b83bb