### PR TITLE
Add base DB command interceptor with logging

### DIFF
--- a/src/nORM/Enterprise/IDbCommandInterceptor.cs
+++ b/src/nORM/Enterprise/IDbCommandInterceptor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using nORM.Core;
 
 #nullable enable
@@ -51,5 +52,70 @@ namespace nORM.Enterprise
         /// Called when execution of a command results in an exception.
         /// </summary>
         Task CommandFailedAsync(DbCommand command, DbContext context, Exception exception, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Base implementation of <see cref="IDbCommandInterceptor"/> that logs command execution.
+    /// </summary>
+    public abstract class BaseDbCommandInterceptor : IDbCommandInterceptor
+    {
+        /// <summary>
+        /// Logger used to emit diagnostic messages for command execution.
+        /// </summary>
+        protected ILogger Logger { get; }
+
+        protected BaseDbCommandInterceptor(ILogger logger)
+        {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <inheritdoc />
+        public virtual Task<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, DbContext context, CancellationToken cancellationToken)
+        {
+            Logger.LogInformation("Executing non-query: {CommandText}", command.CommandText);
+            return Task.FromResult(InterceptionResult<int>.Continue());
+        }
+
+        /// <inheritdoc />
+        public virtual Task NonQueryExecutedAsync(DbCommand command, DbContext context, int result, TimeSpan duration, CancellationToken cancellationToken)
+        {
+            Logger.LogInformation("Executed non-query in {Duration}ms, affected {Result} rows", duration.TotalMilliseconds, result);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public virtual Task<InterceptionResult<object?>> ScalarExecutingAsync(DbCommand command, DbContext context, CancellationToken cancellationToken)
+        {
+            Logger.LogInformation("Executing scalar: {CommandText}", command.CommandText);
+            return Task.FromResult(InterceptionResult<object?>.Continue());
+        }
+
+        /// <inheritdoc />
+        public virtual Task ScalarExecutedAsync(DbCommand command, DbContext context, object? result, TimeSpan duration, CancellationToken cancellationToken)
+        {
+            Logger.LogInformation("Executed scalar in {Duration}ms, result {Result}", duration.TotalMilliseconds, result);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public virtual Task<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, DbContext context, CancellationToken cancellationToken)
+        {
+            Logger.LogInformation("Executing reader: {CommandText}", command.CommandText);
+            return Task.FromResult(InterceptionResult<DbDataReader>.Continue());
+        }
+
+        /// <inheritdoc />
+        public virtual Task ReaderExecutedAsync(DbCommand command, DbContext context, DbDataReader reader, TimeSpan duration, CancellationToken cancellationToken)
+        {
+            Logger.LogInformation("Executed reader in {Duration}ms", duration.TotalMilliseconds);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public virtual Task CommandFailedAsync(DbCommand command, DbContext context, Exception exception, CancellationToken cancellationToken)
+        {
+            Logger.LogError(exception, "Command failed: {CommandText}", command.CommandText);
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add BaseDbCommandInterceptor to provide default logging for command execution

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bab19519a0832cb3b7916e82b5be59