### PR TITLE
Refactor join handling into focused methods

### DIFF
--- a/src/nORM/Query/QueryTranslator.MethodTranslators.cs
+++ b/src/nORM/Query/QueryTranslator.MethodTranslators.cs
@@ -220,7 +220,7 @@ namespace nORM.Query
             public JoinTranslator(bool isGroupJoin) => _isGroupJoin = isGroupJoin;
             public Expression Translate(QueryTranslator t, MethodCallExpression node)
             {
-                return _isGroupJoin ? t.HandleGroupJoin(node) : t.HandleJoin(node, false);
+                return _isGroupJoin ? t.HandleGroupJoin(node) : t.HandleInnerJoin(node);
             }
         }
 


### PR DESCRIPTION
## Summary
- Split monolithic HandleJoin into specialized HandleInnerJoin and HandleGroupJoin
- Extract BuildJoinClause and SetupJoinProjection helpers for SQL and projection setup
- Update method translator to call new join handlers

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb05ee3910832caeb82c9813256c72