### PR TITLE
Add memory-aware query plan cache

### DIFF
--- a/src/nORM/Internal/ConcurrentLruCache.cs
+++ b/src/nORM/Internal/ConcurrentLruCache.cs
@@ -13,7 +13,7 @@ namespace nORM.Internal
         private readonly LinkedList<CacheItem> _lruList = new();
         // Protects access to _lruList, which is not thread-safe.
         private readonly object _lock = new();
-        private readonly int _maxSize;
+        private int _maxSize;
         private readonly TimeSpan? _timeToLive;
         private long _hits;
         private long _misses;
@@ -120,6 +120,20 @@ namespace nORM.Internal
             {
                 _cache.Clear();
                 _lruList.Clear();
+            }
+        }
+
+        public void SetMaxSize(int maxSize)
+        {
+            lock (_lock)
+            {
+                _maxSize = maxSize;
+                while (_lruList.Count > _maxSize)
+                {
+                    var lastNode = _lruList.Last!;
+                    _lruList.RemoveLast();
+                    _cache.TryRemove(lastNode.Value.Key, out _);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Resize plan cache based on available memory and clear under high memory pressure
- Allow ConcurrentLruCache to update its max size dynamically

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68bb3cf81f38832c916007c57a18a33e