### PR TITLE
Standardize provider error handling with Norm exceptions

### DIFF
--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -201,7 +201,7 @@ namespace nORM.Providers
             if (!entityList.Any()) return 0;
 
             if (!m.KeyColumns.Any())
-                throw new Exception($"Cannot delete from '{m.EscTable}': no key columns defined.");
+                throw new NormConfigurationException($"Cannot delete from '{m.EscTable}': no key columns defined.");
 
             var totalDeleted = 0;
             var keyColumns = m.KeyColumns.ToList();

--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -175,7 +175,9 @@ END;";
                 await cn.OpenAsync();
                 await using var cmd = cn.CreateCommand();
                 cmd.CommandText = "SELECT VERSION()";
-                var versionStr = (string)(await cmd.ExecuteScalarAsync() ?? throw new Exception("No version"));
+                var result = await cmd.ExecuteScalarAsync();
+                if (result is not string versionStr)
+                    throw new NormDatabaseException("Unable to retrieve database version.", cmd.CommandText, null, null);
                 var version = new Version(versionStr.Split('-')[0]);
                 return version >= new Version(8, 0);
             }
@@ -313,7 +315,7 @@ END;";
 
             var keyCols = m.KeyColumns.ToList();
             if (!keyCols.Any())
-                throw new Exception($"Cannot delete from '{m.EscTable}': no key columns defined.");
+                throw new NormConfigurationException($"Cannot delete from '{m.EscTable}': no key columns defined.");
 
             var operationKey = $"MySql_BulkDelete_{m.Type.Name}";
             var paramsPerEntity = keyCols.Count;

--- a/src/nORM/Providers/PostgresProvider.cs
+++ b/src/nORM/Providers/PostgresProvider.cs
@@ -181,7 +181,9 @@ FOR EACH ROW EXECUTE FUNCTION {functionName}();";
                 await cn.OpenAsync();
                 await using var cmd = cn.CreateCommand();
                 cmd.CommandText = "SHOW server_version";
-                var versionStr = (string)(await cmd.ExecuteScalarAsync() ?? throw new Exception("No version"));
+                var result = await cmd.ExecuteScalarAsync();
+                if (result is not string versionStr)
+                    throw new NormDatabaseException("Unable to retrieve database version.", cmd.CommandText, null, null);
                 var version = new Version(versionStr.Split(' ')[0]);
                 return version >= new Version(9, 5);
             }

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -195,7 +195,9 @@ END;";
                 await cn.OpenAsync();
                 await using var cmd = cn.CreateCommand();
                 cmd.CommandText = "SELECT CAST(SERVERPROPERTY('ProductVersion') AS VARCHAR(20))";
-                var versionStr = (string)(await cmd.ExecuteScalarAsync() ?? throw new Exception("No version"));
+                var result = await cmd.ExecuteScalarAsync();
+                if (result is not string versionStr)
+                    throw new NormDatabaseException("Unable to retrieve database version.", cmd.CommandText, null, null);
                 var parts = versionStr.Split('.');
                 var version = new Version(int.Parse(parts[0]), int.Parse(parts[1]));
                 return version >= new Version(13, 0);

--- a/src/nORM/Providers/SqliteProvider.cs
+++ b/src/nORM/Providers/SqliteProvider.cs
@@ -156,7 +156,9 @@ END;";
                 await cn.OpenAsync();
                 await using var cmd = cn.CreateCommand();
                 cmd.CommandText = "select sqlite_version()";
-                var versionStr = (string)(await cmd.ExecuteScalarAsync() ?? throw new Exception("No version"));
+                var result = await cmd.ExecuteScalarAsync();
+                if (result is not string versionStr)
+                    throw new NormDatabaseException("Unable to retrieve database version.", cmd.CommandText, null, null);
                 var version = new Version(versionStr);
                 return version >= new Version(3, 9);
             }
@@ -339,7 +341,7 @@ END;";
             if (!entityList.Any()) return 0;
             
             if (!m.KeyColumns.Any())
-                throw new System.Exception($"Cannot delete from '{m.EscTable}': no key columns defined.");
+                throw new NormConfigurationException($"Cannot delete from '{m.EscTable}': no key columns defined.");
             
             var totalDeleted = 0;
             // Respect provider parameter limits when batching deletes


### PR DESCRIPTION
## Summary
- Replace generic exceptions with `NormDatabaseException` when providers fail to fetch version information
- Use `NormConfigurationException` when bulk delete operations lack key columns

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bb25ebb1ec832c8663c95e191373d6