### PR TITLE
Add null checks in QueryTranslator to prevent null references

### DIFF
--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -167,6 +167,10 @@ namespace nORM.Query
 
         public QueryPlan Translate(Expression e)
         {
+            if (e == null) throw new ArgumentNullException(nameof(e));
+            if (_ctx == null) throw new InvalidOperationException("QueryTranslator not properly initialized");
+            if (_provider == null) throw new InvalidOperationException("Provider not set");
+
             // Analyze query complexity before translation
             var complexityInfo = QueryComplexityAnalyzer.AnalyzeQuery(e);
 
@@ -293,7 +297,8 @@ namespace nORM.Query
 
         private TableMapping TrackMapping(Type type)
         {
-            var map = _ctx.GetMapping(type);
+            if (type == null) throw new ArgumentNullException(nameof(type));
+            var map = _ctx?.GetMapping(type) ?? throw new InvalidOperationException("Context not available");
             _tables.Add(map.TableName);
             return map;
         }


### PR DESCRIPTION
## Summary
- validate input expression, context, and provider before translation
- guard TrackMapping against null arguments and missing context

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6d527c40832c9bc0290303ce5d90