### PR TITLE
refactor: unify bulk insert batching logic

### DIFF
--- a/src/nORM/Providers/BulkOperationProvider.cs
+++ b/src/nORM/Providers/BulkOperationProvider.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using nORM.Core;
+using nORM.Mapping;
+
+namespace nORM.Providers
+{
+    /// <summary>
+    /// Provides helpers for provider specific bulk operations by extracting the
+    /// common batching and transactional patterns used by multiple providers.
+    /// </summary>
+    public abstract class BulkOperationProvider : DatabaseProvider
+    {
+        /// <summary>
+        /// Executes a bulk operation in batches inside a single transaction. The
+        /// concrete provider supplies the per batch action which performs the
+        /// actual database work.
+        /// </summary>
+        protected async Task<int> ExecuteBulkOperationAsync<T>(
+            DbContext ctx,
+            TableMapping mapping,
+            IList<T> entityList,
+            string operationKey,
+            Func<List<T>, DbTransaction, CancellationToken, Task<int>> batchAction,
+            CancellationToken ct) where T : class
+        {
+            var sizing = BatchSizer.CalculateOptimalBatchSize(
+                entityList.Take(100), mapping, operationKey, entityList.Count);
+
+            var total = 0;
+            await using var transaction = await ctx.Connection
+                .BeginTransactionAsync(ct).ConfigureAwait(false);
+            try
+            {
+                for (int i = 0; i < entityList.Count; i += sizing.OptimalBatchSize)
+                {
+                    var batch = entityList.Skip(i).Take(sizing.OptimalBatchSize).ToList();
+                    var batchSw = Stopwatch.StartNew();
+                    total += await batchAction(batch, transaction, ct).ConfigureAwait(false);
+                    batchSw.Stop();
+                    BatchSizer.RecordBatchPerformance(
+                        operationKey, batch.Count, batchSw.Elapsed, batch.Count);
+                }
+
+                await transaction.CommitAsync(ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    await transaction.RollbackAsync(ct).ConfigureAwait(false);
+                }
+                catch (Exception rollbackEx)
+                {
+                    throw new AggregateException(ex, rollbackEx);
+                }
+                throw;
+            }
+
+            return total;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `BulkOperationProvider` to centralize transactional batch handling
- reuse shared bulk insert logic in Postgres and SQL Server providers

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb210814cc832cb9db1dcd57431d87