### PR TITLE
Handle foreign keys when recreating tables in SQLite migrations

### DIFF
--- a/src/nORM/Migration/SqliteMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/SqliteMigrationSqlGenerator.cs
@@ -53,10 +53,12 @@ namespace nORM.Migration
                     .Select(c => $"\"{c.Name}\" {GetSqlType(c)} {(c.IsNullable ? "NULL" : "NOT NULL")}");
                 var remainingNames = remainingColumns.Select(c => $"\"{c.Name}\"").ToArray();
 
+                down.Add("PRAGMA foreign_keys=off");
                 down.Add($"CREATE TABLE \"__temp__{table.Name}\" ({string.Join(", ", remainingDefs)})");
                 down.Add($"INSERT INTO \"__temp__{table.Name}\" ({string.Join(", ", remainingNames)}) SELECT {string.Join(", ", remainingNames)} FROM \"{table.Name}\"");
                 down.Add($"DROP TABLE \"{table.Name}\"");
                 down.Add($"ALTER TABLE \"__temp__{table.Name}\" RENAME TO \"{table.Name}\"");
+                down.Add("PRAGMA foreign_keys=on");
             }
 
             foreach (var (table, newCol, oldCol) in diff.AlteredColumns)

--- a/tests/SqliteMigrationSqlGeneratorTests.cs
+++ b/tests/SqliteMigrationSqlGeneratorTests.cs
@@ -1,0 +1,31 @@
+using nORM.Migration;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class SqliteMigrationSqlGeneratorTests
+{
+    [Fact]
+    public void DownMigration_DisablesForeignKeys()
+    {
+        var table = new TableSchema
+        {
+            Name = "Blog",
+            Columns =
+            {
+                new ColumnSchema { Name = "Id", ClrType = typeof(int).FullName!, IsNullable = false },
+                new ColumnSchema { Name = "Content", ClrType = typeof(string).FullName!, IsNullable = true }
+            }
+        };
+
+        var diff = new SchemaDiff();
+        diff.AddedColumns.Add((table, table.Columns[1]));
+
+        var generator = new SqliteMigrationSqlGenerator();
+        var sql = generator.GenerateSql(diff);
+
+        Assert.Equal("PRAGMA foreign_keys=off", sql.Down[0]);
+        Assert.Equal("PRAGMA foreign_keys=on", sql.Down[^1]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- disable foreign key constraints when dropping columns via table recreation
- add regression test for foreign key toggling in SQLite migration generator

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b9caba2ae0832ca581f9408f1e74b9