### PR TITLE
Add identity resolution and disable benchmark tracking

### DIFF
--- a/benchmarks/OrmBenchmarks.cs
+++ b/benchmarks/OrmBenchmarks.cs
@@ -343,6 +343,7 @@ namespace nORM.Benchmarks
         {
             return await NormAsyncExtensions.ToListAsync(_nOrmContext!.Query<BenchmarkUser>()
                 .Where(u => u.IsActive)
+                .AsNoTracking()
                 .Take(10));
         }
 
@@ -398,6 +399,7 @@ namespace nORM.Benchmarks
         {
             return await NormAsyncExtensions.ToListAsync(_nOrmContext!.Query<BenchmarkUser>()
                 .Where(u => u.IsActive && u.Age > 25 && u.City == "New York")
+                .AsNoTracking()
                 .OrderBy(u => u.Name)
                 .Skip(5)
                 .Take(20));
@@ -438,6 +440,7 @@ namespace nORM.Benchmarks
                     o => o.UserId,
                     (u, o) => new { u.Name, o.Amount, o.ProductName }
                 )
+                .AsNoTracking()
                 .Where(x => x.Amount > 100)
                 .Take(50));
             return result.Cast<object>().ToList();

--- a/src/nORM/Core/ChangeTracker.cs
+++ b/src/nORM/Core/ChangeTracker.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using nORM.Configuration;
 using nORM.Mapping;
@@ -9,7 +10,8 @@ namespace nORM.Core
 {
     public sealed class ChangeTracker
     {
-        private readonly Dictionary<object, EntityEntry> _entries = new(RefComparer.Instance);
+        private readonly Dictionary<object, EntityEntry> _entriesByReference = new(RefComparer.Instance);
+        private readonly Dictionary<Type, Dictionary<object, EntityEntry>> _entriesByKey = new();
         private readonly DbContextOptions _options;
 
         public ChangeTracker(DbContextOptions options)
@@ -19,35 +21,60 @@ namespace nORM.Core
 
         internal EntityEntry Track(object entity, EntityState state, TableMapping mapping)
         {
-            if (!_entries.TryGetValue(entity, out var entry))
+            var pk = GetPrimaryKeyValue(entity, mapping);
+            if (pk != null && _entriesByKey.TryGetValue(mapping.Type, out var typeEntries) &&
+                typeEntries.TryGetValue(pk, out var existing))
             {
-                entry = new EntityEntry(entity, state, mapping, _options);
-                _entries[entity] = entry;
+                existing.State = state;
+                return existing;
             }
-            else
+
+            var entry = new EntityEntry(entity, state, mapping, _options);
+            _entriesByReference[entity] = entry;
+            if (pk != null)
             {
-                entry.State = state;
+                if (!_entriesByKey.TryGetValue(mapping.Type, out typeEntries))
+                {
+                    typeEntries = new Dictionary<object, EntityEntry>();
+                    _entriesByKey[mapping.Type] = typeEntries;
+                }
+                typeEntries[pk] = entry;
             }
+
             return entry;
         }
 
         internal void Remove(object entity)
         {
-            if (_entries.TryGetValue(entity, out var entry))
+            if (_entriesByReference.TryGetValue(entity, out var entry))
             {
                 entry.DetachEntity();
-                _entries.Remove(entity);
+                _entriesByReference.Remove(entity);
+                var pk = GetPrimaryKeyValue(entity, entry.Mapping);
+                if (pk != null && _entriesByKey.TryGetValue(entry.Mapping.Type, out var typeEntries))
+                {
+                    typeEntries.Remove(pk);
+                    if (typeEntries.Count == 0)
+                        _entriesByKey.Remove(entry.Mapping.Type);
+                }
             }
         }
 
-        public IEnumerable<EntityEntry> Entries => _entries.Values;
+        public IEnumerable<EntityEntry> Entries => _entriesByReference.Values;
 
         internal void DetectChanges()
         {
-            foreach (var entry in _entries.Values)
+            foreach (var entry in _entriesByReference.Values)
             {
                 entry.DetectChanges();
             }
+        }
+
+        private static object? GetPrimaryKeyValue(object entity, TableMapping mapping)
+        {
+            return mapping.KeyColumns.Length == 1
+                ? mapping.KeyColumns[0].Getter(entity)
+                : null; // Composite keys not yet supported
         }
     }
 }

--- a/src/nORM/Navigation/BatchedNavigationLoader.cs
+++ b/src/nORM/Navigation/BatchedNavigationLoader.cs
@@ -130,8 +130,9 @@ namespace nORM.Navigation
             while (await reader.ReadAsync(default).ConfigureAwait(false))
             {
                 var entity = await materializer(reader, default).ConfigureAwait(false);
+                var entry = _context.ChangeTracker.Track(entity, EntityState.Unchanged, mapping);
+                entity = entry.Entity;
                 NavigationPropertyExtensions._navigationContexts.GetValue(entity, _ => new NavigationContext(_context, relation.DependentType));
-                _context.ChangeTracker.Track(entity, EntityState.Unchanged, mapping);
                 results.Add(entity);
             }
             return results;

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -382,9 +382,10 @@ namespace nORM.Navigation
             if (await reader.ReadAsync(ct))
             {
                 var entity = await materializer(reader, ct);
+                var entry = context.ChangeTracker.Track(entity, EntityState.Unchanged, mapping);
+                entity = entry.Entity;
                 // Enable lazy loading for the loaded entity
                 _navigationContexts.GetValue(entity, _ => new NavigationContext(context, entityType));
-                context.ChangeTracker.Track(entity, EntityState.Unchanged, mapping);
                 return entity;
             }
             

--- a/src/nORM/Query/IncludeProcessor.cs
+++ b/src/nORM/Query/IncludeProcessor.cs
@@ -61,8 +61,9 @@ namespace nORM.Query
                     var child = await childMaterializer(reader, ct);
                     if (!noTracking)
                     {
+                        var entry = _ctx.ChangeTracker.Track(child, EntityState.Unchanged, childMap);
+                        child = entry.Entity;
                         NavigationPropertyExtensions.EnableLazyLoading(child, _ctx);
-                        _ctx.ChangeTracker.Track(child, EntityState.Unchanged, childMap);
                     }
                     resultChildren.Add(child);
                 }

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -376,9 +376,10 @@ namespace nORM.Query
                 var entity = (T)await plan.Materializer(reader, ct).ConfigureAwait(false);
                 if (trackable)
                 {
-                    NavigationPropertyExtensions.EnableLazyLoading((object)entity!, _ctx);
                     var actualMap = _ctx.GetMapping(entity!.GetType());
-                    _ctx.ChangeTracker.Track(entity!, EntityState.Unchanged, actualMap);
+                    var entry = _ctx.ChangeTracker.Track(entity!, EntityState.Unchanged, actualMap);
+                    entity = (T)entry.Entity;
+                    NavigationPropertyExtensions.EnableLazyLoading((object)entity!, _ctx);
                 }
                 count++;
                 yield return entity;


### PR DESCRIPTION
## Summary
- prevent benchmark change-tracking buildup by adding `AsNoTracking` to nORM query benchmarks
- add primary-key-based identity resolution to `ChangeTracker`
- reuse tracked entities throughout query and navigation pipelines

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b975e83e44832cb87fc0105b648a30