### PR TITLE
Make database node health checks thread-safe

### DIFF
--- a/src/nORM/Core/DatabaseTopology.cs
+++ b/src/nORM/Core/DatabaseTopology.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace nORM.Core
 {
@@ -15,11 +16,26 @@ namespace nORM.Core
                 = DatabaseRole.Primary;
             public int Priority { get; set; }
                 = 0;
-            public bool IsHealthy { get; set; } = true;
-            public DateTime LastHealthCheck { get; set; }
-                = DateTime.UtcNow;
-            public TimeSpan AverageLatency { get; set; }
-                = TimeSpan.Zero;
+            private int _isHealthy = 1;
+            public bool IsHealthy
+            {
+                get => Volatile.Read(ref _isHealthy) == 1;
+                set => Volatile.Write(ref _isHealthy, value ? 1 : 0);
+            }
+
+            private long _lastHealthCheckTicks = DateTime.UtcNow.Ticks;
+            public DateTime LastHealthCheck
+            {
+                get => new DateTime(Volatile.Read(ref _lastHealthCheckTicks), DateTimeKind.Utc);
+                set => Volatile.Write(ref _lastHealthCheckTicks, value.Ticks);
+            }
+
+            private long _averageLatencyTicks;
+            public TimeSpan AverageLatency
+            {
+                get => TimeSpan.FromTicks(Volatile.Read(ref _averageLatencyTicks));
+                set => Volatile.Write(ref _averageLatencyTicks, value.Ticks);
+            }
             public string Region { get; set; } = string.Empty;
         }
 


### PR DESCRIPTION
## Summary
- prevent race conditions by using `Volatile` for database node health metrics

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68baffcd1cc8832cae18072fb412e9a5