### PR TITLE
Optimize expression visitor allocation with context struct

### DIFF
--- a/src/nORM/Query/QueryTranslator.MethodTranslators.cs
+++ b/src/nORM/Query/QueryTranslator.MethodTranslators.cs
@@ -111,7 +111,8 @@ namespace nORM.Query
                         info = (t._mapping, "T" + t._joinCounter);
                         t._correlatedParams[param] = info;
                     }
-                    var visitor = ExpressionVisitorPool.Get(t._ctx, t._mapping, t._provider, param, info.Alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var vctx = new VisitorContext(t._ctx, t._mapping, t._provider, param, info.Alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var visitor = ExpressionVisitorPool.Get(in vctx);
                     var sql = visitor.Translate(lambda.Body);
                     var isGrouping = node.Arguments[0] is MethodCallExpression mc && mc.Method.Name == "GroupBy";
                     var target = isGrouping ? t._having : t._where;
@@ -148,7 +149,8 @@ namespace nORM.Query
                         info = (t._mapping, "T" + t._joinCounter);
                         t._correlatedParams[param] = info;
                     }
-                    var visitor = ExpressionVisitorPool.Get(t._ctx, t._mapping, t._provider, param, info.Alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var vctx = new VisitorContext(t._ctx, t._mapping, t._provider, param, info.Alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var visitor = ExpressionVisitorPool.Get(in vctx);
                     var sql = visitor.Translate(keySelector.Body);
                     t._orderBy.Add((sql, !t._methodName.Contains("Descending")));
                     ExpressionVisitorPool.Return(visitor);
@@ -345,7 +347,8 @@ namespace nORM.Query
                     var alias = "T" + t._joinCounter;
                     if (!t._correlatedParams.ContainsKey(param))
                         t._correlatedParams[param] = (t._mapping, alias);
-                    var visitor = ExpressionVisitorPool.Get(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var vctxFS = new VisitorContext(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var visitor = ExpressionVisitorPool.Get(in vctxFS);
                     var sql = visitor.Translate(predicate.Body);
                     if (t._where.Length > 0) t._where.Append(" AND ");
                     t._where.Append($"({sql})");
@@ -372,7 +375,8 @@ namespace nORM.Query
                     var alias = "T" + t._joinCounter;
                     if (!t._correlatedParams.ContainsKey(param))
                         t._correlatedParams[param] = (t._mapping, alias);
-                    var visitor = ExpressionVisitorPool.Get(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var vctxLast = new VisitorContext(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var visitor = ExpressionVisitorPool.Get(in vctxLast);
                     var sql = visitor.Translate(lastPredicate.Body);
                     if (t._where.Length > 0) t._where.Append(" AND ");
                     t._where.Append($"({sql})");
@@ -421,7 +425,8 @@ namespace nORM.Query
                         info = (t._mapping, "T" + t._joinCounter);
                         t._correlatedParams[param] = info;
                     }
-                    var visitor = ExpressionVisitorPool.Get(t._ctx, t._mapping, t._provider, param, info.Alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var vctxCount = new VisitorContext(t._ctx, t._mapping, t._provider, param, info.Alias, t._correlatedParams, t._compiledParams, t._paramMap);
+                    var visitor = ExpressionVisitorPool.Get(in vctxCount);
                     var sql = visitor.Translate(countPredicate.Body);
                     if (t._where.Length > 0) t._where.Append(" AND ");
                     t._where.Append($"({sql})");

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -344,7 +344,8 @@ namespace nORM.Query
                         info = (_mapping, _correlatedParams.Values.FirstOrDefault().Alias ?? "T" + _joinCounter);
                         _correlatedParams[param] = info;
                     }
-                    var visitor = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, param, info.Alias, _correlatedParams, _compiledParams, _paramMap);
+                    var vctx = new VisitorContext(_ctx, _mapping, _provider, param, info.Alias, _correlatedParams, _compiledParams, _paramMap);
+                    var visitor = ExpressionVisitorPool.Get(in vctx);
                     var sql = visitor.Translate(arg);
                     foreach (var kvp in visitor.GetParameters())
                         _params[kvp.Key] = kvp.Value;
@@ -365,7 +366,8 @@ namespace nORM.Query
                     info = (_mapping, _correlatedParams.Values.FirstOrDefault().Alias ?? "T" + _joinCounter);
                     _correlatedParams[param] = info;
                 }
-                var visitor = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, param, info.Alias, _correlatedParams, _compiledParams, _paramMap);
+                var vctx = new VisitorContext(_ctx, _mapping, _provider, param, info.Alias, _correlatedParams, _compiledParams, _paramMap);
+                var visitor = ExpressionVisitorPool.Get(in vctx);
                 var valueSql = visitor.Translate(wf.ValueSelector.Body);
                 foreach (var kvp in visitor.GetParameters())
                     _params[kvp.Key] = kvp.Value;
@@ -380,7 +382,8 @@ namespace nORM.Query
                         info = (_mapping, _correlatedParams.Values.FirstOrDefault().Alias ?? "T" + _joinCounter);
                         _correlatedParams[dParam] = info;
                     }
-                    var visitor2 = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, dParam, info.Alias, _correlatedParams, _compiledParams, _paramMap);
+                    var vctx2 = new VisitorContext(_ctx, _mapping, _provider, dParam, info.Alias, _correlatedParams, _compiledParams, _paramMap);
+                    var visitor2 = ExpressionVisitorPool.Get(in vctx2);
                     var defSql = visitor2.Translate(wf.DefaultValueSelector.Body);
                     foreach (var kv in visitor2.GetParameters())
                         _params[kv.Key] = kv.Value;
@@ -488,12 +491,14 @@ namespace nORM.Query
 
                 if (!_correlatedParams.ContainsKey(outerKeySelector.Parameters[0]))
                     _correlatedParams[outerKeySelector.Parameters[0]] = (_mapping, outerAlias);
-                var outerKeyVisitorG = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, outerKeySelector.Parameters[0], outerAlias, _correlatedParams, _compiledParams, _paramMap);
+                var vctxOuterG = new VisitorContext(_ctx, _mapping, _provider, outerKeySelector.Parameters[0], outerAlias, _correlatedParams, _compiledParams, _paramMap);
+                var outerKeyVisitorG = ExpressionVisitorPool.Get(in vctxOuterG);
                 var outerKeySqlG = outerKeyVisitorG.Translate(outerKeySelector.Body);
 
                 if (!_correlatedParams.ContainsKey(innerKeySelector.Parameters[0]))
                     _correlatedParams[innerKeySelector.Parameters[0]] = (innerMapping, innerAliasG);
