### PR TITLE
Ensure tenant-aware cache keys

### DIFF
--- a/src/nORM/Configuration/DbContextOptions.cs
+++ b/src/nORM/Configuration/DbContextOptions.cs
@@ -50,7 +50,7 @@ namespace nORM.Configuration
 
         public DbContextOptions UseInMemoryCache()
         {
-            this.CacheProvider = new NormMemoryCacheProvider();
+            this.CacheProvider = new NormMemoryCacheProvider(() => this.TenantProvider?.GetCurrentTenantId());
             return this;
         }
 

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -271,13 +271,21 @@ namespace nORM.Query
             var hash = new HashCode();
             hash.Add(plan.Sql);
             hash.Add(typeof(TResult));
+
+            var tenant = _ctx.Options.TenantProvider?.GetCurrentTenantId();
+            if (_ctx.Options.TenantProvider != null)
+            {
+                if (tenant == null)
+                    throw new InvalidOperationException("Tenant context required but not available");
+                hash.Add("TENANT:" + tenant.ToString());
+            }
+
             foreach (var kvp in parameters.OrderBy(k => k.Key))
             {
                 hash.Add(kvp.Key);
                 hash.Add(kvp.Value?.GetHashCode() ?? 0);
             }
-            var tenant = _ctx.Options.TenantProvider?.GetCurrentTenantId();
-            if (tenant != null) hash.Add(tenant);
+
             return hash.ToHashCode().ToString();
         }
 
@@ -404,13 +412,21 @@ namespace nORM.Query
             var hash = new HashCode();
             hash.Add(ExpressionFingerprint.Compute(expression));
             hash.Add(typeof(TResult));
+
+            var tenant = _ctx.Options.TenantProvider?.GetCurrentTenantId();
+            if (_ctx.Options.TenantProvider != null)
+            {
+                if (tenant == null)
+                    throw new InvalidOperationException("Tenant context required but not available");
+                hash.Add("TENANT:" + tenant.ToString());
+            }
+
             foreach (var kvp in parameters.OrderBy(k => k.Key))
             {
                 hash.Add(kvp.Key);
                 hash.Add(kvp.Value?.GetHashCode() ?? 0);
             }
-            var tenant = _ctx.Options.TenantProvider?.GetCurrentTenantId();
-            if (tenant != null) hash.Add(tenant);
+
             return hash.ToHashCode().ToString();
         }
 


### PR DESCRIPTION
## Summary
- enforce tenant isolation when generating query cache keys
- scope memory cache tags to the current tenant
- wire tenant provider into in-memory cache configuration

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ba8351bb10832cba5ddac5cf585441