### PR TITLE
Cache column lookups in TableMapping

### DIFF
--- a/src/nORM/Mapping/TableMapping.cs
+++ b/src/nORM/Mapping/TableMapping.cs
@@ -20,6 +20,7 @@ namespace nORM.Mapping
         public readonly Type Type;
         public string EscTable;
         public readonly Column[] Columns;
+        public readonly Dictionary<string, Column> ColumnsByName;
         public readonly Column[] KeyColumns;
         public readonly Column? TimestampColumn;
         public readonly Column? TenantColumn;
@@ -82,6 +83,7 @@ namespace nORM.Mapping
             }
 
             Columns = cols.ToArray();
+            ColumnsByName = Columns.ToDictionary(c => c.Prop.Name, StringComparer.Ordinal);
 
             KeyColumns = Columns.Where(c => c.IsKey).ToArray();
             TimestampColumn = Columns.FirstOrDefault(c => c.IsTimestamp);

--- a/src/nORM/Query/BulkCudBuilder.cs
+++ b/src/nORM/Query/BulkCudBuilder.cs
@@ -58,7 +58,7 @@ namespace nORM.Query
             {
                 var lambda = (LambdaExpression)StripQuotes(call.Arguments[0]);
                 var member = (MemberExpression)lambda.Body;
-                var column = mapping.Columns.First(c => c.Prop.Name == member.Member.Name).EscCol;
+                var column = mapping.ColumnsByName[member.Member.Name].EscCol;
                 var value = Expression.Lambda(call.Arguments[1]).Compile().DynamicInvoke();
                 assigns.Add((column, value));
                 call = call.Object as MethodCallExpression;

--- a/src/nORM/Query/ExpressionToSqlVisitor.cs
+++ b/src/nORM/Query/ExpressionToSqlVisitor.cs
@@ -143,8 +143,7 @@ namespace nORM.Query
         {
             if (node.Expression is ParameterExpression pe && _parameterMappings.TryGetValue(pe, out var info))
             {
-                var column = info.Mapping.Columns.FirstOrDefault(c => c.Prop.Name == node.Member.Name);
-                if (column != null)
+                if (info.Mapping.ColumnsByName.TryGetValue(node.Member.Name, out var column))
                 {
                     // Table aliases are generated internally (e.g. T0, T1) and are not influenced
                     // by user input, so escaping them adds unnecessary quoting that breaks

--- a/src/nORM/Query/MaterializerFactory.cs
+++ b/src/nORM/Query/MaterializerFactory.cs
@@ -71,7 +71,7 @@ namespace nORM.Query
                     kvp =>
                     {
                         var dmap = kvp.Value;
-                        var indices = dmap.Columns.Select(c => Array.FindIndex(mapping.Columns, bc => bc.Prop.Name == c.Prop.Name)).ToArray();
+                        var indices = dmap.Columns.Select(c => Array.IndexOf(mapping.Columns, mapping.ColumnsByName[c.Prop.Name])).ToArray();
                         return (Func<DbDataReader, object>)(reader =>
                         {
                             var entity = Activator.CreateInstance(dmap.Type)!;
@@ -217,8 +217,7 @@ namespace nORM.Query
                     if (arg is MemberExpression m)
                     {
                         // Try to resolve against the current mapping first
-                        var col = mapping.Columns.FirstOrDefault(c => c.Prop.Name == m.Member.Name);
-                        if (col != null)
+                        if (mapping.ColumnsByName.TryGetValue(m.Member.Name, out var col))
                         {
                             cols.Add(col);
                         }

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -375,7 +375,7 @@ namespace nORM.Query
                     var alias = ne.Members![i].Name;
                     if (arg is MemberExpression me)
                     {
-                        var col = _mapping.Columns.First(c => c.Prop.Name == me.Member.Name);
+                        var col = _mapping.ColumnsByName[me.Member.Name];
                         sb.Append(col.EscCol).Append(" AS ").Append(_provider.Escape(alias));
                     }
                     else if (arg is ParameterExpression p && paramMap.TryGetValue(p, out var wf))
@@ -1023,12 +1023,12 @@ namespace nORM.Query
             {
                 if (_correlatedParams.TryGetValue(pe, out var info))
                 {
-                    var col = info.Mapping.Columns.First(c => c.Prop.Name == node.Member.Name);
+                    var col = info.Mapping.ColumnsByName[node.Member.Name];
                     _sql.Append($"{ValidateTableAlias(info.Alias)}.{col.EscCol}");
                 }
                 else
                 {
-                    var col = _mapping.Columns.First(c => c.Prop.Name == node.Member.Name);
+                    var col = _mapping.ColumnsByName[node.Member.Name];
                     _sql.Append(col.EscCol);
                 }
                 return node;
@@ -1093,8 +1093,7 @@ namespace nORM.Query
                     var mapping = isOuterTable ? outerMapping : innerMapping;
                     var alias = isOuterTable ? outerAlias : innerAlias;
 
-                    var column = mapping.Columns.FirstOrDefault(c => c.Prop.Name == memberExpr.Member.Name);
-                    if (column != null)
+                    if (mapping.ColumnsByName.TryGetValue(memberExpr.Member.Name, out var column))
                     {
                         var colSql = $"{alias}.{column.EscCol}";
                         if (!neededColumns.Contains(colSql))

--- a/src/nORM/Query/SelectClauseVisitor.cs
+++ b/src/nORM/Query/SelectClauseVisitor.cs
@@ -65,7 +65,7 @@ namespace nORM.Query
             }
             else
             {
-                _sb.Append(_mapping.Columns.First(c => c.Prop.Name == node.Member.Name).EscCol);
+                _sb.Append(_mapping.ColumnsByName[node.Member.Name].EscCol);
             }
             return node;
         }
@@ -78,7 +78,7 @@ namespace nORM.Query
                 var lambda = (LambdaExpression)StripQuotes(node.Arguments[1]);
                 if (lambda.Body is MemberExpression me)
                 {
-                    _sb.Append(_mapping.Columns.First(c => c.Prop.Name == me.Member.Name).EscCol);
+                    _sb.Append(_mapping.ColumnsByName[me.Member.Name].EscCol);
                 }
             }
             else if (node.Method.Name.ToUpper() != "COUNT")


### PR DESCRIPTION
## Summary
- cache columns by property name inside `TableMapping`
- use cached column lookups in query translation and materialization

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb22baffc8832cb06d1eb99f836a66