### PR TITLE
Validate DDL in TemporalManager

### DIFF
--- a/src/nORM/Versioning/TemporalManager.cs
+++ b/src/nORM/Versioning/TemporalManager.cs
@@ -62,6 +62,9 @@ namespace nORM.Versioning
                 var trimmed = batch.Trim();
                 if (trimmed.Length == 0) continue;
 
+                if (!IsValidDdl(trimmed))
+                    throw new NormQueryException($"Invalid DDL: {trimmed}");
+
                 await handler.ExecuteWithExceptionHandling(async () =>
                 {
                     await using var cmd = (await context.EnsureConnectionAsync().ConfigureAwait(false)).CreateCommand();
@@ -70,6 +73,12 @@ namespace nORM.Versioning
                     return 0;
                 }, "ExecuteDdlAsync", new Dictionary<string, object> { ["Sql"] = trimmed }).ConfigureAwait(false);
             }
+        }
+
+        private static bool IsValidDdl(string ddl)
+        {
+            var lower = ddl.ToLowerInvariant();
+            return lower.StartsWith("create") || lower.StartsWith("alter") || lower.StartsWith("drop");
         }
     }
 }


### PR DESCRIPTION
## Summary
- validate DDL batches in TemporalManager before executing
- add IsValidDdl helper to restrict commands to CREATE, ALTER, or DROP

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bab2b5307c832cb02794dc8f21b579