### PR TITLE
Use xxHash for cache keys

### DIFF
--- a/src/nORM.csproj
+++ b/src/nORM.csproj
@@ -26,6 +26,7 @@
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
       <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="170.100.0" />
+      <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
     </ItemGroup>
 
   <ItemGroup>

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -10,7 +10,7 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
-using System.Security.Cryptography;
+using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 using nORM.Core;
 using nORM.Execution;
@@ -293,9 +293,9 @@ namespace nORM.Query
                 sb.Append('|').Append(kvp.Key).Append('=').Append(kvp.Value?.GetHashCode() ?? 0);
             }
 
-            using var sha = SHA256.Create();
             var bytes = Encoding.UTF8.GetBytes(sb.ToString());
-            return Convert.ToHexString(sha.ComputeHash(bytes));
+            var hash = XxHash128.Hash(bytes);
+            return Convert.ToHexString(hash);
         }
 
         private async Task<int> ExecuteDeleteInternalAsync(Expression expression, CancellationToken ct)
@@ -440,9 +440,9 @@ namespace nORM.Query
                 sb.Append('|').Append(kvp.Key).Append('=').Append(kvp.Value?.GetHashCode() ?? 0);
             }
 
-            using var sha = SHA256.Create();
             var bytes = Encoding.UTF8.GetBytes(sb.ToString());
-            return Convert.ToHexString(sha.ComputeHash(bytes));
+            var hash = XxHash128.Hash(bytes);
+            return Convert.ToHexString(hash);
         }
 
         private static Expression UnwrapQueryExpression(Expression expression)


### PR DESCRIPTION
## Summary
- Replace SHA256 with xxHash128 for cache key generation
- Add System.IO.Hashing package dependency

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb00107ed4832cbc6e691910ac1c9a