### PR TITLE
Ensure ConfigureAwait(false) on internal awaits

### DIFF
--- a/src/nORM/Core/ConnectionManager.cs
+++ b/src/nORM/Core/ConnectionManager.cs
@@ -144,7 +144,7 @@ namespace nORM.Core
                 try
                 {
                     var sw = System.Diagnostics.Stopwatch.StartNew();
-                    await using var cn = await pool.RentAsync();
+                    await using var cn = await pool.RentAsync().ConfigureAwait(false);
                     sw.Stop();
                     node.IsHealthy = true;
                     node.LastHealthCheck = DateTime.UtcNow;

--- a/src/nORM/Core/ConnectionPool.cs
+++ b/src/nORM/Core/ConnectionPool.cs
@@ -158,7 +158,7 @@ namespace nORM.Core
         public async ValueTask DisposeAsync()
         {
             Dispose();
-            await Task.CompletedTask;
+            await Task.CompletedTask.ConfigureAwait(false);
         }
 
         private sealed class PooledDbConnection : DbConnection

--- a/src/nORM/Core/DatabaseFacade.cs
+++ b/src/nORM/Core/DatabaseFacade.cs
@@ -20,8 +20,8 @@ namespace nORM.Core
         {
             if (_context.CurrentTransaction != null)
                 throw new InvalidOperationException("A transaction is already active.");
-            await _context.EnsureConnectionAsync(ct);
-            var transaction = await _context.Connection.BeginTransactionAsync(ct);
+            await _context.EnsureConnectionAsync(ct).ConfigureAwait(false);
+            var transaction = await _context.Connection.BeginTransactionAsync(ct).ConfigureAwait(false);
             _context.CurrentTransaction = transaction;
             return new DbContextTransaction(transaction, _context);
         }

--- a/src/nORM/Core/DbContextTransaction.cs
+++ b/src/nORM/Core/DbContextTransaction.cs
@@ -27,8 +27,8 @@ namespace nORM.Core
 
         public async Task CommitAsync(CancellationToken ct = default)
         {
-            await _transaction.CommitAsync(ct);
-            await DisposeAsync();
+            await _transaction.CommitAsync(ct).ConfigureAwait(false);
+            await DisposeAsync().ConfigureAwait(false);
         }
 
         public void Rollback()
@@ -39,8 +39,8 @@ namespace nORM.Core
 
         public async Task RollbackAsync(CancellationToken ct = default)
         {
-            await _transaction.RollbackAsync(ct);
-            await DisposeAsync();
+            await _transaction.RollbackAsync(ct).ConfigureAwait(false);
+            await DisposeAsync().ConfigureAwait(false);
         }
 
         public void Dispose()
@@ -58,7 +58,7 @@ namespace nORM.Core
             if (!_completed)
             {
                 _completed = true;
-                await _transaction.DisposeAsync();
+                await _transaction.DisposeAsync().ConfigureAwait(false);
                 _context.ClearTransaction(_transaction);
             }
         }

--- a/src/nORM/Core/Norm.cs
+++ b/src/nORM/Core/Norm.cs
@@ -39,7 +39,7 @@ namespace nORM.Core
                         parameters[name] = value!;
 
                 var execProvider = new NormQueryProvider(ctx);
-                return await execProvider.ExecuteCompiledAsync<List<T>>(cachedPlan, parameters, default);
+                return await execProvider.ExecuteCompiledAsync<List<T>>(cachedPlan, parameters, default).ConfigureAwait(false);
             };
         }
 

--- a/src/nORM/Core/NormAsyncExtensions.cs
+++ b/src/nORM/Core/NormAsyncExtensions.cs
@@ -77,7 +77,7 @@ namespace nORM.Core
         {
             if (source.Provider is Query.NormQueryProvider)
             {
-                var list = await source.ToListAsync(ct);
+                var list = await source.ToListAsync(ct).ConfigureAwait(false);
                 return list.ToArray();
             }
             
@@ -100,7 +100,7 @@ namespace nORM.Core
                     nameof(Queryable.Any),
                     new[] { typeof(T) },
                     source.Expression);
