### PR TITLE
Validate LIKE escape character to prevent SQL injection

### DIFF
--- a/src/nORM/Core/NormValidator.cs
+++ b/src/nORM/Core/NormValidator.cs
@@ -142,6 +142,16 @@ namespace nORM.Core
             return true;
         }
 
+        private static readonly HashSet<char> AllowedLikeEscapeChars = new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#$%&()*+,-./:;<=>?@[]^_{|}~\\");
+
+        public static char ValidateLikeEscapeChar(char escapeChar)
+        {
+            if (!AllowedLikeEscapeChars.Contains(escapeChar))
+                throw new ArgumentException($"Invalid LIKE escape character: {escapeChar}");
+
+            return escapeChar;
+        }
+
         public static void ValidateConnectionString(string connectionString, string provider)
         {
             if (string.IsNullOrWhiteSpace(connectionString))

--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -42,7 +42,7 @@ namespace nORM.Providers
 
         public virtual string EscapeLikePattern(string value)
         {
-            var esc = LikeEscapeChar.ToString();
+            var esc = NormValidator.ValidateLikeEscapeChar(LikeEscapeChar).ToString();
             return value
                 .Replace(esc, esc + esc)
                 .Replace("%", esc + "%")

--- a/src/nORM/Query/ExpressionToSqlVisitor.cs
+++ b/src/nORM/Query/ExpressionToSqlVisitor.cs
@@ -251,8 +251,9 @@ namespace nORM.Query
                           if (TryGetConstantValue(node.Arguments[0], out var contains) && contains is string cs)
                           {
                               var containsParam = $"{_provider.ParamPrefix}p{_paramIndex++}";
+                              var escChar = NormValidator.ValidateLikeEscapeChar(_provider.LikeEscapeChar);
                               _sql.AppendParameterizedValue(containsParam, CreateSafeLikePattern(cs, LikeOperation.Contains), _params)
-                                  .Append($" ESCAPE '{_provider.LikeEscapeChar}'");
+                                  .Append($" ESCAPE '{escChar}'");
                           }
                           else
                           {
@@ -265,8 +266,9 @@ namespace nORM.Query
                           if (TryGetConstantValue(node.Arguments[0], out var starts) && starts is string ss)
                           {
                               var startsParam = $"{_provider.ParamPrefix}p{_paramIndex++}";
+                              var escChar = NormValidator.ValidateLikeEscapeChar(_provider.LikeEscapeChar);
                               _sql.AppendParameterizedValue(startsParam, CreateSafeLikePattern(ss, LikeOperation.StartsWith), _params)
-                                  .Append($" ESCAPE '{_provider.LikeEscapeChar}'");
+                                  .Append($" ESCAPE '{escChar}'");
                           }
                           else
                           {
@@ -279,8 +281,9 @@ namespace nORM.Query
                           if (TryGetConstantValue(node.Arguments[0], out var ends) && ends is string es)
                           {
                               var endsParam = $"{_provider.ParamPrefix}p{_paramIndex++}";
+                              var escChar = NormValidator.ValidateLikeEscapeChar(_provider.LikeEscapeChar);
                               _sql.AppendParameterizedValue(endsParam, CreateSafeLikePattern(es, LikeOperation.EndsWith), _params)
-                                  .Append($" ESCAPE '{_provider.LikeEscapeChar}'");
+                                  .Append($" ESCAPE '{escChar}'");
                           }
                           else
                           {
@@ -597,12 +600,7 @@ namespace nORM.Query
         {
             if (string.IsNullOrEmpty(value)) return string.Empty;
 
-            // Validate and double-escape
-            var escaped = value
-                .Replace("\\", "\\\\")  // Escape backslashes first
-                .Replace("%", "\\%")
-                .Replace("_", "\\_")
-                .Replace("[", "\\[");
+            var escaped = _provider.EscapeLikePattern(value);
 
             return operation switch
             {


### PR DESCRIPTION
## Summary
- Sanitize provider LIKE escape characters with whitelist validation
- Apply escape char validation when building LIKE clauses
- Use provider-specific escaping for generated LIKE patterns

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bab3d2a05c832c884e1b1cb6e40603