### PR TITLE
Avoid deadlock in ConnectionPool by using single lock

### DIFF
--- a/src/nORM/Core/ConnectionPool.cs
+++ b/src/nORM/Core/ConnectionPool.cs
@@ -16,7 +16,6 @@ namespace nORM.Core
         private readonly Func<DbConnection> _connectionFactory;
         private readonly ConcurrentQueue<PooledItem> _pool = new();
         private readonly object _poolLock = new();
-        private readonly object _returnLock = new();
         private readonly SemaphoreSlim _semaphore;
         private readonly Timer _cleanupTimer;
         private readonly int _minSize;
@@ -103,7 +102,7 @@ namespace nORM.Core
 
         private void Return(DbConnection connection)
         {
-            lock (_returnLock)
+            lock (_poolLock)
             {
                 if (_disposed)
                 {


### PR DESCRIPTION
## Summary
- prevent potential deadlocks by using only `_poolLock` for all connection pool operations

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bab955aa90832c88d3745adc850abd