### PR TITLE
Add temporal trigger generation for major providers

### DIFF
--- a/src/nORM/Providers/PostgresProvider.cs
+++ b/src/nORM/Providers/PostgresProvider.cs
@@ -114,7 +114,39 @@ CREATE TABLE {historyTable} (
         }
 
         public override string GenerateTemporalTriggersSql(TableMapping mapping)
-            => throw new NotImplementedException();
+        {
+            var table = Escape(mapping.TableName);
+            var history = Escape(mapping.TableName + "_History");
+            var columns = string.Join(", ", mapping.Columns.Select(c => Escape(c.PropName)));
+            var newColumns = string.Join(", ", mapping.Columns.Select(c => "NEW." + Escape(c.PropName)));
+            var oldColumns = string.Join(", ", mapping.Columns.Select(c => "OLD." + Escape(c.PropName)));
+            var keyCondition = string.Join(" AND ", mapping.KeyColumns.Select(c => $"{Escape(c.PropName)} = OLD.{Escape(c.PropName)}"));
+            var functionName = Escape(mapping.TableName + "_TemporalFunction");
+
+            return $@"
+CREATE OR REPLACE FUNCTION {functionName}() RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_OP = 'INSERT') THEN
+        INSERT INTO {history} (""__ValidFrom"", ""__ValidTo"", ""__Operation"", {columns})
+        VALUES (now() at time zone 'utc', '9999-12-31', 'I', {newColumns});
+    ELSIF (TG_OP = 'UPDATE') THEN
+        UPDATE {history} SET ""__ValidTo"" = now() at time zone 'utc' WHERE ""__ValidTo"" = '9999-12-31' AND {keyCondition};
+        INSERT INTO {history} (""__ValidFrom"", ""__ValidTo"", ""__Operation"", {columns})
+        VALUES (now() at time zone 'utc', '9999-12-31', 'U', {newColumns});
+    ELSIF (TG_OP = 'DELETE') THEN
+        UPDATE {history} SET ""__ValidTo"" = now() at time zone 'utc' WHERE ""__ValidTo"" = '9999-12-31' AND {keyCondition};
+        INSERT INTO {history} (""__ValidFrom"", ""__ValidTo"", ""__Operation"", {columns})
+        VALUES (now() at time zone 'utc', now() at time zone 'utc', 'D', {oldColumns});
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS {Escape(mapping.TableName + "_TemporalTrigger")} ON {table};
+CREATE TRIGGER {Escape(mapping.TableName + "_TemporalTrigger")}
+AFTER INSERT OR UPDATE OR DELETE ON {table}
+FOR EACH ROW EXECUTE FUNCTION {functionName}();";
+        }
 
         protected override void ValidateConnection(DbConnection connection)
         {


### PR DESCRIPTION
## Summary
- implement history triggers for SQL Server using inserted/deleted pseudo tables
- add PostgreSQL trigger function capturing insert, update and delete
- implement MySQL temporal triggers for insert/update/delete operations

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b9aa388ce8832ca2790e00ab576c2b