### PR TITLE
Refactor QueryTranslator into smaller builders

### DIFF
--- a/src/nORM/Query/JoinBuilder.cs
+++ b/src/nORM/Query/JoinBuilder.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using nORM.Mapping;
+
+namespace nORM.Query
+{
+    /// <summary>
+    /// Responsible for constructing SQL JOIN clauses and managing join specific
+    /// projection setup. Extracted from <see cref="QueryTranslator"/>.
+    /// </summary>
+    internal static class JoinBuilder
+    {
+        public static string BuildJoinClause(
+            LambdaExpression? projection,
+            TableMapping outerMapping,
+            string outerAlias,
+            TableMapping innerMapping,
+            string innerAlias,
+            string joinType,
+            string outerKeySql,
+            string innerKeySql,
+            string? orderBy = null)
+        {
+            using var joinSql = new OptimizedSqlBuilder(256);
+
+            if (projection?.Body is NewExpression newExpr)
+            {
+                var neededColumns = ExtractNeededColumns(newExpr, outerMapping, innerMapping);
+                if (neededColumns.Count == 0)
+                {
+                    var outerCols = outerMapping.Columns.Select(c => $"{outerAlias}.{c.EscCol}");
+                    var innerCols = innerMapping.Columns.Select(c => $"{innerAlias}.{c.EscCol}");
+                    joinSql.AppendSelect(System.ReadOnlySpan<char>.Empty);
+                    joinSql.InnerBuilder.AppendJoin(", ", outerCols.Concat(innerCols));
+                    joinSql.Append(' ');
+                }
+                else
+                {
+                    joinSql.AppendSelect(System.ReadOnlySpan<char>.Empty);
+                    joinSql.InnerBuilder.AppendJoin(", ", neededColumns);
+                    joinSql.Append(' ');
+                }
+            }
+            else
+            {
+                var outerCols = outerMapping.Columns.Select(c => $"{outerAlias}.{c.EscCol}");
+                var innerCols = innerMapping.Columns.Select(c => $"{innerAlias}.{c.EscCol}");
+                joinSql.AppendSelect(System.ReadOnlySpan<char>.Empty);
+                joinSql.InnerBuilder.AppendJoin(", ", outerCols.Concat(innerCols));
+                joinSql.Append(' ');
+            }
+
+            joinSql.Append($"FROM {outerMapping.EscTable} {outerAlias} ");
+            joinSql.Append($"{joinType} {innerMapping.EscTable} {innerAlias} ");
+            joinSql.Append($"ON {outerKeySql} = {innerKeySql}");
+            if (orderBy != null)
+                joinSql.Append($" ORDER BY {orderBy}");
+
+            return joinSql.ToSqlString();
+        }
+
+        public static void SetupJoinProjection(
+            LambdaExpression? resultSelector,
+            TableMapping outerMapping,
+            TableMapping innerMapping,
+            string outerAlias,
+            string innerAlias,
+            Dictionary<ParameterExpression, (TableMapping Mapping, string Alias)> correlatedParams,
+            ref LambdaExpression? projection)
+        {
+            projection = resultSelector;
+            if (resultSelector != null)
+            {
+                if (!correlatedParams.ContainsKey(resultSelector.Parameters[0]))
+                    correlatedParams[resultSelector.Parameters[0]] = (outerMapping, outerAlias);
+                if (!correlatedParams.ContainsKey(resultSelector.Parameters[1]))
+                    correlatedParams[resultSelector.Parameters[1]] = (innerMapping, innerAlias);
+            }
+        }
+
+        public static List<string> ExtractNeededColumns(NewExpression newExpr, TableMapping outerMapping, TableMapping innerMapping)
+        {
+            var neededColumns = new List<string>();
+            var outerAlias = "T0";
+            var innerAlias = "T1";
+
+            foreach (var arg in newExpr.Arguments)
+            {
+                if (arg is MemberExpression memberExpr && memberExpr.Expression is ParameterExpression paramExpr)
+                {
+                    var isOuterTable = paramExpr.Type == outerMapping.Type;
+                    var mapping = isOuterTable ? outerMapping : innerMapping;
+                    var alias = isOuterTable ? outerAlias : innerAlias;
+
+                    if (mapping.ColumnsByName.TryGetValue(memberExpr.Member.Name, out var column))
+                    {
+                        var colSql = $"{alias}.{column.EscCol}";
+                        if (!neededColumns.Contains(colSql))
+                            neededColumns.Add(colSql);
+                    }
+                }
+                else if (arg is ParameterExpression param)
+                {
+                    var isOuter = param.Type == outerMapping.Type;
+                    var mapping = isOuter ? outerMapping : innerMapping;
+                    var alias = isOuter ? outerAlias : innerAlias;
+                    foreach (var col in mapping.Columns)
+                    {
+                        var colSql = $"{alias}.{col.EscCol}";
+                        if (!neededColumns.Contains(colSql))
+                            neededColumns.Add(colSql);
+                    }
+                }
+            }
+
+            return neededColumns;
+        }
+    }
+}

