### PR TITLE
Refactor raw SQL parameter handling into helper

### DIFF
--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -632,13 +632,7 @@ namespace nORM.Core
                 await using var cmd = ctx.Connection.CreateCommand();
                 cmd.CommandTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
                 cmd.CommandText = sql;
-                var paramDict = new Dictionary<string, object>();
-                for (int i = 0; i < parameters.Length; i++)
-                {
-                    var pName = $"{_p.ParamPrefix}p{i}";
-                    cmd.AddParam(pName, parameters[i]);
-                    paramDict[pName] = parameters[i];
-                }
+                var paramDict = ParameterHelper.AddParameters(_p, cmd, parameters);
 
                 if (!NormValidator.IsSafeRawSql(sql))
                     throw new NormUsageException("Potential SQL injection detected in raw query.");
@@ -689,13 +683,7 @@ namespace nORM.Core
                 await using var cmd = ctx.Connection.CreateCommand();
                 cmd.CommandTimeout = (int)ctx.Options.TimeoutConfiguration.BaseTimeout.TotalSeconds;
                 cmd.CommandText = sql;
-                var paramDict = new Dictionary<string, object>();
-                for (int i = 0; i < parameters.Length; i++)
-                {
-                    var pName = $"{_p.ParamPrefix}p{i}";
-                    cmd.AddParam(pName, parameters[i]);
-                    paramDict[pName] = parameters[i];
-                }
+                var paramDict = ParameterHelper.AddParameters(_p, cmd, parameters);
 
                 if (!NormValidator.IsSafeRawSql(sql))
                     throw new NormUsageException("Potential SQL injection detected in raw query.");

--- a/src/nORM/Core/ParameterHelper.cs
+++ b/src/nORM/Core/ParameterHelper.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Data.Common;
+using nORM.Providers;
+using nORM.Internal;
+
+#nullable enable
+
+namespace nORM.Core
+{
+    internal static class ParameterHelper
+    {
+        public static Dictionary<string, object> AddParameters(DatabaseProvider provider, DbCommand cmd, object[] parameters)
+        {
+            var paramDict = new Dictionary<string, object>();
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                var pName = $"{provider.ParamPrefix}p{i}";
+                cmd.AddParam(pName, parameters[i]);
+                paramDict[pName] = parameters[i];
+            }
+
+            return paramDict;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ParameterHelper.AddParameters` to centralize command parameter construction
- Use helper in `DbContext` raw SQL methods to remove duplicate loops

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb16228580832ca41f9419c5ae129b