### PR TITLE
fix: enforce IN clause parameter limits

### DIFF
--- a/src/nORM/Query/ExpressionToSqlVisitor.cs
+++ b/src/nORM/Query/ExpressionToSqlVisitor.cs
@@ -392,7 +392,12 @@ namespace nORM.Query
                         return node;
                     }
 
-                    var maxBatchSize = Math.Max(1, Math.Min(1000, _provider.MaxParameters - _paramIndex - 10));
+                    var remainingParams = _provider.MaxParameters - _paramIndex - 10;
+                    if (remainingParams <= 0 || items.Count > remainingParams)
+                        throw new NormQueryException(string.Format(ErrorMessages.QueryTranslationFailed,
+                            $"IN clause exceeds maximum parameter count of {remainingParams}"));
+
+                    var maxBatchSize = Math.Max(1, Math.Min(1000, remainingParams));
                     if (items.Count > maxBatchSize)
                     {
                         _sql.Append("(");


### PR DESCRIPTION
## Summary
- throw `NormQueryException` when `IN` values exceed provider parameter limits
- ensure batching uses remaining slots to prevent excessive parameters

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68babf2047ac832c85fea594156fe9e1