### PR TITLE
Implement history table creation for SQL Server, PostgreSQL, and MySQL providers

### DIFF
--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -103,7 +103,19 @@ namespace nORM.Providers
             => $"JSON_UNQUOTE(JSON_EXTRACT({columnName}, '{jsonPath}'))";
 
         public override string GenerateCreateHistoryTableSql(TableMapping mapping)
-            => throw new NotImplementedException();
+        {
+            var historyTable = Escape(mapping.TableName + "_History");
+            var columns = string.Join(",\n    ", mapping.Columns.Select(c => $"{Escape(c.PropName)} {GetSqlType(c.Prop.PropertyType)}"));
+
+            return $@"
+CREATE TABLE {historyTable} (
+    `__VersionId` BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `__ValidFrom` DATETIME NOT NULL,
+    `__ValidTo` DATETIME NOT NULL,
+    `__Operation` CHAR(1) NOT NULL,
+    {columns}
+) ENGINE=InnoDB;";
+        }
 
         public override string GenerateTemporalTriggersSql(TableMapping mapping)
             => throw new NotImplementedException();

--- a/src/nORM/Providers/PostgresProvider.cs
+++ b/src/nORM/Providers/PostgresProvider.cs
@@ -99,7 +99,19 @@ namespace nORM.Providers
         }
 
         public override string GenerateCreateHistoryTableSql(TableMapping mapping)
-            => throw new NotImplementedException();
+        {
+            var historyTable = Escape(mapping.TableName + "_History");
+            var columns = string.Join(",\n    ", mapping.Columns.Select(c => $"{Escape(c.PropName)} {GetPostgresType(c.Prop.PropertyType)}"));
+
+            return $@"
+CREATE TABLE {historyTable} (
+    ""__VersionId"" BIGSERIAL PRIMARY KEY,
+    ""__ValidFrom"" TIMESTAMP NOT NULL,
+    ""__ValidTo"" TIMESTAMP NOT NULL,
+    ""__Operation"" CHAR(1) NOT NULL,
+    {columns}
+);";
+        }
 
         public override string GenerateTemporalTriggersSql(TableMapping mapping)
             => throw new NotImplementedException();

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -106,7 +106,19 @@ namespace nORM.Providers
             => $"JSON_VALUE({columnName}, '{jsonPath}')";
 
         public override string GenerateCreateHistoryTableSql(TableMapping mapping)
-            => throw new NotImplementedException();
+        {
+            var historyTable = Escape(mapping.TableName + "_History");
+            var columns = string.Join(",\n    ", mapping.Columns.Select(c => $"{Escape(c.PropName)} {GetSqlType(c.Prop.PropertyType)}"));
+
+            return $@"
+CREATE TABLE {historyTable} (
+    [__VersionId] BIGINT IDENTITY(1,1) PRIMARY KEY,
+    [__ValidFrom] DATETIME2 NOT NULL,
+    [__ValidTo] DATETIME2 NOT NULL,
+    [__Operation] CHAR(1) NOT NULL,
+    {columns}
+);";
+        }
 
         public override string GenerateTemporalTriggersSql(TableMapping mapping)
             => throw new NotImplementedException();


### PR DESCRIPTION
## Summary
- Implemented `GenerateCreateHistoryTableSql` for SQL Server, PostgreSQL, and MySQL providers.
- Added SQL type mapping for history columns using provider-specific syntax and data types.

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a93db6e4832ca575afcd57d71ac5