### PR TITLE
Fix thread safety in cache implementations

### DIFF
--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -18,7 +18,7 @@ namespace nORM.Providers
 {
     public abstract class DatabaseProvider
     {
-        private static readonly ConcurrentLruCache<(Type Type, string Operation), string> _sqlCache = new(maxSize: 1000);
+        private readonly ConcurrentLruCache<(Type Type, string Operation), string> _sqlCache = new(maxSize: 1000);
         protected static readonly DynamicBatchSizer BatchSizer = new();
         
         public string ParamPrefix { get; protected init; } = "@";


### PR DESCRIPTION
## Summary
- replace static MemoryCache plan cache with thread-safe ConcurrentDictionary
- scope SQL cache to DatabaseProvider instances to avoid cross-thread issues

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ba6aa7c39c832ca026c1ea9d5a0358