### PR TITLE
Mask connection string data in errors

### DIFF
--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -81,8 +81,21 @@ namespace nORM.Core
         }
 
         public DbContext(string connectionString, DatabaseProvider p, DbContextOptions? options = null)
-            : this(CreateConnection(connectionString, p), p, options)
+            : this(CreateConnectionSafe(connectionString, p), p, options)
         {
+        }
+
+        private static DbConnection CreateConnectionSafe(string connectionString, DatabaseProvider provider)
+        {
+            try
+            {
+                return CreateConnection(connectionString, provider);
+            }
+            catch (Exception ex)
+            {
+                var safeConnStr = NormValidator.MaskSensitiveConnectionStringData(connectionString);
+                throw new ArgumentException($"Invalid connection string format: {safeConnStr}", nameof(connectionString), ex);
+            }
         }
 
         private static DbConnection CreateConnection(string connectionString, DatabaseProvider provider)

--- a/src/nORM/Core/NormValidator.cs
+++ b/src/nORM/Core/NormValidator.cs
@@ -153,7 +153,25 @@ namespace nORM.Core
             }
             catch (Exception ex)
             {
-                throw new ArgumentException("Invalid connection string format", ex);
+                var safeConnStr = MaskSensitiveConnectionStringData(connectionString);
+                throw new ArgumentException($"Invalid connection string format: {safeConnStr}", ex);
+            }
+        }
+
+        internal static string MaskSensitiveConnectionStringData(string connectionString)
+        {
+            var builder = new DbConnectionStringBuilder();
+            try
+            {
+                builder.ConnectionString = connectionString;
+                if (builder.ContainsKey("Password")) builder["Password"] = "***";
+                if (builder.ContainsKey("Pwd")) builder["Pwd"] = "***";
+                if (builder.ContainsKey("User Password")) builder["User Password"] = "***";
+                return builder.ConnectionString;
+            }
+            catch
+            {
+                return "[INVALID_CONNECTION_STRING]";
             }
         }
 

--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -52,7 +52,10 @@ namespace nORM.Providers
         protected virtual void ValidateConnection(DbConnection connection)
         {
             if (connection.State != ConnectionState.Open)
-                throw new InvalidOperationException($"Connection must be open for {GetType().Name}");
+            {
+                var safeConnStr = NormValidator.MaskSensitiveConnectionStringData(connection.ConnectionString);
+                throw new InvalidOperationException($"Connection must be open for {GetType().Name}. Connection: {safeConnStr}");
+            }
         }
 
         protected void EnsureValidParameterName(string? parameterName, string argumentName)


### PR DESCRIPTION
## Summary
- mask sensitive connection string details in validation errors
- guard DbContext and providers from leaking raw connection strings

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ba9ca31e98832ca3fdf1a1f023a8d9