### PR TITLE
Add safeguards for expression compilation

### DIFF
--- a/src/nORM/Core/Norm.cs
+++ b/src/nORM/Core/Norm.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using nORM.Internal;
 using nORM.Query;
@@ -18,6 +19,50 @@ namespace nORM.Core
         {
             if (queryExpression == null) throw new ArgumentNullException(nameof(queryExpression));
 
+            ExpressionUtils.ValidateExpression(queryExpression);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            return CompileWithTimeout<TContext, TParam, T>(queryExpression, cts.Token);
+        }
+
+        private static Func<TContext, TParam, Task<List<T>>> CompileWithTimeout<TContext, TParam, T>(Expression<Func<TContext, TParam, IQueryable<T>>> queryExpression, CancellationToken token)
+            where TContext : DbContext
+            where T : class
+        {
+            Func<TContext, TParam, Task<List<T>>>? result = null;
+            Exception? compileException = null;
+
+            var task = Task.Run(() =>
+            {
+                try
+                {
+                    result = CompileQueryInternal<TContext, TParam, T>(queryExpression);
+                }
+                catch (Exception ex)
+                {
+                    compileException = ex;
+                }
+            }, token);
+
+            try
+            {
+                task.Wait(token);
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new TimeoutException("Expression compilation timed out", ex);
+            }
+
+            if (compileException != null)
+                throw compileException;
+
+            return result!;
+        }
+
+        private static Func<TContext, TParam, Task<List<T>>> CompileQueryInternal<TContext, TParam, T>(Expression<Func<TContext, TParam, IQueryable<T>>> queryExpression)
+            where TContext : DbContext
+            where T : class
+        {
             QueryPlan? cachedPlan = null;
             IReadOnlyList<string>? paramNames = null;
 
@@ -49,7 +94,10 @@ namespace nORM.Core
             {
                 if (node.Method.DeclaringType == typeof(NormQueryable) && node.Method.Name == "Query")
                 {
-                    var result = Expression.Lambda(node).Compile().DynamicInvoke();
+                    ExpressionUtils.ValidateExpression(node);
+                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                    var del = ExpressionUtils.CompileWithTimeout(Expression.Lambda(node), cts.Token);
+                    var result = del.DynamicInvoke();
                     return Expression.Constant(result, node.Type);
                 }
                 return base.VisitMethodCall(node);

--- a/src/nORM/Internal/ExpressionUtils.cs
+++ b/src/nORM/Internal/ExpressionUtils.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace nORM.Internal
+{
+    internal static class ExpressionUtils
+    {
+        private const int MaxNodeCount = 10000;
+        private const int MaxDepth = 100;
+
+        internal sealed class Complexity
+        {
+            public int NodeCount { get; init; }
+            public int Depth { get; init; }
+        }
+
+        public static Complexity AnalyzeExpressionComplexity(Expression expression)
+        {
+            var visitor = new ComplexityVisitor();
+            visitor.Visit(expression);
+            return new Complexity { NodeCount = visitor.NodeCount, Depth = visitor.MaxDepth };
+        }
+
+        public static void ValidateExpression(Expression expression)
+        {
+            var complexity = AnalyzeExpressionComplexity(expression);
+            if (complexity.NodeCount > MaxNodeCount)
+                throw new InvalidOperationException($"Expression too complex: {complexity.NodeCount} nodes");
+            if (complexity.Depth > MaxDepth)
+                throw new InvalidOperationException($"Expression too deep: {complexity.Depth} levels");
+        }
+
+        public static TDelegate CompileWithTimeout<TDelegate>(Expression<TDelegate> expression, CancellationToken token)
+        {
+            var task = Task.Run(() => expression.Compile(), token);
+            try
+            {
+                task.Wait(token);
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new TimeoutException("Expression compilation timed out", ex);
+            }
+            return task.Result;
+        }
+
+        public static Delegate CompileWithTimeout(LambdaExpression expression, CancellationToken token)
+        {
+            var task = Task.Run(expression.Compile, token);
+            try
+            {
+                task.Wait(token);
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new TimeoutException("Expression compilation timed out", ex);
+            }
+            return task.Result;
+        }
+
+        private sealed class ComplexityVisitor : ExpressionVisitor
+        {
+            public int NodeCount { get; private set; }
+            public int MaxDepth { get; private set; }
+            private int _currentDepth;
+
+            public override Expression? Visit(Expression? node)
+            {
+                if (node == null)
+                    return null;
+                NodeCount++;
+                _currentDepth++;
+                if (_currentDepth > MaxDepth)
+                    MaxDepth = _currentDepth;
+                var result = base.Visit(node);
+                _currentDepth--;
+                return result;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- validate expression tree complexity before compiling queries
- enforce timeouts when compiling expressions to avoid resource exhaustion
- provide shared utilities for complexity analysis and timed compilation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ba8b1b3f3c832ca49d1598e5757e93