### PR TITLE
Cache tenant column in TableMapping

### DIFF
--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -835,7 +835,7 @@ namespace nORM.Core
         private void SetTenantId<T>(T entity, TableMapping map) where T : class
         {
             if (Options.TenantProvider == null) return;
-            var tenantCol = map.Columns.FirstOrDefault(c => c.PropName == Options.TenantColumnName);
+            var tenantCol = map.TenantColumn;
             if (tenantCol != null)
             {
                 tenantCol.Setter(entity, Options.TenantProvider.GetCurrentTenantId());

--- a/src/nORM/Mapping/TableMapping.cs
+++ b/src/nORM/Mapping/TableMapping.cs
@@ -22,6 +22,7 @@ namespace nORM.Mapping
         public readonly Column[] Columns;
         public readonly Column[] KeyColumns;
         public readonly Column? TimestampColumn;
+        public readonly Column? TenantColumn;
         public string TableName { get; }
         public readonly Dictionary<string, Relation> Relations = new();
         public readonly DatabaseProvider Provider;
@@ -84,6 +85,7 @@ namespace nORM.Mapping
 
             KeyColumns = Columns.Where(c => c.IsKey).ToArray();
             TimestampColumn = Columns.FirstOrDefault(c => c.IsTimestamp);
+            TenantColumn = Columns.FirstOrDefault(c => c.PropName == ctx.Options.TenantColumnName);
 
             DiscoverRelations(ctx);
         }

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -512,7 +512,7 @@ namespace nORM.Query
             if (_ctx.Options.TenantProvider != null)
             {
                 var map = _ctx.GetMapping(entityType);
-                var tenantCol = map.Columns.FirstOrDefault(c => c.PropName == _ctx.Options.TenantColumnName);
+                var tenantCol = map.TenantColumn;
                 if (tenantCol != null)
                 {
                     var param = Expression.Parameter(entityType, "t");


### PR DESCRIPTION
## Summary
- cache tenant column lookup in TableMapping constructor
- use cached tenant column when setting tenant ID and applying tenant filter

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb1ab3e974832cb7045991c6b2e7da