### PR TITLE
Pool string builders for SQL generation

### DIFF
--- a/src/nORM/Internal/PooledStringBuilder.cs
+++ b/src/nORM/Internal/PooledStringBuilder.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.ObjectPool;
+
+namespace nORM.Internal;
+
+/// <summary>
+/// Provides shared <see cref="StringBuilder"/> pooling helpers for SQL generation.
+/// </summary>
+internal static class PooledStringBuilder
+{
+    private static readonly ObjectPool<StringBuilder> _pool =
+        new DefaultObjectPool<StringBuilder>(new StringBuilderPooledObjectPolicy());
+
+    public static StringBuilder Rent() => _pool.Get();
+
+    public static void Return(StringBuilder sb)
+    {
+        sb.Clear();
+        _pool.Return(sb);
+    }
+
+    public static string Join(IEnumerable<string> values, string separator = ", ")
+    {
+        var sb = Rent();
+        try
+        {
+            using var e = values.GetEnumerator();
+            if (e.MoveNext())
+            {
+                sb.Append(e.Current);
+                while (e.MoveNext())
+                {
+                    sb.Append(separator);
+                    sb.Append(e.Current);
+                }
+            }
+            return sb.ToString();
+        }
+        finally
+        {
+            Return(sb);
+        }
+    }
+
+    public static string JoinOrderBy(List<(string col, bool asc)> orderBy)
+    {
+        var sb = Rent();
+        try
+        {
+            for (int i = 0; i < orderBy.Count; i++)
+            {
+                if (i > 0) sb.Append(", ");
+                var (col, asc) = orderBy[i];
+                sb.Append(col).Append(asc ? " ASC" : " DESC");
+            }
+            return sb.ToString();
+        }
+        finally
+        {
+            Return(sb);
+        }
+    }
+}

--- a/src/nORM/Navigation/BatchedNavigationLoader.cs
+++ b/src/nORM/Navigation/BatchedNavigationLoader.cs
@@ -123,7 +123,7 @@ namespace nORM.Navigation
                 cmd.AddParam(pn, keys[i]);
             }
 
-            cmd.CommandText = $"SELECT * FROM {mapping.EscTable} WHERE {relation.ForeignKey.EscCol} IN ({string.Join(",", paramNames)})";
+            cmd.CommandText = $"SELECT * FROM {mapping.EscTable} WHERE {relation.ForeignKey.EscCol} IN ({PooledStringBuilder.Join(paramNames, ",")})";
 
             using var translator = Query.QueryTranslator.Rent(_context);
             var materializer = translator.CreateMaterializer(mapping, relation.DependentType);

--- a/src/nORM/Query/IncludeProcessor.cs
+++ b/src/nORM/Query/IncludeProcessor.cs
@@ -70,7 +70,7 @@ namespace nORM.Query
                     cmd.AddParam(pn, keyBatch[i]!);
                 }
 
-                cmd.CommandText = $"SELECT * FROM {childMap.EscTable} WHERE {relation.ForeignKey.EscCol} IN ({string.Join(",", paramNames)})";
+                cmd.CommandText = $"SELECT * FROM {childMap.EscTable} WHERE {relation.ForeignKey.EscCol} IN ({PooledStringBuilder.Join(paramNames, ",")})";
 
                 await using var reader = await cmd.ExecuteReaderWithInterceptionAsync(_ctx, CommandBehavior.Default, ct).ConfigureAwait(false);
                 while (await reader.ReadAsync(ct).ConfigureAwait(false))

--- a/src/nORM/Query/SelectClauseVisitor.cs
+++ b/src/nORM/Query/SelectClauseVisitor.cs
@@ -57,7 +57,11 @@ namespace nORM.Query
         {
             if (node.Expression is ParameterExpression p && p.Type.IsGenericType && p.Type.GetGenericTypeDefinition() == typeof(IGrouping<,>) && node.Member.Name == "Key")
             {
-                _sb.Append(string.Join(", ", _groupBy));
+                for (int i = 0; i < _groupBy.Count; i++)
+                {
+                    if (i > 0) _sb.Append(", ");
+                    _sb.Append(_groupBy[i]);
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary
- add PooledStringBuilder utility for shared StringBuilder pooling
- use pooled builders in query translation and navigation loaders to avoid string.Join allocations
- streamline group key building in SelectClauseVisitor

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb0a0f76a8832c83f62eb50a27436d