### PR TITLE
fix: reset visitors before pooling

### DIFF
--- a/src/nORM/Query/ExpressionVisitorPool.cs
+++ b/src/nORM/Query/ExpressionVisitorPool.cs
@@ -27,16 +27,16 @@ internal static class ExpressionVisitorPool
         return visitor;
     }
 
-    public static void Return(ExpressionToSqlVisitor visitor) => _pool.Return(visitor);
+    public static void Return(ExpressionToSqlVisitor visitor)
+    {
+        visitor.Reset();
+        _pool.Return(visitor);
+    }
 }
 
 internal sealed class VisitorPooledObjectPolicy : PooledObjectPolicy<ExpressionToSqlVisitor>
 {
     public override ExpressionToSqlVisitor Create() => new ExpressionToSqlVisitor();
 
-    public override bool Return(ExpressionToSqlVisitor obj)
-    {
-        obj.Reset();
-        return true;
-    }
+    public override bool Return(ExpressionToSqlVisitor obj) => true;
 }


### PR DESCRIPTION
## Summary
- ensure `ExpressionToSqlVisitor` state is cleared before returning to pool
- provide minimal `VisitorPooledObjectPolicy`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b964a4eca4832cb55b7244a7207ab4