### PR TITLE
refactor: introduce provider capabilities

### DIFF
--- a/src/nORM/Navigation/BatchedNavigationLoader.cs
+++ b/src/nORM/Navigation/BatchedNavigationLoader.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using nORM.Core;
@@ -117,34 +116,8 @@ namespace nORM.Navigation
             await _context.EnsureConnectionAsync(default).ConfigureAwait(false);
             using var cmd = _context.Connection.CreateCommand();
 
-            if (_context.Provider is PostgresProvider)
-            {
-                var pName = _context.Provider.ParamPrefix + "p0";
-                var p = cmd.CreateParameter();
-                p.ParameterName = pName;
-                p.Value = keys.ToArray();
-                cmd.Parameters.Add(p);
-                cmd.CommandText = $"SELECT * FROM {mapping.EscTable} WHERE {relation.ForeignKey.EscCol} = ANY({pName})";
-            }
-            else if (_context.Provider is SqlServerProvider)
-            {
-                var pName = _context.Provider.ParamPrefix + "p0";
-                var joined = string.Join(",", keys.Select(k => Convert.ToString(k, CultureInfo.InvariantCulture)));
-                cmd.AddParam(pName, joined);
-                cmd.CommandText = $"SELECT * FROM {mapping.EscTable} WHERE {relation.ForeignKey.EscCol} IN (SELECT value FROM STRING_SPLIT({pName}, ','))";
-            }
-            else
-            {
-                var paramNames = new List<string>();
-                for (int i = 0; i < keys.Count; i++)
-                {
-                    var pn = _context.Provider.ParamPrefix + "p" + i;
-                    paramNames.Add(pn);
-                    cmd.AddParam(pn, keys[i]);
-                }
-
-                cmd.CommandText = $"SELECT * FROM {mapping.EscTable} WHERE {relation.ForeignKey.EscCol} IN ({PooledStringBuilder.Join(paramNames, ",")})";
-            }
+            var where = _context.Provider.BuildContainsClause(cmd, relation.ForeignKey.EscCol, keys);
+            cmd.CommandText = $"SELECT * FROM {mapping.EscTable} WHERE {where}";
 
             cmd.CommandTimeout = (int)_context.GetAdaptiveTimeout(AdaptiveTimeoutManager.OperationType.ComplexSelect, cmd.CommandText).TotalSeconds;
 

--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -79,6 +79,24 @@ namespace nORM.Providers
             throw new NotSupportedException($"Savepoints are not supported for transactions of type {transaction.GetType().FullName}.");
         }
 
+        public virtual Task InitializeConnectionAsync(DbConnection connection, CancellationToken ct) => Task.CompletedTask;
+
+        public virtual void InitializeConnection(DbConnection connection) { }
+
+        public virtual CommandType StoredProcedureCommandType => CommandType.StoredProcedure;
+
+        public virtual string BuildContainsClause(DbCommand cmd, string columnName, IReadOnlyList<object?> values)
+        {
+            var paramNames = new List<string>(values.Count);
+            for (int i = 0; i < values.Count; i++)
+            {
+                var pn = $"{ParamPrefix}p{i}";
+                cmd.AddParam(pn, values[i]);
+                paramNames.Add(pn);
+            }
+            return $"{columnName} IN ({string.Join(",", paramNames)})";
+        }
+
         protected virtual Task<bool> IsTransactionLogNearCapacityAsync(DbContext ctx, CancellationToken ct)
             => Task.FromResult(false);
 

--- a/src/nORM/Providers/PostgresProvider.cs
+++ b/src/nORM/Providers/PostgresProvider.cs
@@ -102,6 +102,16 @@ namespace nORM.Providers
             return $"jsonb_extract_path_text({columnName}, {pgPath})";
         }
 
+        public override string BuildContainsClause(DbCommand cmd, string columnName, IReadOnlyList<object?> values)
+        {
+            var pName = ParamPrefix + "p0";
+            var p = cmd.CreateParameter();
+            p.ParameterName = pName;
+            p.Value = values.ToArray();
+            cmd.Parameters.Add(p);
+            return $"{columnName} = ANY({pName})";
+        }
+
         public override string GenerateCreateHistoryTableSql(TableMapping mapping)
         {
             var historyTable = Escape(mapping.TableName + "_History");

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -12,6 +12,7 @@ using nORM.Core;
 using nORM.Internal;
 using nORM.Mapping;
 using Microsoft.Extensions.Logging;
+using System.Globalization;
 
 #nullable enable
 
@@ -105,6 +106,14 @@ namespace nORM.Providers
 
         public override string TranslateJsonPathAccess(string columnName, string jsonPath)
             => $"JSON_VALUE({columnName}, '{jsonPath}')";
+
+        public override string BuildContainsClause(DbCommand cmd, string columnName, IReadOnlyList<object?> values)
+        {
+            var pName = ParamPrefix + "p0";
+            var joined = string.Join(",", values.Select(v => Convert.ToString(v, CultureInfo.InvariantCulture)));
+            cmd.AddParam(pName, joined);
+            return $"{columnName} IN (SELECT value FROM STRING_SPLIT({pName}, ','))";
+        }
 
         public override string GenerateCreateHistoryTableSql(TableMapping mapping)
         {


### PR DESCRIPTION
## Summary
- add capability methods to `DatabaseProvider`
- use provider-driven initialization and stored procedure command type in `DbContext`
- leverage provider clause builders for batched navigation loading

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68bb46bd68f0832c9dfe60437c2ef326