### PR TITLE
Dispose ThreadLocal QueryTranslator to prevent memory leak

### DIFF
--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -63,7 +63,7 @@ namespace nORM.Query
         // Initialize _groupJoinInfo in constructor to suppress warning
         // This field is used in complex join scenarios
 
-        private static readonly ThreadLocal<QueryTranslator?> _threadLocalTranslator =
+        private static ThreadLocal<QueryTranslator?> _threadLocalTranslator =
             new(() => null, trackAllValues: false);
 
         private QueryTranslator()
@@ -428,7 +428,9 @@ namespace nORM.Query
             }
             finally
             {
-                _threadLocalTranslator.Value = null;
+                // Properly dispose ThreadLocal to prevent memory leaks
+                _threadLocalTranslator.Dispose();
+                _threadLocalTranslator = new(() => null, trackAllValues: false);
             }
         }
 


### PR DESCRIPTION
## Summary
- dispose thread-local QueryTranslator to prevent memory leak
- reinitialize thread-local for subsequent reuse

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bada5f8258832ca8b876442f51c900