### PR TITLE
Handle null tracked entities

### DIFF
--- a/src/nORM/Core/ChangeTracker.cs
+++ b/src/nORM/Core/ChangeTracker.cs
@@ -94,7 +94,8 @@ namespace nORM.Core
             var entriesSnapshot = _entriesByReference.Values.ToList();
             foreach (var entry in entriesSnapshot)
             {
-                if (_entriesByReference.ContainsKey(entry.Entity))
+                var entity = entry.Entity;
+                if (entity != null && _entriesByReference.ContainsKey(entity))
                 {
                     entry.DetectChanges();
                 }

--- a/src/nORM/Navigation/BatchedNavigationLoader.cs
+++ b/src/nORM/Navigation/BatchedNavigationLoader.cs
@@ -134,7 +134,7 @@ namespace nORM.Navigation
             {
                 var entity = await materializer(reader, default).ConfigureAwait(false);
                 var entry = _context.ChangeTracker.Track(entity, EntityState.Unchanged, mapping);
-                entity = entry.Entity;
+                entity = entry.Entity!;
                 NavigationPropertyExtensions._navigationContexts.GetValue(entity, _ => new NavigationContext(_context, relation.DependentType));
                 results.Add(entity);
             }

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -410,7 +410,7 @@ namespace nORM.Navigation
             {
                 var entity = await materializer(reader, ct).ConfigureAwait(false);
                 var entry = context.ChangeTracker.Track(entity, EntityState.Unchanged, mapping);
-                entity = entry.Entity;
+                entity = entry.Entity!;
                 // Enable lazy loading for the loaded entity
                 _navigationContexts.GetValue(entity, _ => new NavigationContext(context, entityType));
                 return entity;

--- a/src/nORM/Query/IncludeProcessor.cs
+++ b/src/nORM/Query/IncludeProcessor.cs
@@ -62,7 +62,7 @@ namespace nORM.Query
                     if (!noTracking)
                     {
                         var entry = _ctx.ChangeTracker.Track(child, EntityState.Unchanged, childMap);
-                        child = entry.Entity;
+                        child = entry.Entity!;
                         NavigationPropertyExtensions.EnableLazyLoading(child, _ctx);
                     }
                     resultChildren.Add(child);

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -389,7 +389,7 @@ namespace nORM.Query
                 {
                     var actualMap = _ctx.GetMapping(entity!.GetType());
                     var entry = _ctx.ChangeTracker.Track(entity!, EntityState.Unchanged, actualMap);
-                    entity = (T)entry.Entity;
+                    entity = (T)entry.Entity!;
                     NavigationPropertyExtensions.EnableLazyLoading((object)entity!, _ctx);
                 }
                 count++;

--- a/src/nORM/Query/QueryExecutor.cs
+++ b/src/nORM/Query/QueryExecutor.cs
@@ -96,7 +96,7 @@ namespace nORM.Query
                 ? entityMap
                 : _ctx.GetMapping(entity.GetType());
             var entry = _ctx.ChangeTracker.Track(entity, EntityState.Unchanged, actualMap);
-            entity = entry.Entity;
+            entity = entry.Entity!;
             NavigationPropertyExtensions.EnableLazyLoading(entity, _ctx);
             return entity;
         }
@@ -146,9 +146,9 @@ namespace nORM.Query
                             if (trackOuter)
                             {
                                 var actualMap = _ctx.GetMapping(outer.GetType());
-                                var entry = _ctx.ChangeTracker.Track(outer, EntityState.Unchanged, actualMap);
-                                outer = entry.Entity;
-                                NavigationPropertyExtensions.EnableLazyLoading(outer, _ctx);
+                                  var entry = _ctx.ChangeTracker.Track(outer, EntityState.Unchanged, actualMap);
+                                  outer = entry.Entity!;
+                                  NavigationPropertyExtensions.EnableLazyLoading(outer, _ctx);
                             }
 
                             currentOuter = outer;
@@ -161,9 +161,9 @@ namespace nORM.Query
                             if (trackInner)
                             {
                                 var actualMap = _ctx.GetMapping(inner.GetType());
-                                var entry = _ctx.ChangeTracker.Track(inner, EntityState.Unchanged, actualMap);
-                                inner = entry.Entity;
-                                NavigationPropertyExtensions.EnableLazyLoading(inner, _ctx);
+                                  var entry = _ctx.ChangeTracker.Track(inner, EntityState.Unchanged, actualMap);
+                                  inner = entry.Entity!;
+                                  NavigationPropertyExtensions.EnableLazyLoading(inner, _ctx);
                             }
                             currentChildren.Add(inner);
                         }


### PR DESCRIPTION
## Summary
- make `EntityEntry` resilient to garbage-collected entities by storing a nullable reference and skipping change tracking when the entity is gone
- guard `ChangeTracker` and `DbContext` operations against null `Entity` values to avoid crashes

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bace05fac4832c9358135d8d53f040