### PR TITLE
Simplify resource disposal patterns

### DIFF
--- a/src/nORM/Core/ConnectionManager.cs
+++ b/src/nORM/Core/ConnectionManager.cs
@@ -207,61 +207,17 @@ namespace nORM.Core
             if (_disposed)
                 return;
             _disposed = true;
-
-            List<Exception>? exceptions = null;
-
-            try
-            {
-                _disposeCts.Cancel();
-                _healthCheckTimer.Dispose();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error disposing health check timer");
-                exceptions = new List<Exception> { ex };
-            }
-            finally
-            {
-                _disposeCts.Dispose();
-            }
+            _disposeCts.Cancel();
+            _healthCheckTimer.Dispose();
+            _disposeCts.Dispose();
 
             foreach (var pool in _connectionPools.Values)
             {
-                try
-                {
-                    pool.Dispose();
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error disposing connection pool");
-                    (exceptions ??= new List<Exception>()).Add(ex);
-                }
+                pool.Dispose();
             }
 
-            try
-            {
-                _failoverSemaphore.Dispose();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error disposing failover semaphore");
-                (exceptions ??= new List<Exception>()).Add(ex);
-            }
-
-            try
-            {
-                _poolInitSemaphore.Dispose();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error disposing initialization semaphore");
-                (exceptions ??= new List<Exception>()).Add(ex);
-            }
-
-            if (exceptions != null)
-            {
-                throw new AggregateException("One or more errors occurred during ConnectionManager disposal", exceptions);
-            }
+            _failoverSemaphore.Dispose();
+            _poolInitSemaphore.Dispose();
         }
     }
 }

--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -870,14 +870,7 @@ namespace nORM.Core
             {
                 for (int i = _disposables.Count - 1; i >= 0; i--)
                 {
-                    try
-                    {
-                        _disposables[i]?.Dispose();
-                    }
-                    catch (Exception ex)
-                    {
-                        Options.Logger?.LogError(ex, "Error disposing resource");
-                    }
+                    _disposables[i]?.Dispose();
                 }
 
                 _disposables.Clear();
@@ -904,14 +897,7 @@ namespace nORM.Core
             {
                 for (int i = _disposables.Count - 1; i >= 0; i--)
                 {
-                    try
-                    {
-                        _disposables[i]?.Dispose();
-                    }
-                    catch (Exception ex)
-                    {
-                        Options.Logger?.LogError(ex, "Error disposing resource");
-                    }
+                    _disposables[i]?.Dispose();
                 }
 
                 _disposables.Clear();

--- a/src/nORM/Query/OptimizedSqlBuilder.cs
+++ b/src/nORM/Query/OptimizedSqlBuilder.cs
@@ -225,15 +225,8 @@ namespace nORM.Query
         public void Dispose()
         {
             Clear();
-            try
-            {
-                if (_returnToPool)
-                    _stringBuilderPool.Return(_buffer);
-            }
-            catch
-            {
-                // Swallow to avoid leaking if the pool rejects the builder
-            }
+            if (_returnToPool)
+                _stringBuilderPool.Return(_buffer);
         }
     }
 }

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -133,18 +133,8 @@ namespace nORM.Query
             _splitQuery = false;
             _tables = new HashSet<string>();
             _params = new Dictionary<string, object>();
-            try
-            {
-                _clauses?.Dispose();
-            }
-            catch (Exception ex)
-            {
-                _ctx.Options.Logger?.LogError(ex, "Failed to dispose SqlClauseBuilder");
-            }
-            finally
-            {
-                _clauses = new SqlClauseBuilder();
-            }
+            _clauses?.Dispose();
+            _clauses = new SqlClauseBuilder();
             _estimatedTimeout = ctx.Options.TimeoutConfiguration.BaseTimeout;
             _isCacheable = false;
             _cacheExpiration = null;
@@ -153,18 +143,8 @@ namespace nORM.Query
 
         private void Clear()
         {
-            try
-            {
-                _clauses?.Dispose();
-            }
-            catch
-            {
-                // Swallow any exceptions to avoid masking disposal failures
-            }
-            finally
-            {
-                _clauses = new SqlClauseBuilder();
-            }
+            _clauses?.Dispose();
+            _clauses = new SqlClauseBuilder();
 
             _ctx = null!;
             _provider = null!;

--- a/src/nORM/Query/SqlClauseBuilder.cs
+++ b/src/nORM/Query/SqlClauseBuilder.cs
@@ -22,39 +22,9 @@ namespace nORM.Query
 
         public void Dispose()
         {
-            var exceptions = new List<Exception>();
-
-            try
-            {
-                Sql.Dispose();
-            }
-            catch (Exception ex)
-            {
-                exceptions.Add(ex);
-            }
-
-            try
-            {
-                Where.Dispose();
-            }
-            catch (Exception ex)
-            {
-                exceptions.Add(ex);
-            }
-
-            try
-            {
-                Having.Dispose();
-            }
-            catch (Exception ex)
-            {
-                exceptions.Add(ex);
-            }
-
-            if (exceptions.Count > 0)
-            {
-                throw new AggregateException("Disposal failures", exceptions);
-            }
+            Sql.Dispose();
+            Where.Dispose();
+            Having.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary
- streamline ConnectionManager shutdown by disposing resources directly
- remove exception aggregation from SqlClauseBuilder
- clean up disposal in QueryTranslator, DbContext, OptimizedSqlBuilder, and query execution path

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb1be60318832c92ac13d1a3a7f4cf