### PR TITLE
Add basic raw SQL injection guard

### DIFF
--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -670,6 +670,9 @@ namespace nORM.Core
                     paramDict[pName] = parameters[i];
                 }
 
+                if (!NormValidator.IsSafeRawSql(sql))
+                    throw new NormUsageException("Potential SQL injection detected in raw query.");
+
                 NormValidator.ValidateRawSql(sql, paramDict);
 
                 var props = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
@@ -724,6 +727,9 @@ namespace nORM.Core
                     paramDict[pName] = parameters[i];
                 }
 
+                if (!NormValidator.IsSafeRawSql(sql))
+                    throw new NormUsageException("Potential SQL injection detected in raw query.");
+
                 NormValidator.ValidateRawSql(sql, paramDict);
 
                 var materializer = global::nORM.Query.QueryTranslator.Rent(this).CreateMaterializer(GetMapping(typeof(T)), typeof(T));
@@ -756,6 +762,9 @@ namespace nORM.Core
                     }
                 }
 
+                if (!NormValidator.IsSafeRawSql(procedureName))
+                    throw new NormUsageException("Potential SQL injection detected in raw query.");
+
                 NormValidator.ValidateRawSql(procedureName, paramDict);
 
                 var materializer = global::nORM.Query.QueryTranslator.Rent(this).CreateMaterializer(GetMapping(typeof(T)), typeof(T));
@@ -786,6 +795,9 @@ namespace nORM.Core
                     paramDict[pName] = pValue ?? DBNull.Value;
                 }
             }
+
+            if (!NormValidator.IsSafeRawSql(procedureName))
+                throw new NormUsageException("Potential SQL injection detected in raw query.");
 
             NormValidator.ValidateRawSql(procedureName, paramDict);
 
@@ -835,6 +847,9 @@ namespace nORM.Core
                     cmd.Parameters.Add(p);
                     outputParamMap[op.Name] = p;
                 }
+
+                if (!NormValidator.IsSafeRawSql(procedureName))
+                    throw new NormUsageException("Potential SQL injection detected in raw query.");
 
                 NormValidator.ValidateRawSql(procedureName, paramDict);
 

--- a/src/nORM/Core/NormValidator.cs
+++ b/src/nORM/Core/NormValidator.cs
@@ -129,6 +129,19 @@ namespace nORM.Core
                 throw new ArgumentException($"Parameter count {parameters.Count} exceeds maximum of {MaxParameterCount}");
         }
 
+        internal static bool IsSafeRawSql(string sql)
+        {
+            if (string.IsNullOrWhiteSpace(sql))
+                return false;
+
+            var lowerSql = sql.ToLowerInvariant();
+            if (lowerSql.Contains("drop ") || lowerSql.Contains("alter ") ||
+                lowerSql.Contains("truncate ") || lowerSql.Contains("exec "))
+                return false;
+
+            return true;
+        }
+
         public static void ValidateConnectionString(string connectionString, string provider)
         {
             if (string.IsNullOrWhiteSpace(connectionString))


### PR DESCRIPTION
## Summary
- add simple IsSafeRawSql heuristic to detect obviously dangerous statements
- enforce safety check before executing raw SQL queries or stored procedures

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ba9dd27628832ca3953f7a6295857c