-                return await normProvider.ExecuteAsync<bool>(anyExpression, ct);
+                return await normProvider.ExecuteAsync<bool>(anyExpression, ct).ConfigureAwait(false);
             }
             
             throw new NormUsageException(

--- a/src/nORM/Core/NormQueryable.cs
+++ b/src/nORM/Core/NormQueryable.cs
@@ -110,9 +110,9 @@ namespace nORM.Core
             => ((NormQueryProvider)Provider).AsAsyncEnumerable<T>(Expression, ct);
 
         public Task<List<T>> ToListAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<List<T>>(Expression, ct);
-        public async Task<T[]> ToArrayAsync(CancellationToken ct = default) => (await ToListAsync(ct)).ToArray();
+        public async Task<T[]> ToArrayAsync(CancellationToken ct = default) => (await ToListAsync(ct).ConfigureAwait(false)).ToArray();
         public Task<int> CountAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<int>(Expression.Call(typeof(Queryable), nameof(Queryable.Count), new[] { typeof(T) }, Expression), ct);
-        public async Task<bool> AnyAsync(CancellationToken ct = default) => await ((NormQueryProvider)Provider).ExecuteAsync<bool>(Expression.Call(typeof(Queryable), nameof(Queryable.Any), new[] { typeof(T) }, Expression), ct);
+        public async Task<bool> AnyAsync(CancellationToken ct = default) => await ((NormQueryProvider)Provider).ExecuteAsync<bool>(Expression.Call(typeof(Queryable), nameof(Queryable.Any), new[] { typeof(T) }, Expression), ct).ConfigureAwait(false);
         public Task<T> FirstAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<T>(Expression.Call(typeof(Queryable), nameof(Queryable.First), new[] { typeof(T) }, Expression), ct);
         public Task<T?> FirstOrDefaultAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<T?>(Expression.Call(typeof(Queryable), nameof(Queryable.FirstOrDefault), new[] { typeof(T) }, Expression), ct);
         public Task<T> SingleAsync(CancellationToken ct = default) => ((NormQueryProvider)Provider).ExecuteAsync<T>(Expression.Call(typeof(Queryable), nameof(Queryable.Single), new[] { typeof(T) }, Expression), ct);
@@ -200,11 +200,11 @@ namespace nORM.Core
 
         public Task<List<T>> ToListAsync(CancellationToken ct = default)
             => ((NormQueryProvider)Provider).ExecuteAsync<List<T>>(Expression, ct);
-        public async Task<T[]> ToArrayAsync(CancellationToken ct = default) => (await ToListAsync(ct)).ToArray();
+        public async Task<T[]> ToArrayAsync(CancellationToken ct = default) => (await ToListAsync(ct).ConfigureAwait(false)).ToArray();
         public Task<int> CountAsync(CancellationToken ct = default)
             => ((NormQueryProvider)Provider).ExecuteAsync<int>(Expression.Call(typeof(Queryable), nameof(Queryable.Count), new[] { typeof(T) }, Expression), ct);
         public async Task<bool> AnyAsync(CancellationToken ct = default)
-            => await ((NormQueryProvider)Provider).ExecuteAsync<bool>(Expression.Call(typeof(Queryable), nameof(Queryable.Any), new[] { typeof(T) }, Expression), ct);
+            => await ((NormQueryProvider)Provider).ExecuteAsync<bool>(Expression.Call(typeof(Queryable), nameof(Queryable.Any), new[] { typeof(T) }, Expression), ct).ConfigureAwait(false);
         public Task<T> FirstAsync(CancellationToken ct = default)
             => ((NormQueryProvider)Provider).ExecuteAsync<T>(Expression.Call(typeof(Queryable), nameof(Queryable.First), new[] { typeof(T) }, Expression), ct);
         public Task<T?> FirstOrDefaultAsync(CancellationToken ct = default)

--- a/src/nORM/Execution/DefaultExecutionStrategy.cs
+++ b/src/nORM/Execution/DefaultExecutionStrategy.cs
@@ -18,7 +18,7 @@ namespace nORM.Execution
         {
             try
             {
-                return await operation(_ctx, ct);
+                return await operation(_ctx, ct).ConfigureAwait(false);
             }
             catch (DbException ex)
             {

--- a/src/nORM/Execution/RetryingExecutionStrategy.cs
+++ b/src/nORM/Execution/RetryingExecutionStrategy.cs
@@ -27,7 +27,7 @@ namespace nORM.Execution
             {
                 try
                 {
-                    return await operation(_ctx, ct);
+                    return await operation(_ctx, ct).ConfigureAwait(false);
                 }
                 catch (DbException ex)
                 {
@@ -39,7 +39,7 @@ namespace nORM.Execution
                         throw normEx;
                     }
                     var delay = TimeSpan.FromMilliseconds(_policy.BaseDelay.TotalMilliseconds * Math.Pow(2, retryCount));
-                    await Task.Delay(delay, ct);
+                    await Task.Delay(delay, ct).ConfigureAwait(false);
                     retryCount++;
                 }
             }

--- a/src/nORM/Migration/MySqlMigrationRunner.cs
+++ b/src/nORM/Migration/MySqlMigrationRunner.cs
@@ -34,30 +34,30 @@ namespace nORM.Migration
 
         public async Task ApplyMigrationsAsync(CancellationToken ct = default)
         {
-            await EnsureHistoryTableAsync(ct);
-            var pending = await GetPendingMigrationsInternalAsync(ct);
+            await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
+            var pending = await GetPendingMigrationsInternalAsync(ct).ConfigureAwait(false);
             if (!pending.Any()) return;
 
-            await using var transaction = await _connection.BeginTransactionAsync(ct);
+            await using var transaction = await _connection.BeginTransactionAsync(ct).ConfigureAwait(false);
             foreach (var migration in pending)
             {
                 migration.Up(_connection, (DbTransaction)transaction);
-                await MarkMigrationAppliedAsync(migration, (DbTransaction)transaction, ct);
+                await MarkMigrationAppliedAsync(migration, (DbTransaction)transaction, ct).ConfigureAwait(false);
             }
-            await transaction.CommitAsync(ct);
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
         }
 
         public async Task<bool> HasPendingMigrationsAsync(CancellationToken ct = default)
         {
-            await EnsureHistoryTableAsync(ct);
-            var pending = await GetPendingMigrationsInternalAsync(ct);
+            await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
+            var pending = await GetPendingMigrationsInternalAsync(ct).ConfigureAwait(false);
             return pending.Any();
         }
 
         public async Task<string[]> GetPendingMigrationsAsync(CancellationToken ct = default)
         {
-            await EnsureHistoryTableAsync(ct);
-            var pending = await GetPendingMigrationsInternalAsync(ct);
+            await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
+            var pending = await GetPendingMigrationsInternalAsync(ct).ConfigureAwait(false);
             return pending.Select(p => $"{p.Version}_{p.Name}").ToArray();
         }
 
@@ -69,7 +69,7 @@ namespace nORM.Migration
                 .OrderBy(m => m.Version)
                 .ToList();
 
-            var appliedVersions = await GetAppliedMigrationVersionsAsync(ct);
+            var appliedVersions = await GetAppliedMigrationVersionsAsync(ct).ConfigureAwait(false);
 
             return all.Where(m => !appliedVersions.Contains(m.Version)).ToList();
         }
@@ -82,7 +82,7 @@ namespace nORM.Migration
             cmd.AddParam("@Version", migration.Version);
             cmd.AddParam("@Name", migration.Name);
             cmd.AddParam("@AppliedOn", DateTime.UtcNow);
-            await ExecuteNonQueryAsync(cmd, ct);
+            await ExecuteNonQueryAsync(cmd, ct).ConfigureAwait(false);
         }
 
         private async Task<HashSet<long>> GetAppliedMigrationVersionsAsync(CancellationToken ct)
