### PR TITLE
Dispose connection when factory creation fails

### DIFF
--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -93,12 +93,17 @@ namespace nORM.Core
 
         private static DbConnection CreateConnectionSafe(string connectionString, DatabaseProvider provider)
         {
+            DbConnection? connection = null;
+
             try
             {
-                return DbConnectionFactory.Create(connectionString, provider);
+                connection = DbConnectionFactory.Create(connectionString, provider);
+                return connection;
             }
             catch (Exception ex)
             {
+                connection?.Dispose();
+
                 var safeConnStr = NormValidator.MaskSensitiveConnectionStringData(connectionString);
                 throw new ArgumentException($"Invalid connection string format: {safeConnStr}", nameof(connectionString), ex);
             }


### PR DESCRIPTION
## Summary
- ensure CreateConnectionSafe disposes partially created connections

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb43c87454832c955eb2272af1f747