### PR TITLE
Fix parameter index race condition

### DIFF
--- a/src/nORM/Query/ExpressionToSqlVisitor.cs
+++ b/src/nORM/Query/ExpressionToSqlVisitor.cs
@@ -455,8 +455,9 @@ namespace nORM.Query
             var rootType = GetRootElementType(source);
             var mapping = _ctx.GetMapping(rootType);
 
-            using var subTranslator = QueryTranslator.Create(_ctx, mapping, _params, ref _paramIndex, _parameterMappings, new HashSet<string>(), _compiledParams, _paramMap, _parameterMappings.Count);
+            using var subTranslator = QueryTranslator.Create(_ctx, mapping, _params, _paramIndex, _parameterMappings, new HashSet<string>(), _compiledParams, _paramMap, _parameterMappings.Count);
             var subPlan = subTranslator.Translate(source);
+            _paramIndex = subTranslator.ParameterIndex;
 
             _sql.Append(negate ? "NOT EXISTS(" : "EXISTS(");
             _sql.Append(subPlan.Sql);
@@ -468,8 +469,9 @@ namespace nORM.Query
             var rootType = GetRootElementType(source);
             var mapping = _ctx.GetMapping(rootType);
 
-            using var subTranslator = QueryTranslator.Create(_ctx, mapping, _params, ref _paramIndex, _parameterMappings, new HashSet<string>(), _compiledParams, _paramMap, _parameterMappings.Count);
+            using var subTranslator = QueryTranslator.Create(_ctx, mapping, _params, _paramIndex, _parameterMappings, new HashSet<string>(), _compiledParams, _paramMap, _parameterMappings.Count);
             var subPlan = subTranslator.Translate(source);
+            _paramIndex = subTranslator.ParameterIndex;
 
             Visit(value);
             _sql.Append(" IN (");

--- a/src/nORM/Query/ParameterManager.cs
+++ b/src/nORM/Query/ParameterManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Threading;
 
 namespace nORM.Query
 {
@@ -14,14 +15,23 @@ namespace nORM.Query
         public Dictionary<string, object> Parameters { get; set; } = new();
         public List<string> CompiledParameters { get; set; } = new();
         public Dictionary<ParameterExpression, string> ParameterMap { get; set; } = new();
-        public int Index;
+
+        private int _index;
+
+        public int Index
+        {
+            get => Volatile.Read(ref _index);
+            set => Volatile.Write(ref _index, value);
+        }
+
+        public int GetNextIndex() => Interlocked.Increment(ref _index) - 1;
 
         public void Reset()
         {
             Parameters = new Dictionary<string, object>();
             CompiledParameters = new List<string>();
             ParameterMap = new Dictionary<ParameterExpression, string>();
-            Index = 0;
+            Volatile.Write(ref _index, 0);
         }
     }
 }


### PR DESCRIPTION
## Summary
- make parameter index generation atomic to avoid race conditions
- propagate parameter index from sub-translators

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb4d2c0c44832ca092b48cc13c7356