@@ -92,8 +92,8 @@ namespace nORM.Migration
             cmd.CommandText = $"SELECT `Version` FROM `{HistoryTableName}`";
             try
             {
-                await using var reader = await ExecuteReaderAsync(cmd, ct);
-                while (await reader.ReadAsync(ct))
+                await using var reader = await ExecuteReaderAsync(cmd, ct).ConfigureAwait(false);
+                while (await reader.ReadAsync(ct).ConfigureAwait(false))
                 {
                     versions.Add(reader.GetInt64(0));
                 }
@@ -109,7 +109,7 @@ namespace nORM.Migration
         {
             await using var cmd = _connection.CreateCommand();
             cmd.CommandText = $"CREATE TABLE IF NOT EXISTS `{HistoryTableName}` (Version BIGINT PRIMARY KEY, Name VARCHAR(255) NOT NULL, AppliedOn DATETIME(6) NOT NULL);";
-            await ExecuteNonQueryAsync(cmd, ct);
+            await ExecuteNonQueryAsync(cmd, ct).ConfigureAwait(false);
         }
 
         private Task<int> ExecuteNonQueryAsync(DbCommand cmd, CancellationToken ct)

--- a/src/nORM/Migration/SqlServerMigrationRunner.cs
+++ b/src/nORM/Migration/SqlServerMigrationRunner.cs
@@ -34,30 +34,30 @@ namespace nORM.Migration
 
         public async Task ApplyMigrationsAsync(CancellationToken ct = default)
         {
-            await EnsureHistoryTableAsync(ct);
-            var pending = await GetPendingMigrationsInternalAsync(ct);
+            await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
+            var pending = await GetPendingMigrationsInternalAsync(ct).ConfigureAwait(false);
             if (!pending.Any()) return;
 
-            await using var transaction = await _connection.BeginTransactionAsync(ct);
+            await using var transaction = await _connection.BeginTransactionAsync(ct).ConfigureAwait(false);
             foreach (var migration in pending)
             {
                 migration.Up(_connection, (DbTransaction)transaction);
-                await MarkMigrationAppliedAsync(migration, (DbTransaction)transaction, ct);
+                await MarkMigrationAppliedAsync(migration, (DbTransaction)transaction, ct).ConfigureAwait(false);
             }
-            await transaction.CommitAsync(ct);
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
         }
 
         public async Task<bool> HasPendingMigrationsAsync(CancellationToken ct = default)
         {
-            await EnsureHistoryTableAsync(ct);
-            var pending = await GetPendingMigrationsInternalAsync(ct);
+            await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
+            var pending = await GetPendingMigrationsInternalAsync(ct).ConfigureAwait(false);
             return pending.Any();
         }
 
         public async Task<string[]> GetPendingMigrationsAsync(CancellationToken ct = default)
         {
-            await EnsureHistoryTableAsync(ct);
-            var pending = await GetPendingMigrationsInternalAsync(ct);
+            await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
+            var pending = await GetPendingMigrationsInternalAsync(ct).ConfigureAwait(false);
             return pending.Select(p => $"{p.Version}_{p.Name}").ToArray();
         }
 
@@ -69,7 +69,7 @@ namespace nORM.Migration
                 .OrderBy(m => m.Version)
                 .ToList();
 
-            var appliedVersions = await GetAppliedMigrationVersionsAsync(ct);
+            var appliedVersions = await GetAppliedMigrationVersionsAsync(ct).ConfigureAwait(false);
 
             return all.Where(m => !appliedVersions.Contains(m.Version)).ToList();
         }
