### PR TITLE
Fix concurrent enumeration in ChangeTracker

### DIFF
--- a/src/nORM/Core/ChangeTracker.cs
+++ b/src/nORM/Core/ChangeTracker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using nORM.Configuration;
 using nORM.Mapping;
 using RefComparer = System.Collections.Generic.ReferenceEqualityComparer;
@@ -64,9 +65,13 @@ namespace nORM.Core
 
         internal void DetectChanges()
         {
-            foreach (var entry in _entriesByReference.Values)
+            var entriesSnapshot = _entriesByReference.Values.ToList();
+            foreach (var entry in entriesSnapshot)
             {
-                entry.DetectChanges();
+                if (_entriesByReference.ContainsKey(entry.Entity))
+                {
+                    entry.DetectChanges();
+                }
             }
         }
 

--- a/src/nORM/Core/EntityEntry.cs
+++ b/src/nORM/Core/EntityEntry.cs
@@ -69,7 +69,7 @@ namespace nORM.Core
 
         internal void DetectChanges()
         {
-            if (State is EntityState.Added or EntityState.Deleted) return;
+            if (State is EntityState.Added or EntityState.Deleted or EntityState.Detached) return;
             if (_hasNotifiedChange) return;
 
             var hasChanges = false;


### PR DESCRIPTION
## Summary
- protect ChangeTracker.DetectChanges from collection modification by iterating over snapshot and verifying entries remain tracked
- avoid change detection on detached entities

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7c518ca0832c84c4dddc39cb92f4