### PR TITLE
Avoid string allocations for parameter cache keys

### DIFF
--- a/src/nORM/Query/OptimizedSqlBuilder.cs
+++ b/src/nORM/Query/OptimizedSqlBuilder.cs
@@ -41,7 +41,7 @@ namespace nORM.Query
         }
 
         private readonly StringBuilder _buffer;
-        private readonly Dictionary<string, string> _parameterCache = new();
+        private readonly Dictionary<(Type? type, int hash), string> _parameterCache = new();
         private readonly bool _returnToPool;
         private bool _hasWhere;
 
@@ -180,8 +180,9 @@ namespace nORM.Query
 
         public OptimizedSqlBuilder AppendParameterizedValue(string parameterName, object? value, Dictionary<string, object> parameters)
         {
+            var type = value?.GetType();
             var valueHash = value?.GetHashCode() ?? 0;
-            var cacheKey = $"{value?.GetType().Name}_{valueHash}";
+            var cacheKey = (type, valueHash);
             if (_parameterCache.TryGetValue(cacheKey, out var existing))
             {
                 _buffer.Append(existing);


### PR DESCRIPTION
## Summary
- Eliminate temporary string keys when caching parameterized values by using a `(Type? type, int hash)` tuple key

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb30cf1ad4832c8289313f1a66f48f