### PR TITLE
Reject queries exceeding adaptive complexity thresholds

### DIFF
--- a/src/nORM/Query/AdaptiveQueryComplexityAnalyzer.cs
+++ b/src/nORM/Query/AdaptiveQueryComplexityAnalyzer.cs
@@ -60,6 +60,9 @@ namespace nORM.Query
                 if (!_complexQuerySemaphore.Wait(TimeSpan.FromSeconds(1)))
                     throw new NormQueryException("System is under high query load. Please retry later.");
                 _complexQuerySemaphore.Release();
+                throw new NormQueryException(string.Format(
+                    ErrorMessages.QueryTranslationFailed,
+                    $"Query complexity too high (cost: {baseAnalysis.EstimatedCost}, threshold: {adaptedLimits.HighCostThreshold})."));
             }
 
             return baseAnalysis;


### PR DESCRIPTION
## Summary
- Throw an exception when query complexity surpasses adaptive safety limits

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68bb37b45b18832c878932d92a5e9e7d