### PR TITLE
Ensure child components dispose with context

### DIFF
--- a/src/nORM/Navigation/BatchedNavigationLoader.cs
+++ b/src/nORM/Navigation/BatchedNavigationLoader.cs
@@ -21,6 +21,7 @@ namespace nORM.Navigation
         {
             _context = context;
             _batchTimer = new Timer(ProcessBatch, null, TimeSpan.FromMilliseconds(10), TimeSpan.FromMilliseconds(10));
+            _context.RegisterForDisposal(this);
         }
 
         public async Task<List<object>> LoadNavigationAsync(object entity, string propertyName, CancellationToken ct = default)


### PR DESCRIPTION
## Summary
- Manage dependent disposables inside `DbContext` with reverse-order cleanup and error logging
- Allow components to register for disposal and have `BatchedNavigationLoader` auto-registered

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ba76094f6c832ca8ebcca9ecad5402