### PR TITLE
Introduce factory for QueryTranslator creation

### DIFF
--- a/src/nORM/Query/ExpressionToSqlVisitor.cs
+++ b/src/nORM/Query/ExpressionToSqlVisitor.cs
@@ -453,7 +453,7 @@ namespace nORM.Query
             var rootType = GetRootElementType(source);
             var mapping = _ctx.GetMapping(rootType);
 
-            using var subTranslator = new QueryTranslator(_ctx, mapping, _params, ref _paramIndex, _parameterMappings, new HashSet<string>(), _compiledParams, _paramMap, _parameterMappings.Count);
+            using var subTranslator = QueryTranslator.Create(_ctx, mapping, _params, ref _paramIndex, _parameterMappings, new HashSet<string>(), _compiledParams, _paramMap, _parameterMappings.Count);
             var subPlan = subTranslator.Translate(source);
 
             _sql.Append(negate ? "NOT EXISTS(" : "EXISTS(");
@@ -466,7 +466,7 @@ namespace nORM.Query
             var rootType = GetRootElementType(source);
             var mapping = _ctx.GetMapping(rootType);
 
-            using var subTranslator = new QueryTranslator(_ctx, mapping, _params, ref _paramIndex, _parameterMappings, new HashSet<string>(), _compiledParams, _paramMap, _parameterMappings.Count);
+            using var subTranslator = QueryTranslator.Create(_ctx, mapping, _params, ref _paramIndex, _parameterMappings, new HashSet<string>(), _compiledParams, _paramMap, _parameterMappings.Count);
             var subPlan = subTranslator.Translate(source);
 
             Visit(value);


### PR DESCRIPTION
## Summary
- add static factory method to centralize QueryTranslator creation
- replace direct constructor calls with factory method usage

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb244dd07c832c92382b0d9c559dc0