### PR TITLE
feat: adapt expression compile timeout

### DIFF
--- a/src/nORM/Core/Norm.cs
+++ b/src/nORM/Core/Norm.cs
@@ -21,7 +21,8 @@ namespace nORM.Core
 
             ExpressionUtils.ValidateExpression(queryExpression);
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var timeout = ExpressionUtils.GetCompilationTimeout(queryExpression);
+            using var cts = new CancellationTokenSource(timeout);
             return CompileWithTimeout<TContext, TParam, T>(queryExpression, cts.Token);
         }
 
@@ -95,7 +96,8 @@ namespace nORM.Core
                 if (node.Method.DeclaringType == typeof(NormQueryable) && node.Method.Name == "Query")
                 {
                     ExpressionUtils.ValidateExpression(node);
-                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                    var timeout = ExpressionUtils.GetCompilationTimeout(node);
+                    using var cts = new CancellationTokenSource(timeout);
                     var del = ExpressionUtils.CompileWithTimeout(Expression.Lambda(node), cts.Token);
                     var result = del.DynamicInvoke();
                     return Expression.Constant(result, node.Type);

--- a/src/nORM/Internal/ExpressionUtils.cs
+++ b/src/nORM/Internal/ExpressionUtils.cs
@@ -32,6 +32,15 @@ namespace nORM.Internal
                 throw new InvalidOperationException($"Expression too deep: {complexity.Depth} levels");
         }
 
+        public static TimeSpan GetCompilationTimeout(Expression expression)
+        {
+            var complexity = AnalyzeExpressionComplexity(expression);
+            var multiplier = Math.Max(1, Math.Max(complexity.NodeCount / 1000, complexity.Depth / 10));
+            var timeout = TimeSpan.FromSeconds(30 * multiplier);
+            var maxTimeout = TimeSpan.FromMinutes(5);
+            return timeout > maxTimeout ? maxTimeout : timeout;
+        }
+
         public static TDelegate CompileWithTimeout<TDelegate>(Expression<TDelegate> expression, CancellationToken token)
         {
             var task = Task.Run(() => expression.Compile(), token);

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -1323,7 +1323,8 @@ namespace nORM.Query
             var lambda = Expression.Lambda<Func<object, object>>(convertBody, objParam);
 
             ExpressionUtils.ValidateExpression(lambda);
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var timeout = ExpressionUtils.GetCompilationTimeout(lambda);
+            using var cts = new CancellationTokenSource(timeout);
             var invoker = ExpressionUtils.CompileWithTimeout(lambda, cts.Token);
 
             return obj =>
@@ -1362,7 +1363,8 @@ namespace nORM.Query
 
             var lambda = Expression.Lambda<Func<object, IEnumerable<object>, object>>(body, outerParam, innerParam);
             ExpressionUtils.ValidateExpression(lambda);
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var timeout = ExpressionUtils.GetCompilationTimeout(lambda);
+            using var cts = new CancellationTokenSource(timeout);
             return ExpressionUtils.CompileWithTimeout(lambda, cts.Token);
         }
 


### PR DESCRIPTION
## Summary
- scale expression compilation timeout according to tree complexity
- use adaptive compilation timeout in Norm and query translator

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bacab86838832c8c7401973cf1afe2