### PR TITLE
Add source generator attributes and async query improvements

### DIFF
--- a/src/SourceGeneration/CompileTimeQueryAttribute.cs
+++ b/src/SourceGeneration/CompileTimeQueryAttribute.cs
@@ -2,10 +2,16 @@ using System;
 
 namespace nORM.SourceGeneration
 {
-    [AttributeUsage(AttributeTargets.Method)]
+    /// <summary>
+    /// Indicates that a method should be populated by the source generator with
+    /// a pre-compiled query for the specified entity type.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
     public sealed class CompileTimeQueryAttribute : Attribute
     {
+        /// <summary>The entity type that the generated query should materialize.</summary>
         public Type EntityType { get; }
+
         public CompileTimeQueryAttribute(Type entityType) => EntityType = entityType;
     }
 }

--- a/src/SourceGeneration/GenerateMaterializerAttribute.cs
+++ b/src/SourceGeneration/GenerateMaterializerAttribute.cs
@@ -2,7 +2,13 @@ using System;
 
 namespace nORM.SourceGeneration
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    /// <summary>
+    /// Marks an entity type for which a materializer should be generated at
+    /// compile time. The associated source generator will produce a method that
+    /// can populate an instance of the decorated type directly from a
+    /// <see cref="System.Data.Common.DbDataReader"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
     public sealed class GenerateMaterializerAttribute : Attribute
     {
     }

--- a/src/nORM.SourceGenerators/MaterializerQueryGenerator.cs
+++ b/src/nORM.SourceGenerators/MaterializerQueryGenerator.cs
@@ -238,10 +238,10 @@ namespace nORM.SourceGenerators
             sb.AppendLine($"        cmd.CommandText = \"{sql}\";");
             sb.AppendLine($"        var materializer = CompiledMaterializerStore.Get<{entityTypeName}>();");
             sb.AppendLine($"        var list = new System.Collections.Generic.List<{entityTypeName}>();");
-            sb.AppendLine($"        await using var reader = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, {ctParam});");
-            sb.AppendLine($"        while (await reader.ReadAsync({ctParam}))");
+            sb.AppendLine($"        await using var reader = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, {ctParam}).ConfigureAwait(false);");
+            sb.AppendLine($"        while (await reader.ReadAsync({ctParam}).ConfigureAwait(false))");
             sb.AppendLine("        {");
-            sb.AppendLine($"            list.Add(await materializer(reader, {ctParam}));");
+            sb.AppendLine($"            list.Add(await materializer(reader, {ctParam}).ConfigureAwait(false));");
             sb.AppendLine("        }");
             sb.AppendLine("        return list;");
             sb.AppendLine("    }");


### PR DESCRIPTION
## Summary
- Document and restrict usage of `GenerateMaterializerAttribute`
- Document and restrict usage of `CompileTimeQueryAttribute`
- Improve generated queries to avoid context capture using `ConfigureAwait(false)`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c1a23fcc832c8c458b8f3e4e9361