### PR TITLE
Refactor expression compilation into utility

### DIFF
--- a/src/nORM/Core/Norm.cs
+++ b/src/nORM/Core/Norm.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Threading;
 using System.Threading.Tasks;
 using nORM.Internal;
-using nORM.Query;
 
 #nullable enable
 
@@ -19,91 +17,7 @@ namespace nORM.Core
         {
             if (queryExpression == null) throw new ArgumentNullException(nameof(queryExpression));
 
-            ExpressionUtils.ValidateExpression(queryExpression);
-
-            var timeout = ExpressionUtils.GetCompilationTimeout(queryExpression);
-            using var cts = new CancellationTokenSource(timeout);
-            return CompileWithTimeout<TContext, TParam, T>(queryExpression, cts.Token);
-        }
-
-        private static Func<TContext, TParam, Task<List<T>>> CompileWithTimeout<TContext, TParam, T>(Expression<Func<TContext, TParam, IQueryable<T>>> queryExpression, CancellationToken token)
-            where TContext : DbContext
-            where T : class
-        {
-            Func<TContext, TParam, Task<List<T>>>? result = null;
-            Exception? compileException = null;
-
-            var task = Task.Run(() =>
-            {
-                try
-                {
-                    result = CompileQueryInternal<TContext, TParam, T>(queryExpression);
-                }
-                catch (Exception ex)
-                {
-                    compileException = ex;
-                }
-            }, token);
-
-            try
-            {
-                task.Wait(token);
-            }
-            catch (OperationCanceledException ex)
-            {
-                throw new TimeoutException("Expression compilation timed out", ex);
-            }
-
-            if (compileException != null)
-                throw compileException;
-
-            return result!;
-        }
-
-        private static Func<TContext, TParam, Task<List<T>>> CompileQueryInternal<TContext, TParam, T>(Expression<Func<TContext, TParam, IQueryable<T>>> queryExpression)
-            where TContext : DbContext
-            where T : class
-        {
-            QueryPlan? cachedPlan = null;
-            IReadOnlyList<string>? paramNames = null;
-
-            return async (ctx, value) =>
-            {
-                if (cachedPlan == null)
-                {
-                    var ctxParam = queryExpression.Parameters[0];
-                    var body = new ParameterReplacer(ctxParam, Expression.Constant(ctx)).Visit(queryExpression.Body)!;
-                    body = new QueryCallEvaluator().Visit(body)!;
-                    var provider = new NormQueryProvider(ctx);
-                    cachedPlan = provider.GetPlan(body, out _);
-                    paramNames = cachedPlan.CompiledParameters;
-                }
-
-                var parameters = cachedPlan.Parameters.ToDictionary(k => k.Key, v => v.Value);
-                if (paramNames != null)
-                    foreach (var name in paramNames)
-                        parameters[name] = value!;
-
-                var execProvider = new NormQueryProvider(ctx);
-                return await execProvider.ExecuteCompiledAsync<List<T>>(cachedPlan, parameters, default).ConfigureAwait(false);
-            };
-        }
-
-        private sealed class QueryCallEvaluator : ExpressionVisitor
-        {
-            protected override Expression VisitMethodCall(MethodCallExpression node)
-            {
-                if (node.Method.DeclaringType == typeof(NormQueryable) && node.Method.Name == "Query")
-                {
-                    ExpressionUtils.ValidateExpression(node);
-                    var timeout = ExpressionUtils.GetCompilationTimeout(node);
-                    using var cts = new CancellationTokenSource(timeout);
-                    var del = ExpressionUtils.CompileWithTimeout(Expression.Lambda(node), cts.Token);
-                    var result = del.DynamicInvoke();
-                    return Expression.Constant(result, node.Type);
-                }
-                return base.VisitMethodCall(node);
-            }
+            return ExpressionCompiler.CompileQuery<TContext, TParam, T>(queryExpression);
         }
     }
 }