-                var innerKeyVisitorG = ExpressionVisitorPool.Get(_ctx, innerMapping, _provider, innerKeySelector.Parameters[0], innerAliasG, _correlatedParams, _compiledParams, _paramMap);
+                var vctxInnerG = new VisitorContext(_ctx, innerMapping, _provider, innerKeySelector.Parameters[0], innerAliasG, _correlatedParams, _compiledParams, _paramMap);
+                var innerKeyVisitorG = ExpressionVisitorPool.Get(in vctxInnerG);
                 var innerKeySqlG = innerKeyVisitorG.Translate(innerKeySelector.Body);
 
                 foreach (var kvp in outerKeyVisitorG.GetParameters())
@@ -542,12 +547,14 @@ namespace nORM.Query
 
             if (!_correlatedParams.ContainsKey(outerKeySelector.Parameters[0]))
                 _correlatedParams[outerKeySelector.Parameters[0]] = (_mapping, outerAlias);
-            var outerKeyVisitor = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, outerKeySelector.Parameters[0], outerAlias, _correlatedParams, _compiledParams, _paramMap);
+            var vctxOuter = new VisitorContext(_ctx, _mapping, _provider, outerKeySelector.Parameters[0], outerAlias, _correlatedParams, _compiledParams, _paramMap);
+            var outerKeyVisitor = ExpressionVisitorPool.Get(in vctxOuter);
             var outerKeySql = outerKeyVisitor.Translate(outerKeySelector.Body);
 
             if (!_correlatedParams.ContainsKey(innerKeySelector.Parameters[0]))
                 _correlatedParams[innerKeySelector.Parameters[0]] = (innerMapping, innerAlias);
