### PR TITLE
Add time-based eviction to materializer cache

### DIFF
--- a/src/nORM/Query/MaterializerFactory.cs
+++ b/src/nORM/Query/MaterializerFactory.cs
@@ -18,7 +18,11 @@ namespace nORM.Query
     /// </summary>
     internal sealed class MaterializerFactory
     {
-        private static readonly ConcurrentLruCache<(int MappingTypeHash, int TargetTypeHash, int ProjectionHash, string TableName), Func<DbDataReader, CancellationToken, Task<object>>> _cache = new(maxSize: 1000);
+        private static readonly ConcurrentLruCache<(int MappingTypeHash, int TargetTypeHash, int ProjectionHash, string TableName), Func<DbDataReader, CancellationToken, Task<object>>> _cache
+            = new(maxSize: 1000, timeToLive: TimeSpan.FromMinutes(10));
+
+        internal static (long Hits, long Misses, double HitRate) CacheStats
+            => (_cache.Hits, _cache.Misses, _cache.HitRate);
 
         public Func<DbDataReader, CancellationToken, Task<object>> CreateMaterializer(TableMapping mapping, Type targetType, LambdaExpression? projection = null)
         {

--- a/tests/ConcurrentLruCacheTests.cs
+++ b/tests/ConcurrentLruCacheTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using nORM.Internal;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class ConcurrentLruCacheTests
+{
+    [Fact]
+    public void Expired_entries_are_evicted()
+    {
+        var cache = new ConcurrentLruCache<int, string>(maxSize: 10, timeToLive: TimeSpan.FromMilliseconds(50));
+        cache.GetOrAdd(1, _ => "value");
+        Thread.Sleep(60);
+        Assert.False(cache.TryGet(1, out _));
+    }
+
+    [Fact]
+    public void Hit_rate_is_tracked()
+    {
+        var cache = new ConcurrentLruCache<int, string>(maxSize: 10, timeToLive: TimeSpan.FromMinutes(1));
+        cache.GetOrAdd(1, _ => "value");
+        cache.GetOrAdd(1, _ => "other");
+        Assert.Equal(1, cache.Hits);
+        Assert.Equal(1, cache.Misses);
+        Assert.Equal(0.5, cache.HitRate);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement TTL-based eviction and hit-rate tracking in ConcurrentLruCache
- use expiring cache in MaterializerFactory and expose cache metrics
- add unit tests for cache expiration and hit-rate tracking

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bac50fdfc8832cb1052b096477cbef