### PR TITLE
Fix ThreadLocal memory leak in QueryTranslator

### DIFF
--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -434,9 +434,9 @@ namespace nORM.Query
             }
             finally
             {
-                // Properly dispose ThreadLocal to prevent memory leaks
-                _threadLocalTranslator.Dispose();
-                _threadLocalTranslator = new(() => null, trackAllValues: false);
+                // Clear thread-local reference to avoid retaining disposed translators
+                if (_threadLocalTranslator.IsValueCreated)
+                    _threadLocalTranslator.Value = null;
             }
         }
 

--- a/tests/QueryTranslatorThreadLocalTests.cs
+++ b/tests/QueryTranslatorThreadLocalTests.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using System.Threading;
+using Microsoft.Data.Sqlite;
+using nORM.Core;
+using nORM.Providers;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class QueryTranslatorThreadLocalTests
+{
+    [Fact]
+    public void Dispose_clears_threadlocal_without_replacing_it()
+    {
+        using var cn = new SqliteConnection("Data Source=:memory:");
+        using var ctx = new DbContext(cn, new SqliteProvider());
+
+        var translatorType = typeof(DbContext).Assembly.GetType("nORM.Query.QueryTranslator", true)!;
+
+        var threadLocalField = translatorType.GetField("_threadLocalTranslator", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var rentMethod = translatorType.GetMethod("Rent", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var disposeMethod = translatorType.GetMethod("Dispose")!;
+
+        var threadLocalBefore = threadLocalField.GetValue(null)!;
+
+        var translator = rentMethod.Invoke(null, new object[] { ctx });
+
+        disposeMethod.Invoke(translator, null);
+
+        var threadLocalAfter = threadLocalField.GetValue(null)!;
+
+        Assert.Same(threadLocalBefore, threadLocalAfter);
+
+        var threadLocalType = typeof(ThreadLocal<>).MakeGenericType(translatorType);
+        var valueProp = threadLocalType.GetProperty("Value")!;
+        var value = valueProp.GetValue(threadLocalAfter);
+        Assert.Null(value);
+    }
+}
+


### PR DESCRIPTION
## Summary
- clear thread-local QueryTranslator reference instead of recreating ThreadLocal
- add regression test ensuring ThreadLocal instance is preserved after disposal

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68baffba3cfc832cbd7a61739a3ea1d5