### PR TITLE
Detect hash collisions in change tracker

### DIFF
--- a/src/nORM/Core/EntityEntry.cs
+++ b/src/nORM/Core/EntityEntry.cs
@@ -100,7 +100,16 @@ namespace nORM.Core
                 else
                 {
                     var currentHash = _getHashCodes[i](entity);
-                    changed = currentHash != _originalHashes[i];
+                    if (currentHash != _originalHashes[i])
+                    {
+                        changed = true;
+                    }
+                    else
+                    {
+                        // Hash collision - verify using precise comparison
+                        var currentValue = _getValues[i](entity);
+                        changed = !Equals(currentValue, _originalValues[i]);
+                    }
                 }
                 _changedProperties[i] = changed;
                 hasChanges |= changed;

--- a/tests/PreciseChangeTrackingTests.cs
+++ b/tests/PreciseChangeTrackingTests.cs
@@ -22,7 +22,7 @@ namespace nORM.Tests
     public class PreciseChangeTrackingTests
     {
         [Fact]
-        public void Hash_collision_not_detected_by_default()
+        public void Hash_collision_detected_by_default()
         {
             using var cn = new SqliteConnection("Data Source=:memory:");
             cn.Open();
@@ -33,7 +33,7 @@ namespace nORM.Tests
             var detect = typeof(ChangeTracker).GetMethod("DetectChanges", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             detect!.Invoke(ctx.ChangeTracker, null);
             var state = ctx.ChangeTracker.Entries.Single().State;
-            Assert.Equal(EntityState.Unchanged, state);
+            Assert.Equal(EntityState.Modified, state);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- ensure hash-based change tracking verifies value equality when hashes match to avoid missed modifications
- update test to assert collisions are detected by default

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2ce99064832caabd55c6ae90ab19