-            var innerKeyVisitor = ExpressionVisitorPool.Get(_ctx, innerMapping, _provider, innerKeySelector.Parameters[0], innerAlias, _correlatedParams, _compiledParams, _paramMap);
+            var vctxInner = new VisitorContext(_ctx, innerMapping, _provider, innerKeySelector.Parameters[0], innerAlias, _correlatedParams, _compiledParams, _paramMap);
+            var innerKeyVisitor = ExpressionVisitorPool.Get(in vctxInner);
             var innerKeySql = innerKeyVisitor.Translate(innerKeySelector.Body);
 
             foreach (var kvp in outerKeyVisitor.GetParameters())
@@ -1054,7 +1061,8 @@ namespace nORM.Query
             var alias = "T" + _joinCounter;
             if (!_correlatedParams.ContainsKey(param))
                 _correlatedParams[param] = (_mapping, alias);
-            var visitor = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, param, alias, _correlatedParams, _compiledParams, _paramMap);
+            var vctx = new VisitorContext(_ctx, _mapping, _provider, param, alias, _correlatedParams, _compiledParams, _paramMap);
+            var visitor = ExpressionVisitorPool.Get(in vctx);
             var columnSql = visitor.Translate(selectorLambda.Body);
 
             foreach (var kvp in visitor.GetParameters())
@@ -1087,7 +1095,8 @@ namespace nORM.Query
             var alias = "T" + _joinCounter;
             if (!_correlatedParams.ContainsKey(param))
                 _correlatedParams[param] = (_mapping, alias);
-            var visitor = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, param, alias, _correlatedParams, _compiledParams, _paramMap);
+            var vctx2 = new VisitorContext(_ctx, _mapping, _provider, param, alias, _correlatedParams, _compiledParams, _paramMap);
+            var visitor = ExpressionVisitorPool.Get(in vctx2);
             var groupBySql = visitor.Translate(keySelectorLambda.Body);
 
             foreach (var kvp in visitor.GetParameters())
@@ -1148,7 +1157,8 @@ namespace nORM.Query
                         // Try to translate as regular expression
                         if (!_correlatedParams.ContainsKey(resultSelector.Parameters[0]))
                             _correlatedParams[resultSelector.Parameters[0]] = (_mapping, alias);
-                        var visitor = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, resultSelector.Parameters[0], alias, _correlatedParams, _compiledParams, _paramMap);
+                        var vctx = new VisitorContext(_ctx, _mapping, _provider, resultSelector.Parameters[0], alias, _correlatedParams, _compiledParams, _paramMap);
+                        var visitor = ExpressionVisitorPool.Get(in vctx);
                         var sql = visitor.Translate(arg);
                         selectItems.Add($"{sql} AS {memberName}");
 
@@ -1181,7 +1191,8 @@ namespace nORM.Query
                         {
                             if (!_correlatedParams.ContainsKey(selector.Parameters[0]))
                                 _correlatedParams[selector.Parameters[0]] = (_mapping, alias);
-                            var visitor = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, selector.Parameters[0], alias, _correlatedParams, _compiledParams, _paramMap);
+                            var vctxSel = new VisitorContext(_ctx, _mapping, _provider, selector.Parameters[0], alias, _correlatedParams, _compiledParams, _paramMap);
+                            var visitor = ExpressionVisitorPool.Get(in vctxSel);
                             var columnSql = visitor.Translate(selector.Body);
                             foreach (var kvp in visitor.GetParameters())
                                 _params[kvp.Key] = kvp.Value;