@@ -82,7 +82,7 @@ namespace nORM.Migration
             cmd.AddParam("@Version", migration.Version);
             cmd.AddParam("@Name", migration.Name);
             cmd.AddParam("@AppliedOn", DateTime.UtcNow);
-            await ExecuteNonQueryAsync(cmd, ct);
+            await ExecuteNonQueryAsync(cmd, ct).ConfigureAwait(false);
         }
 
         private async Task<HashSet<long>> GetAppliedMigrationVersionsAsync(CancellationToken ct)
@@ -92,8 +92,8 @@ namespace nORM.Migration
             cmd.CommandText = $"SELECT [Version] FROM [{HistoryTableName}]";
             try
             {
-                await using var reader = await ExecuteReaderAsync(cmd, ct);
-                while (await reader.ReadAsync(ct))
+                await using var reader = await ExecuteReaderAsync(cmd, ct).ConfigureAwait(false);
+                while (await reader.ReadAsync(ct).ConfigureAwait(false))
                 {
                     versions.Add(reader.GetInt64(0));
                 }
@@ -109,7 +109,7 @@ namespace nORM.Migration
         {
             await using var cmd = _connection.CreateCommand();
             cmd.CommandText = $"IF OBJECT_ID(N'{HistoryTableName}', N'U') IS NULL CREATE TABLE [{HistoryTableName}] (Version BIGINT PRIMARY KEY, Name NVARCHAR(255) NOT NULL, AppliedOn DATETIME2 NOT NULL);";
-            await ExecuteNonQueryAsync(cmd, ct);
+            await ExecuteNonQueryAsync(cmd, ct).ConfigureAwait(false);
         }
 
         private Task<int> ExecuteNonQueryAsync(DbCommand cmd, CancellationToken ct)

--- a/src/nORM/Migration/SqliteMigrationRunner.cs
+++ b/src/nORM/Migration/SqliteMigrationRunner.cs
@@ -34,30 +34,30 @@ namespace nORM.Migration
 
         public async Task ApplyMigrationsAsync(CancellationToken ct = default)
         {
-            await EnsureHistoryTableAsync(ct);
-            var pending = await GetPendingMigrationsInternalAsync(ct);
+            await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
+            var pending = await GetPendingMigrationsInternalAsync(ct).ConfigureAwait(false);
             if (!pending.Any()) return;
 
-            await using var transaction = await _connection.BeginTransactionAsync(ct);
+            await using var transaction = await _connection.BeginTransactionAsync(ct).ConfigureAwait(false);
             foreach (var migration in pending)
             {
                 migration.Up(_connection, (DbTransaction)transaction);
-                await MarkMigrationAppliedAsync(migration, (DbTransaction)transaction, ct);
+                await MarkMigrationAppliedAsync(migration, (DbTransaction)transaction, ct).ConfigureAwait(false);
             }
-            await transaction.CommitAsync(ct);
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
         }
 
         public async Task<bool> HasPendingMigrationsAsync(CancellationToken ct = default)
         {
-            await EnsureHistoryTableAsync(ct);
-            var pending = await GetPendingMigrationsInternalAsync(ct);
+            await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
+            var pending = await GetPendingMigrationsInternalAsync(ct).ConfigureAwait(false);
             return pending.Any();
         }
 
         public async Task<string[]> GetPendingMigrationsAsync(CancellationToken ct = default)
         {
-            await EnsureHistoryTableAsync(ct);
-            var pending = await GetPendingMigrationsInternalAsync(ct);
+            await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
+            var pending = await GetPendingMigrationsInternalAsync(ct).ConfigureAwait(false);
             return pending.Select(p => $"{p.Version}_{p.Name}").ToArray();
         }
 
@@ -69,7 +69,7 @@ namespace nORM.Migration
                 .OrderBy(m => m.Version)
                 .ToList();
 
-            var appliedVersions = await GetAppliedMigrationVersionsAsync(ct);
+            var appliedVersions = await GetAppliedMigrationVersionsAsync(ct).ConfigureAwait(false);
 
             return all.Where(m => !appliedVersions.Contains(m.Version)).ToList();
         }
