### PR TITLE
Limit materializer cache size

### DIFF
--- a/src/SourceGeneration/CompiledMaterializerStore.cs
+++ b/src/SourceGeneration/CompiledMaterializerStore.cs
@@ -1,24 +1,25 @@
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using nORM.Internal;
 
 namespace nORM.SourceGeneration
 {
     public static class CompiledMaterializerStore
     {
-        private static readonly ConcurrentDictionary<Type, (Delegate Typed, Func<DbDataReader, CancellationToken, Task<object>> Untyped)> _map = new();
+        private static readonly ConcurrentLruCache<Type, (Delegate Typed, Func<DbDataReader, CancellationToken, Task<object>> Untyped)> _map = new(maxSize: 500);
 
         public static void Add(Type type, Func<DbDataReader, object> materializer)
-            => _map[type] = (materializer, (reader, ct) => Task.FromResult(materializer(reader)));
+            => _map.GetOrAdd(type, _ => (materializer, (reader, ct) => Task.FromResult(materializer(reader))));
 
         public static void Add<T>(Func<DbDataReader, T> materializer)
-            => _map[typeof(T)] = (materializer, (reader, ct) => Task.FromResult((object)materializer(reader)!));
+            => _map.GetOrAdd(typeof(T), _ => (materializer, (reader, ct) => Task.FromResult((object)materializer(reader)!)));
 
         public static bool TryGet(Type type, out Func<DbDataReader, CancellationToken, Task<object>> materializer)
         {
-            if (_map.TryGetValue(type, out var entry))
+            if (_map.TryGet(type, out var entry))
             {
                 materializer = entry.Untyped;
                 return true;
@@ -28,6 +29,10 @@ namespace nORM.SourceGeneration
         }
 
         public static Func<DbDataReader, CancellationToken, Task<T>> Get<T>()
-            => (reader, ct) => Task.FromResult(((Func<DbDataReader, T>)_map[typeof(T)].Typed)(reader));
+        {
+            if (!_map.TryGet(typeof(T), out var entry))
+                throw new KeyNotFoundException($"Materializer for {typeof(T)} not found.");
+            return (reader, ct) => Task.FromResult(((Func<DbDataReader, T>)entry.Typed)(reader));
+        }
     }
 }

--- a/src/nORM/Internal/ConcurrentLruCache.cs
+++ b/src/nORM/Internal/ConcurrentLruCache.cs
@@ -66,6 +66,25 @@ namespace nORM.Internal
             }
         }
 
+        public bool TryGet(TKey key, out TValue value)
+        {
+            if (_cache.TryGetValue(key, out var existingNode))
+            {
+                lock (_lock)
+                {
+                    if (existingNode.List != null)
+                    {
+                        _lruList.Remove(existingNode);
+                        _lruList.AddFirst(existingNode);
+                        value = existingNode.Value.Value;
+                        return true;
+                    }
+                }
+            }
+            value = default!;
+            return false;
+        }
+
         private record CacheItem(TKey Key, TValue Value);
     }
 }


### PR DESCRIPTION
## Summary
- Avoid unbounded growth in compiled materializer cache by using a bounded ConcurrentLruCache (max 500 entries)
- Add lookup helper to ConcurrentLruCache to support non-allocating TryGet

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68baa3a0473c832c96543ed0d69c2faa