@@ -1198,7 +1209,8 @@ namespace nORM.Query
                         {
                             if (!_correlatedParams.ContainsKey(selector.Parameters[0]))
                                 _correlatedParams[selector.Parameters[0]] = (_mapping, alias);
-                            var visitor = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, selector.Parameters[0], alias, _correlatedParams, _compiledParams, _paramMap);
+                            var vctxSel = new VisitorContext(_ctx, _mapping, _provider, selector.Parameters[0], alias, _correlatedParams, _compiledParams, _paramMap);
+                            var visitor = ExpressionVisitorPool.Get(in vctxSel);
                             var columnSql = visitor.Translate(selector.Body);
                             foreach (var kvp in visitor.GetParameters())
                                 _params[kvp.Key] = kvp.Value;
@@ -1215,7 +1227,8 @@ namespace nORM.Query
                         {
                             if (!_correlatedParams.ContainsKey(selector.Parameters[0]))
                                 _correlatedParams[selector.Parameters[0]] = (_mapping, alias);
-                            var visitor = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, selector.Parameters[0], alias, _correlatedParams, _compiledParams, _paramMap);
+                            var vctxSel = new VisitorContext(_ctx, _mapping, _provider, selector.Parameters[0], alias, _correlatedParams, _compiledParams, _paramMap);
+                            var visitor = ExpressionVisitorPool.Get(in vctxSel);
                             var columnSql = visitor.Translate(selector.Body);
                             foreach (var kvp in visitor.GetParameters())
                                 _params[kvp.Key] = kvp.Value;
@@ -1232,7 +1245,8 @@ namespace nORM.Query
                         {
                             if (!_correlatedParams.ContainsKey(selector.Parameters[0]))
                                 _correlatedParams[selector.Parameters[0]] = (_mapping, alias);
-                            var visitor = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, selector.Parameters[0], alias, _correlatedParams, _compiledParams, _paramMap);
+                            var vctxSel = new VisitorContext(_ctx, _mapping, _provider, selector.Parameters[0], alias, _correlatedParams, _compiledParams, _paramMap);
+                            var visitor = ExpressionVisitorPool.Get(in vctxSel);
                             var columnSql = visitor.Translate(selector.Body);
                             foreach (var kvp in visitor.GetParameters())
                                 _params[kvp.Key] = kvp.Value;
@@ -1259,7 +1273,8 @@ namespace nORM.Query
                 var alias = "T" + _joinCounter;
                 if (!_correlatedParams.ContainsKey(param))
                     _correlatedParams[param] = (_mapping, alias);
-                var visitor = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, param, alias, _correlatedParams, _compiledParams, _paramMap);
+                var vctx = new VisitorContext(_ctx, _mapping, _provider, param, alias, _correlatedParams, _compiledParams, _paramMap);
+                var visitor = ExpressionVisitorPool.Get(in vctx);
                 var columnSql = visitor.Translate(selector.Body);
 
                 foreach (var kvp in visitor.GetParameters())
@@ -1294,7 +1309,8 @@ namespace nORM.Query
             var alias = "T" + _joinCounter;
             if (!_correlatedParams.ContainsKey(param))
                 _correlatedParams[param] = (_mapping, alias);
-            var visitor = ExpressionVisitorPool.Get(_ctx, _mapping, _provider, param, alias, _correlatedParams, _compiledParams, _paramMap);
+            var vctx2 = new VisitorContext(_ctx, _mapping, _provider, param, alias, _correlatedParams, _compiledParams, _paramMap);
+            var visitor = ExpressionVisitorPool.Get(in vctx2);
             var predicateSql = visitor.Translate(predicate.Body);
 
             foreach (var kvp in visitor.GetParameters())


### PR DESCRIPTION
## Summary
- Introduce `VisitorContext` to carry visitor configuration and reduce parameter allocation
- Update `ExpressionToSqlVisitor` and `QueryTranslator` to initialize visitors from pooled context
- Adjust method translators to use the new context-based visitor creation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bae0dd3d04832c81bf324426f2df68