### PR TITLE
feat: adaptive query complexity analyzer

### DIFF
--- a/src/nORM/Core/IMemoryMonitor.cs
+++ b/src/nORM/Core/IMemoryMonitor.cs
@@ -1,0 +1,13 @@
+namespace nORM.Core
+{
+    /// <summary>
+    /// Provides information about current system memory usage.
+    /// </summary>
+    public interface IMemoryMonitor
+    {
+        /// <summary>
+        /// Gets the amount of available memory in bytes.
+        /// </summary>
+        long GetAvailableMemory();
+    }
+}

--- a/src/nORM/Core/SystemMemoryMonitor.cs
+++ b/src/nORM/Core/SystemMemoryMonitor.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace nORM.Core
+{
+    /// <summary>
+    /// Default implementation of <see cref="IMemoryMonitor"/> that queries the runtime for memory information.
+    /// </summary>
+    internal sealed class SystemMemoryMonitor : IMemoryMonitor
+    {
+        public long GetAvailableMemory()
+        {
+            return GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+        }
+    }
+}

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -66,6 +66,9 @@ namespace nORM.Query
         private static ThreadLocal<QueryTranslator?> _threadLocalTranslator =
             new(() => null, trackAllValues: false);
 
+        private static readonly AdaptiveQueryComplexityAnalyzer _complexityAnalyzer =
+            new AdaptiveQueryComplexityAnalyzer(new SystemMemoryMonitor());
+
         private QueryTranslator()
         {
         }
@@ -177,7 +180,7 @@ namespace nORM.Query
             if (_provider == null) throw new InvalidOperationException("Provider not set");
 
             // Analyze query complexity before translation
-            var complexityInfo = QueryComplexityAnalyzer.AnalyzeQuery(e);
+            var complexityInfo = _complexityAnalyzer.AnalyzeQuery(e, _ctx.Options);
 
             if (complexityInfo.WarningMessages.Any())
             {


### PR DESCRIPTION
## Summary
- add memory monitor and adaptive query complexity analyzer with dynamic limits and concurrency throttling
- integrate adaptive analyzer into query translation
- cover complex query safeguards with new tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68baf74fc1ec832c9acc01018178bc68