--- a/src/nORM/Query/ParameterManager.cs
+++ b/src/nORM/Query/ParameterManager.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace nORM.Query
+{
+    /// <summary>
+    /// Manages SQL parameters, compiled parameter names and mapping between
+    /// expression parameters and generated SQL parameter placeholders.
+    /// Extracted from <see cref="QueryTranslator"/> to comply with the
+    /// single responsibility principle.
+    /// </summary>
+    internal sealed class ParameterManager
+    {
+        public Dictionary<string, object> Parameters { get; set; } = new();
+        public List<string> CompiledParameters { get; set; } = new();
+        public Dictionary<ParameterExpression, string> ParameterMap { get; set; } = new();
+        public int Index;
+
+        public void Reset()
+        {
+            Parameters = new Dictionary<string, object>();
+            CompiledParameters = new List<string>();
+            ParameterMap = new Dictionary<ParameterExpression, string>();
+            Index = 0;
+        }
+    }
+}

--- a/src/nORM/Query/QueryTranslator.MethodTranslators.cs
+++ b/src/nORM/Query/QueryTranslator.MethodTranslators.cs
@@ -169,7 +169,7 @@ namespace nORM.Query
                 {
                     if (!t._paramMap.TryGetValue(tp, out var tName))
                     {
-                        tName = t._ctx.Provider.ParamPrefix + "p" + t._paramIndex++;
+                        tName = t._ctx.Provider.ParamPrefix + "p" + t._parameterManager.Index++;
                         t._params[tName] = DBNull.Value;
                         t._compiledParams.Add(tName);
                         t._paramMap[tp] = tName;
@@ -178,7 +178,7 @@ namespace nORM.Query
                 }
                 else if (QueryTranslator.TryGetIntValue(node.Arguments[1], out int take))
                 {
-                    var pName = t._ctx.Provider.ParamPrefix + "p" + t._paramIndex++;
+                    var pName = t._ctx.Provider.ParamPrefix + "p" + t._parameterManager.Index++;
                     t._params[pName] = take;
                     t._take = take;
                     t._takeParam = pName;
@@ -196,7 +196,7 @@ namespace nORM.Query
                 {
                     if (!t._paramMap.TryGetValue(sp, out var sName))
                     {
-                        sName = t._ctx.Provider.ParamPrefix + "p" + t._paramIndex++;
+                        sName = t._ctx.Provider.ParamPrefix + "p" + t._parameterManager.Index++;
                         t._params[sName] = DBNull.Value;
                         t._compiledParams.Add(sName);
                         t._paramMap[sp] = sName;
@@ -205,7 +205,7 @@ namespace nORM.Query
                 }
                 else if (QueryTranslator.TryGetIntValue(node.Arguments[1], out int skip))
                 {
-                    var pName = t._ctx.Provider.ParamPrefix + "p" + t._paramIndex++;
+                    var pName = t._ctx.Provider.ParamPrefix + "p" + t._parameterManager.Index++;
                     t._params[pName] = skip;
                     t._skip = skip;
                     t._skipParam = pName;
@@ -299,7 +299,7 @@ namespace nORM.Query
                 {
                     if (!t._paramMap.TryGetValue(eaParam, out var eName))
                     {
-                        eName = t._ctx.Provider.ParamPrefix + "p" + t._paramIndex++;
+                        eName = t._ctx.Provider.ParamPrefix + "p" + t._parameterManager.Index++;
                         t._params[eName] = DBNull.Value;
                         t._compiledParams.Add(eName);
                         t._paramMap[eaParam] = eName;
@@ -327,7 +327,7 @@ namespace nORM.Query
                 }
 
                 t._take = 1;
-                var pName = t._ctx.Provider.ParamPrefix + "p" + t._paramIndex++;
+                var pName = t._ctx.Provider.ParamPrefix + "p" + t._parameterManager.Index++;
                 t._params[pName] = 1;
                 t._takeParam = pName;
                 t._singleResult = t._methodName == "ElementAt";
@@ -358,7 +358,7 @@ namespace nORM.Query
                     ExpressionVisitorPool.Return(visitor);
                 }
                 t._take = 1;
-                var pName = t._ctx.Provider.ParamPrefix + "p" + t._paramIndex++;
+                var pName = t._ctx.Provider.ParamPrefix + "p" + t._parameterManager.Index++;
                 t._params[pName] = 1;
                 t._takeParam = pName;
                 t._singleResult = t._methodName == "First" || t._methodName == "Single";
@@ -400,7 +400,7 @@ namespace nORM.Query
                         t._orderBy.Add((key.EscCol, false));
                 }
                 t._take = 1;
-                var pName = t._ctx.Provider.ParamPrefix + "p" + t._paramIndex++;
+                var pName = t._ctx.Provider.ParamPrefix + "p" + t._parameterManager.Index++;
                 t._params[pName] = 1;
                 t._takeParam = pName;
                 t._singleResult = t._methodName == "Last";

--- a/src/nORM/Query/SqlBuilder.cs
+++ b/src/nORM/Query/SqlBuilder.cs
@@ -5,8 +5,10 @@ namespace nORM.Query
 {
     /// <summary>
     /// Container for the various SQL clause builders used by <see cref="QueryTranslator"/>.
+    /// Renamed from <c>SqlClauseBuilder</c> to emphasize its role as a focused
+    /// SQL construction utility.
     /// </summary>
-    internal sealed class SqlClauseBuilder : IDisposable
+    internal sealed class SqlBuilder : IDisposable
     {
         public OptimizedSqlBuilder Sql { get; } = new();
         public OptimizedSqlBuilder Where { get; } = new();


### PR DESCRIPTION
## Summary
- Introduce `ParameterManager` to own SQL parameters and mappings
- Add `JoinBuilder` for JOIN SQL construction and projection mapping
- Rename `SqlClauseBuilder` to `SqlBuilder` and update `QueryTranslator` to delegate to new helpers

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb4088b334832c9574f283a651f01a