### PR TITLE
feat: add SQL support for compile-time queries

### DIFF
--- a/src/SourceGeneration/CompileTimeQueryAttribute.cs
+++ b/src/SourceGeneration/CompileTimeQueryAttribute.cs
@@ -4,14 +4,19 @@ namespace nORM.SourceGeneration
 {
     /// <summary>
     /// Indicates that a method should be populated by the source generator with
-    /// a pre-compiled query for the specified entity type.
+    /// a pre-compiled query using the provided SQL statement.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
     public sealed class CompileTimeQueryAttribute : Attribute
     {
-        /// <summary>The entity type that the generated query should materialize.</summary>
-        public Type EntityType { get; }
+        /// <summary>The SQL query to execute at runtime.</summary>
+        public string Sql { get; }
 
-        public CompileTimeQueryAttribute(Type entityType) => EntityType = entityType;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompileTimeQueryAttribute"/> class
+        /// with the SQL query to execute.
+        /// </summary>
+        /// <param name="sql">The SQL command text.</param>
+        public CompileTimeQueryAttribute(string sql) => Sql = sql;
     }
 }


### PR DESCRIPTION
## Summary
- allow `[CompileTimeQuery]` to accept a SQL string
- generate query implementations that add `DbParameter` instances for method parameters

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ba61a6c480832c9f44975aa1978875