### PR TITLE
Add migration runners for Postgres, MySQL and SQLite

### DIFF
--- a/src/dotnet-norm/Program.cs
+++ b/src/dotnet-norm/Program.cs
@@ -59,7 +59,7 @@ var database = new Command("database", "Database related commands");
 
 var update = new Command("update", "Apply pending migrations to the database.\nExample:\n  norm database update --connection \"...\" --provider sqlserver --assembly Migrations.dll");
 var migConnOpt = new Option<string>("--connection") { Description = "Database connection string", Required = true };
-var migProvOpt = new Option<string>("--provider") { Description = "Database provider. Currently only 'sqlserver' is supported for applying migrations.", Required = true };
+var migProvOpt = new Option<string>("--provider") { Description = "Database provider (sqlserver, sqlite, postgres, mysql)", Required = true };
 var assemblyOpt = new Option<string>("--assembly") { Description = "Path to migrations assembly (e.g. ./bin/Debug/net8.0/App.Migrations.dll)", Required = true };
 update.Add(migConnOpt);
 update.Add(migProvOpt);
@@ -82,6 +82,9 @@ update.SetAction(async (ParseResult result, CancellationToken _) =>
         IMigrationRunner runner = prov.ToLowerInvariant() switch
         {
             "sqlserver" => new SqlServerMigrationRunner(connection, assembly),
+            "sqlite" => new SqliteMigrationRunner(connection, assembly),
+            "postgres" or "postgresql" => new PostgresMigrationRunner(connection, assembly),
+            "mysql" => new MySqlMigrationRunner(connection, assembly),
             _ => throw new ArgumentException($"Provider '{prov}' does not support migrations.")
         };
         if (!await runner.HasPendingMigrationsAsync())

--- a/src/nORM/Migration/PostgresMigrationRunner.cs
+++ b/src/nORM/Migration/PostgresMigrationRunner.cs
@@ -15,20 +15,20 @@ using nORM.Providers;
 
 namespace nORM.Migration
 {
-    public class SqlServerMigrationRunner : IMigrationRunner
+    public class PostgresMigrationRunner : IMigrationRunner
     {
         private readonly DbConnection _connection;
         private readonly Assembly _migrationsAssembly;
         private readonly DbContext? _context;
-        internal const string HistoryTableName = "__NormMigrationsHistory";
+        private const string HistoryTableName = "__NormMigrationsHistory";
 
-        public SqlServerMigrationRunner(DbConnection connection, Assembly migrationsAssembly, DbContextOptions? options = null)
+        public PostgresMigrationRunner(DbConnection connection, Assembly migrationsAssembly, DbContextOptions? options = null)
         {
             _connection = connection;
             _migrationsAssembly = migrationsAssembly;
             if (options != null && options.CommandInterceptors.Count > 0)
             {
-                _context = new DbContext(connection, new SqlServerProvider(), options);
+                _context = new DbContext(connection, new PostgresProvider(new GenericParameterFactory(connection)), options);
             }
         }
 
@@ -78,7 +78,7 @@ namespace nORM.Migration
         {
             await using var cmd = _connection.CreateCommand();
             cmd.Transaction = transaction;
-            cmd.CommandText = $"INSERT INTO [{HistoryTableName}] (Version, Name, AppliedOn) VALUES (@Version, @Name, @AppliedOn)";
+            cmd.CommandText = $"INSERT INTO \"{HistoryTableName}\" (\"Version\", \"Name\", \"AppliedOn\") VALUES (@Version, @Name, @AppliedOn);";
             cmd.AddParam("@Version", migration.Version);
             cmd.AddParam("@Name", migration.Name);
             cmd.AddParam("@AppliedOn", DateTime.UtcNow);
@@ -89,7 +89,7 @@ namespace nORM.Migration
         {
             var versions = new HashSet<long>();
             await using var cmd = _connection.CreateCommand();
-            cmd.CommandText = $"SELECT [Version] FROM [{HistoryTableName}]";
+            cmd.CommandText = $"SELECT \"Version\" FROM \"{HistoryTableName}\"";
             try
             {
                 await using var reader = await ExecuteReaderAsync(cmd, ct);
@@ -108,7 +108,7 @@ namespace nORM.Migration
         private async Task EnsureHistoryTableAsync(CancellationToken ct)
         {
             await using var cmd = _connection.CreateCommand();
-            cmd.CommandText = $"IF OBJECT_ID(N'{HistoryTableName}', N'U') IS NULL CREATE TABLE [{HistoryTableName}] (Version BIGINT PRIMARY KEY, Name NVARCHAR(255) NOT NULL, AppliedOn DATETIME2 NOT NULL);";
+            cmd.CommandText = $"CREATE TABLE IF NOT EXISTS \"{HistoryTableName}\" (Version BIGINT PRIMARY KEY, Name TEXT NOT NULL, AppliedOn TIMESTAMP NOT NULL);";
             await ExecuteNonQueryAsync(cmd, ct);
         }
 
@@ -117,5 +117,19 @@ namespace nORM.Migration
 
         private Task<DbDataReader> ExecuteReaderAsync(DbCommand cmd, CancellationToken ct)
             => _context != null ? cmd.ExecuteReaderWithInterceptionAsync(_context, CommandBehavior.Default, ct) : cmd.ExecuteReaderAsync(ct);
+
+        private sealed class GenericParameterFactory : IDbParameterFactory
+        {
+            private readonly DbConnection _connection;
+            public GenericParameterFactory(DbConnection connection) => _connection = connection;
+            public DbParameter CreateParameter(string name, object? value)
+            {
+                using var cmd = _connection.CreateCommand();
+                var p = cmd.CreateParameter();
+                p.ParameterName = name;
+                p.Value = value ?? DBNull.Value;
+                return p;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend CLI to run migrations on PostgreSQL, MySQL, and SQLite databases
- add provider-specific migration runner implementations

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b9c30c1508832ca5134a17b3dcea1d