### PR TITLE
Add streaming support for stored procedures

### DIFF
--- a/tests/StoredProcedureAsyncEnumerableTests.cs
+++ b/tests/StoredProcedureAsyncEnumerableTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using nORM.Core;
+using nORM.Providers;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class StoredProcedureAsyncEnumerableTests
+{
+    public class Person
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public async Task ExecuteStoredProcedureAsAsyncEnumerable_streams_results()
+    {
+        using var cn = new SqliteConnection("Data Source=:memory:");
+        cn.Open();
+        using (var cmd = cn.CreateCommand())
+        {
+            cmd.CommandText = "CREATE TABLE Person(Id INTEGER, Name TEXT);" +
+                             "INSERT INTO Person VALUES(1,'Alice');" +
+                             "INSERT INTO Person VALUES(2,'Bob');";
+            cmd.ExecuteNonQuery();
+        }
+        using var ctx = new DbContext(cn, new SqliteProvider());
+        var results = new List<Person>();
+        await foreach (var p in ctx.ExecuteStoredProcedureAsAsyncEnumerable<Person>("SELECT Id, Name FROM Person ORDER BY Id"))
+        {
+            results.Add(p);
+        }
+        Assert.Equal(2, results.Count);
+        Assert.Equal("Alice", results[0].Name);
+        Assert.Equal("Bob", results[1].Name);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ExecuteStoredProcedureAsAsyncEnumerable` to stream stored procedure results
- add test covering streaming behavior

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ba6690e4b0832ca2e1dcd9d483b4b9