--- a/src/nORM/Internal/ExpressionCompiler.cs
+++ b/src/nORM/Internal/ExpressionCompiler.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using nORM.Core;
+using nORM.Query;
+
+#nullable enable
+
+namespace nORM.Internal
+{
+    internal static class ExpressionCompiler
+    {
+        public static Func<TContext, TParam, Task<List<T>>> CompileQuery<TContext, TParam, T>(Expression<Func<TContext, TParam, IQueryable<T>>> queryExpression)
+            where TContext : DbContext
+            where T : class
+        {
+            ExpressionUtils.ValidateExpression(queryExpression);
+            var timeout = ExpressionUtils.GetCompilationTimeout(queryExpression);
+            using var cts = new CancellationTokenSource(timeout);
+            return CompileWithTimeout<TContext, TParam, T>(queryExpression, cts.Token);
+        }
+
+        private static Func<TContext, TParam, Task<List<T>>> CompileWithTimeout<TContext, TParam, T>(Expression<Func<TContext, TParam, IQueryable<T>>> queryExpression, CancellationToken token)
+            where TContext : DbContext
+            where T : class
+        {
+            Func<TContext, TParam, Task<List<T>>>? result = null;
+            Exception? compileException = null;
+
+            var task = Task.Run(() =>
+            {
+                try
+                {
+                    result = CompileQueryInternal<TContext, TParam, T>(queryExpression);
+                }
+                catch (Exception ex)
+                {
+                    compileException = ex;
+                }
+            }, token);
+
+            try
+            {
+                task.Wait(token);
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new TimeoutException("Expression compilation timed out", ex);
+            }
+
+            if (compileException != null)
+                throw compileException;
+
+            return result!;
+        }
+
+        private static Func<TContext, TParam, Task<List<T>>> CompileQueryInternal<TContext, TParam, T>(Expression<Func<TContext, TParam, IQueryable<T>>> queryExpression)
+            where TContext : DbContext
+            where T : class
+        {
+            QueryPlan? cachedPlan = null;
+            IReadOnlyList<string>? paramNames = null;
+
+            return async (ctx, value) =>
+            {
+                if (cachedPlan == null)
+                {
+                    var ctxParam = queryExpression.Parameters[0];
+                    var body = new ParameterReplacer(ctxParam, Expression.Constant(ctx)).Visit(queryExpression.Body)!;
+                    body = new QueryCallEvaluator().Visit(body)!;
+                    var provider = new NormQueryProvider(ctx);
+                    cachedPlan = provider.GetPlan(body, out _);
+                    paramNames = cachedPlan.CompiledParameters;
+                }
+
+                var parameters = cachedPlan.Parameters.ToDictionary(k => k.Key, v => v.Value);
+                if (paramNames != null)
+                    foreach (var name in paramNames)
+                        parameters[name] = value!;
+
+                var execProvider = new NormQueryProvider(ctx);
+                return await execProvider.ExecuteCompiledAsync<List<T>>(cachedPlan, parameters, default).ConfigureAwait(false);
+            };
+        }
+
+        internal static object? Evaluate(Expression expression)
+        {
+            ExpressionUtils.ValidateExpression(expression);
+            var timeout = ExpressionUtils.GetCompilationTimeout(expression);
+            using var cts = new CancellationTokenSource(timeout);
+            var del = ExpressionUtils.CompileWithTimeout(Expression.Lambda(expression), cts.Token);
+            return del.DynamicInvoke();
+        }
+
+        private sealed class QueryCallEvaluator : ExpressionVisitor
+        {
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                if (node.Method.DeclaringType == typeof(NormQueryable) && node.Method.Name == "Query")
+                {
+                    var result = Evaluate(node);
+                    return Expression.Constant(result, node.Type);
+                }
+                return base.VisitMethodCall(node);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- centralize expression timeout handling in new `ExpressionCompiler`
- simplify `Norm.CompileQuery` to rely on the new compiler

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb212bf920832ca1096e6600932027