@@ -82,7 +82,7 @@ namespace nORM.Migration
             cmd.AddParam("@Version", migration.Version);
             cmd.AddParam("@Name", migration.Name);
             cmd.AddParam("@AppliedOn", DateTime.UtcNow);
-            await ExecuteNonQueryAsync(cmd, ct);
+            await ExecuteNonQueryAsync(cmd, ct).ConfigureAwait(false);
         }
 
         private async Task<HashSet<long>> GetAppliedMigrationVersionsAsync(CancellationToken ct)
@@ -92,8 +92,8 @@ namespace nORM.Migration
             cmd.CommandText = $"SELECT \"Version\" FROM \"{HistoryTableName}\"";
             try
             {
-                await using var reader = await ExecuteReaderAsync(cmd, ct);
-                while (await reader.ReadAsync(ct))
+                await using var reader = await ExecuteReaderAsync(cmd, ct).ConfigureAwait(false);
+                while (await reader.ReadAsync(ct).ConfigureAwait(false))
                 {
                     versions.Add(reader.GetInt64(0));
                 }
@@ -109,7 +109,7 @@ namespace nORM.Migration
         {
             await using var cmd = _connection.CreateCommand();
             cmd.CommandText = $"CREATE TABLE IF NOT EXISTS \"{HistoryTableName}\" (Version INTEGER PRIMARY KEY, Name TEXT NOT NULL, AppliedOn TEXT NOT NULL);";
-            await ExecuteNonQueryAsync(cmd, ct);
+            await ExecuteNonQueryAsync(cmd, ct).ConfigureAwait(false);
         }
 
         private Task<int> ExecuteNonQueryAsync(DbCommand cmd, CancellationToken ct)

--- a/src/nORM/Providers/SqliteProvider.cs
+++ b/src/nORM/Providers/SqliteProvider.cs
@@ -162,7 +162,7 @@ END;";
 
             var totalInserted = 0;
 
-            await using var transaction = await ctx.Connection.BeginTransactionAsync(ct);
+            await using var transaction = await ctx.Connection.BeginTransactionAsync(ct).ConfigureAwait(false);
             try
             {
                 for (int i = 0; i < entityList.Count; i += batchSize)
@@ -185,16 +185,16 @@ END;";
                     }
 
                     var batchSw = Stopwatch.StartNew();
-                    totalInserted += await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
+                    totalInserted += await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct).ConfigureAwait(false);
                     batchSw.Stop();
                     BatchSizer.RecordBatchPerformance(operationKey, batch.Count, batchSw.Elapsed, batch.Count);
                 }
 
