### PR TITLE
Optimize parameter addition by pre-filtering columns

### DIFF
--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -560,12 +560,12 @@ namespace nORM.Core
             switch (operation)
             {
                 case WriteOperation.Insert:
-                    foreach (var col in map.Columns.Where(c => !c.IsDbGenerated))
+                    foreach (var col in map.InsertColumns)
                         cmd.AddParam(_p.ParamPrefix + col.PropName, col.Getter(entity));
                     break;
-                    
+
                 case WriteOperation.Update:
-                    foreach (var col in map.Columns.Where(c => !c.IsKey && !c.IsTimestamp))
+                    foreach (var col in map.UpdateColumns)
                         cmd.AddParam(_p.ParamPrefix + col.PropName, col.Getter(entity));
                     foreach (var col in map.KeyColumns)
                         cmd.AddParam(_p.ParamPrefix + col.PropName, col.Getter(entity));

--- a/src/nORM/Mapping/TableMapping.cs
+++ b/src/nORM/Mapping/TableMapping.cs
@@ -24,6 +24,8 @@ namespace nORM.Mapping
         public readonly Column[] KeyColumns;
         public readonly Column? TimestampColumn;
         public readonly Column? TenantColumn;
+        public readonly Column[] InsertColumns;
+        public readonly Column[] UpdateColumns;
         public string TableName { get; }
         public readonly Dictionary<string, Relation> Relations = new();
         public readonly DatabaseProvider Provider;
@@ -88,6 +90,8 @@ namespace nORM.Mapping
             KeyColumns = Columns.Where(c => c.IsKey).ToArray();
             TimestampColumn = Columns.FirstOrDefault(c => c.IsTimestamp);
             TenantColumn = Columns.FirstOrDefault(c => c.PropName == ctx.Options.TenantColumnName);
+            InsertColumns = Columns.Where(c => !c.IsDbGenerated).ToArray();
+            UpdateColumns = Columns.Where(c => !c.IsKey && !c.IsTimestamp).ToArray();
 
             DiscoverRelations(ctx);
         }


### PR DESCRIPTION
## Summary
- Precompute insertable and updatable columns in `TableMapping` to avoid runtime LINQ.
- Use these cached column sets in `AddParametersOptimized` for more efficient parameter binding.

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb44a18890832c9d54fb7fbb7f007c