### PR TITLE
Honor cancellation tokens in materializers

### DIFF
--- a/src/SourceGeneration/CompiledMaterializerStore.cs
+++ b/src/SourceGeneration/CompiledMaterializerStore.cs
@@ -12,10 +12,18 @@ namespace nORM.SourceGeneration
         private static readonly ConcurrentLruCache<Type, (Delegate Typed, Func<DbDataReader, CancellationToken, Task<object>> Untyped)> _map = new(maxSize: 500);
 
         public static void Add(Type type, Func<DbDataReader, object> materializer)
-            => _map.GetOrAdd(type, _ => (materializer, (reader, ct) => Task.FromResult(materializer(reader))));
+            => _map.GetOrAdd(type, _ => (materializer, (reader, ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult(materializer(reader));
+            }));
 
         public static void Add<T>(Func<DbDataReader, T> materializer)
-            => _map.GetOrAdd(typeof(T), _ => (materializer, (reader, ct) => Task.FromResult((object)materializer(reader)!)));
+            => _map.GetOrAdd(typeof(T), _ => (materializer, (reader, ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult((object)materializer(reader)!);
+            }));
 
         public static bool TryGet(Type type, out Func<DbDataReader, CancellationToken, Task<object>> materializer)
         {
@@ -32,7 +40,11 @@ namespace nORM.SourceGeneration
         {
             if (!_map.TryGet(typeof(T), out var entry))
                 throw new KeyNotFoundException($"Materializer for {typeof(T)} not found.");
-            return (reader, ct) => Task.FromResult(((Func<DbDataReader, T>)entry.Typed)(reader));
+            return (reader, ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult(((Func<DbDataReader, T>)entry.Typed)(reader));
+            };
         }
     }
 }

--- a/src/nORM/Query/MaterializerFactory.cs
+++ b/src/nORM/Query/MaterializerFactory.cs
@@ -56,7 +56,11 @@ namespace nORM.Query
             {
                 var sync = CreateMaterializerInternal(mapping, targetType, projection);
                 ValidateMaterializer(sync, mapping, targetType);
-                return (reader, ct) => Task.FromResult(sync(reader));
+                return (reader, ct) =>
+                {
+                    ct.ThrowIfCancellationRequested();
+                    return Task.FromResult(sync(reader));
+                };
             });
         }
 

--- a/tests/MaterializerCancellationTests.cs
+++ b/tests/MaterializerCancellationTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using nORM.Core;
+using nORM.Providers;
+using nORM.SourceGeneration;
+using Xunit;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace nORM.Tests
+{
+    public class MaterializerCancellationTests
+    {
+        private class Uncompiled
+        {
+            public int Id { get; set; }
+        }
+
+        [Fact]
+        public async Task Compiled_materializer_honors_cancellation()
+        {
+            Assert.True(CompiledMaterializerStore.TryGet(typeof(Materialized), out var mat));
+
+            using var cn = new SqliteConnection("Data Source=:memory:");
+            cn.Open();
+            using var cmd = cn.CreateCommand();
+            cmd.CommandText = "SELECT 1 AS Id";
+            using var reader = cmd.ExecuteReader();
+            Assert.True(reader.Read());
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await mat(reader, cts.Token));
+        }
+
+        [Fact]
+        public async Task Runtime_materializer_honors_cancellation()
+        {
+            using var cn = new SqliteConnection("Data Source=:memory:");
+            cn.Open();
+            using var ctx = new DbContext(cn, new SqliteProvider());
+            var translatorType = typeof(DbContext).Assembly.GetType("nORM.Query.QueryTranslator", true)!;
+            var translator = Activator.CreateInstance(translatorType, ctx)!;
+            var getMapping = typeof(DbContext).GetMethod("GetMapping", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var mapping = getMapping.Invoke(ctx, new object[] { typeof(Uncompiled) });
+            var create = translatorType.GetMethod("CreateMaterializer")!;
+            var materializer = (Func<DbDataReader, CancellationToken, Task<object>>)create.Invoke(translator, new object?[] { mapping!, typeof(Uncompiled), null })!;
+
+            using var cmd = cn.CreateCommand();
+            cmd.CommandText = "SELECT 1 AS Id";
+            using var reader = cmd.ExecuteReader();
+            Assert.True(reader.Read());
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await materializer(reader, cts.Token));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure materializers throw when cancellation is requested
- propagate cancellation token handling to compiled materializer store
- add tests for cancellation token honoring

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb471edb84832c924ed7683e4a87b2