-                await transaction.CommitAsync(ct);
+                await transaction.CommitAsync(ct).ConfigureAwait(false);
             }
             catch
             {
-                await transaction.RollbackAsync(ct);
+                await transaction.RollbackAsync(ct).ConfigureAwait(false);
                 throw;
             }
 
@@ -236,7 +236,7 @@ END;";
             
             var totalUpdated = 0;
             
-            await using var transaction = await ctx.Connection.BeginTransactionAsync(ct);
+            await using var transaction = await ctx.Connection.BeginTransactionAsync(ct).ConfigureAwait(false);
             try
             {
                 await using var cmd = ctx.Connection.CreateCommand();
@@ -244,7 +244,7 @@ END;";
                 cmd.CommandText = BuildUpdate(m);
                 cmd.CommandTimeout = 30;
                 
-                await cmd.PrepareAsync(ct);
+                await cmd.PrepareAsync(ct).ConfigureAwait(false);
                 
                 foreach (var entity in entityList)
                 {
@@ -265,14 +265,14 @@ END;";
                         cmd.AddParam(ParamPrefix + m.TimestampColumn.PropName, m.TimestampColumn.Getter(entity));
                     }
                     
-                    totalUpdated += await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
+                    totalUpdated += await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct).ConfigureAwait(false);
                 }
                 
-                await transaction.CommitAsync(ct);
+                await transaction.CommitAsync(ct).ConfigureAwait(false);
             }
             catch
             {
-                await transaction.RollbackAsync(ct);
+                await transaction.RollbackAsync(ct).ConfigureAwait(false);
                 throw;
             }
             
@@ -298,7 +298,7 @@ END;";
                 batchSize = Math.Min(batchSize, MaxParameters);
             if (batchSize <= 0) batchSize = 1;
             
-            await using var transaction = await ctx.Connection.BeginTransactionAsync(ct);
+            await using var transaction = await ctx.Connection.BeginTransactionAsync(ct).ConfigureAwait(false);
             try
             {
                 if (m.KeyColumns.Length == 1)
@@ -323,7 +323,7 @@ END;";
                         }
                         
                         cmd.CommandText = $"DELETE FROM {m.EscTable} WHERE {keyCol.EscCol} IN ({string.Join(",", paramNames)})";
-                        totalDeleted += await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
+                        totalDeleted += await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct).ConfigureAwait(false);
                     }
                 }
                 else
@@ -332,7 +332,7 @@ END;";
                     cmd.Transaction = transaction;
                     cmd.CommandText = BuildDelete(m);
                     cmd.CommandTimeout = 30;
-                    await cmd.PrepareAsync(ct);
+                    await cmd.PrepareAsync(ct).ConfigureAwait(false);
                     
                     foreach (var entity in entityList)
                     {
@@ -348,15 +348,15 @@ END;";
                             cmd.AddParam(ParamPrefix + m.TimestampColumn.PropName, m.TimestampColumn.Getter(entity));
                         }
                         
-                        totalDeleted += await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct);
+                        totalDeleted += await cmd.ExecuteNonQueryWithInterceptionAsync(ctx, ct).ConfigureAwait(false);
                     }
                 }
                 
