### PR TITLE
Dispose thread-local QueryTranslator

### DIFF
--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -736,7 +736,8 @@ namespace nORM.Core
 
                 NormValidator.ValidateRawSql(sql, paramDict);
 
-                var materializer = global::nORM.Query.QueryTranslator.Rent(this).CreateMaterializer(GetMapping(typeof(T)), typeof(T));
+                using var translator = global::nORM.Query.QueryTranslator.Rent(this);
+                var materializer = translator.CreateMaterializer(GetMapping(typeof(T)), typeof(T));
                 var list = new List<T>();
                 await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(this, CommandBehavior.Default, token).ConfigureAwait(false);
                 while (await reader.ReadAsync(token).ConfigureAwait(false)) list.Add((T)await materializer(reader, token).ConfigureAwait(false));
@@ -771,7 +772,8 @@ namespace nORM.Core
 
                 NormValidator.ValidateRawSql(procedureName, paramDict);
 
-                var materializer = global::nORM.Query.QueryTranslator.Rent(this).CreateMaterializer(GetMapping(typeof(T)), typeof(T));
+                using var translator = global::nORM.Query.QueryTranslator.Rent(this);
+                var materializer = translator.CreateMaterializer(GetMapping(typeof(T)), typeof(T));
                 var list = new List<T>();
                 await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(this, CommandBehavior.Default, token).ConfigureAwait(false);
                 while (await reader.ReadAsync(token).ConfigureAwait(false)) list.Add((T)await materializer(reader, token).ConfigureAwait(false));
@@ -805,7 +807,8 @@ namespace nORM.Core
 
             NormValidator.ValidateRawSql(procedureName, paramDict);
 
-            var materializer = global::nORM.Query.QueryTranslator.Rent(this).CreateMaterializer(GetMapping(typeof(T)), typeof(T));
+            using var translator = global::nORM.Query.QueryTranslator.Rent(this);
+            var materializer = translator.CreateMaterializer(GetMapping(typeof(T)), typeof(T));
             var count = 0;
             await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(this, CommandBehavior.SequentialAccess, ct).ConfigureAwait(false);
             while (await reader.ReadAsync(ct).ConfigureAwait(false))
@@ -857,7 +860,8 @@ namespace nORM.Core
 
                 NormValidator.ValidateRawSql(procedureName, paramDict);
 
-                var materializer = global::nORM.Query.QueryTranslator.Rent(this).CreateMaterializer(GetMapping(typeof(T)), typeof(T));
+                using var translator = global::nORM.Query.QueryTranslator.Rent(this);
+                var materializer = translator.CreateMaterializer(GetMapping(typeof(T)), typeof(T));
                 var list = new List<T>();
                 await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(this, CommandBehavior.Default, token).ConfigureAwait(false);
                 while (await reader.ReadAsync(token).ConfigureAwait(false)) list.Add((T)await materializer(reader, token).ConfigureAwait(false));

--- a/src/nORM/Navigation/BatchedNavigationLoader.cs
+++ b/src/nORM/Navigation/BatchedNavigationLoader.cs
@@ -125,7 +125,8 @@ namespace nORM.Navigation
 
             cmd.CommandText = $"SELECT * FROM {mapping.EscTable} WHERE {relation.ForeignKey.EscCol} IN ({string.Join(",", paramNames)})";
 
-            var materializer = Query.QueryTranslator.Rent(_context).CreateMaterializer(mapping, relation.DependentType);
+            using var translator = Query.QueryTranslator.Rent(_context);
+            var materializer = translator.CreateMaterializer(mapping, relation.DependentType);
             var results = new List<object>();
 
             using var reader = await cmd.ExecuteReaderWithInterceptionAsync(_context, CommandBehavior.Default, default).ConfigureAwait(false);

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -402,7 +402,8 @@ namespace nORM.Navigation
                 _stringBuilderPool.Return(sb);
             }
 
-            var materializer = Query.QueryTranslator.Rent(context).CreateMaterializer(mapping, entityType);
+            using var translator = Query.QueryTranslator.Rent(context);
+            var materializer = translator.CreateMaterializer(mapping, entityType);
 
             using var reader = await cmd.ExecuteReaderWithInterceptionAsync(context, CommandBehavior.Default, ct).ConfigureAwait(false);
             if (await reader.ReadAsync(ct).ConfigureAwait(false))


### PR DESCRIPTION
## Summary
- reset thread-local QueryTranslator instances on dispose to prevent memory leaks
- wrap translator usage with `using` so instances are released

## Testing
- ⚠️ `dotnet test` *(dotnet CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68babd22a300832c954a62c107186e2a