-                await transaction.CommitAsync(ct);
+                await transaction.CommitAsync(ct).ConfigureAwait(false);
             }
             catch
             {
-                await transaction.RollbackAsync(ct);
+                await transaction.RollbackAsync(ct).ConfigureAwait(false);
                 throw;
             }
             

--- a/src/nORM/Query/IncludeProcessor.cs
+++ b/src/nORM/Query/IncludeProcessor.cs
@@ -27,7 +27,7 @@ namespace nORM.Query
             IList current = parents;
             foreach (var relation in include.Path)
             {
-                current = await EagerLoadLevelAsync(relation, current, ct, noTracking);
+                current = await EagerLoadLevelAsync(relation, current, ct, noTracking).ConfigureAwait(false);
                 if (current.Count == 0) break;
             }
         }
@@ -42,7 +42,7 @@ namespace nORM.Query
             if (keys.Count == 0) return resultChildren;
 
             var paramNames = new List<string>();
-            await _ctx.EnsureConnectionAsync(ct);
+            await _ctx.EnsureConnectionAsync(ct).ConfigureAwait(false);
             await using var cmd = _ctx.Connection.CreateCommand();
             cmd.CommandTimeout = (int)_ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
             for (int i = 0; i < keys.Count; i++)
@@ -54,11 +54,11 @@ namespace nORM.Query
             cmd.CommandText = $"SELECT * FROM {childMap.EscTable} WHERE {relation.ForeignKey.EscCol} IN ({string.Join(",", paramNames)})";
 
             var childMaterializer = _materializerFactory.CreateMaterializer(childMap, childMap.Type);
-            await using (var reader = await cmd.ExecuteReaderWithInterceptionAsync(_ctx, CommandBehavior.Default, ct))
+            await using (var reader = await cmd.ExecuteReaderWithInterceptionAsync(_ctx, CommandBehavior.Default, ct).ConfigureAwait(false))
             {
-                while (await reader.ReadAsync(ct))
+                while (await reader.ReadAsync(ct).ConfigureAwait(false))
                 {
-                    var child = await childMaterializer(reader, ct);
+                    var child = await childMaterializer(reader, ct).ConfigureAwait(false);
                     if (!noTracking)
                     {
                         var entry = _ctx.ChangeTracker.Track(child, EntityState.Unchanged, childMap);

--- a/src/nORM/Scaffolding/DatabaseScaffolder.cs
+++ b/src/nORM/Scaffolding/DatabaseScaffolder.cs
@@ -29,7 +29,7 @@ namespace nORM.Scaffolding
         public static async Task ScaffoldAsync(DbConnection connection, DatabaseProvider provider, string outputDirectory, string namespaceName, string contextName = "AppDbContext")
         {
             if (connection.State != ConnectionState.Open)
-                await connection.OpenAsync();
+                await connection.OpenAsync().ConfigureAwait(false);
 
             Directory.CreateDirectory(outputDirectory);
             var tables = connection.GetSchema("Tables");
@@ -45,7 +45,7 @@ namespace nORM.Scaffolding
                 var entityName = ToPascalCase(tableName);
                 entityNames.Add(entityName);
 
-                var entityCode = await ScaffoldEntityAsync(connection, provider, tableName, entityName, namespaceName);
+                var entityCode = await ScaffoldEntityAsync(connection, provider, tableName, entityName, namespaceName).ConfigureAwait(false);
                 File.WriteAllText(Path.Combine(outputDirectory, entityName + ".cs"), entityCode);
             }
 
@@ -68,7 +68,7 @@ namespace nORM.Scaffolding
 
             await using var cmd = connection.CreateCommand();
             cmd.CommandText = $"SELECT * FROM {provider.Escape(tableName)} WHERE 1=0";
-            await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SchemaOnly | CommandBehavior.KeyInfo);
+            await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SchemaOnly | CommandBehavior.KeyInfo).ConfigureAwait(false);
             var schema = reader.GetSchemaTable()!;
             foreach (DataRow row in schema.Rows)
             {


### PR DESCRIPTION
## Summary
- Use ConfigureAwait(false) on internal asynchronous operations to avoid context deadlocks
- Apply consistent ConfigureAwait usage across DbContext, connection management, and providers

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c4efeb28832cacfe032f099630c7