### PR TITLE
Escape table aliases to prevent SQL injection

### DIFF
--- a/src/nORM/Query/ExpressionToSqlVisitor.cs
+++ b/src/nORM/Query/ExpressionToSqlVisitor.cs
@@ -149,10 +149,8 @@ namespace nORM.Query
             {
                 if (info.Mapping.ColumnsByName.TryGetValue(node.Member.Name, out var column))
                 {
-                    // Table aliases are generated internally (e.g. T0, T1) and are not influenced
-                    // by user input, so escaping them adds unnecessary quoting that breaks
-                    // expected SQL output. Use the alias directly while keeping column names
-                    // escaped to avoid injection.
+                    // Table aliases are generated internally and escaped when created,
+                    // allowing them to be used safely without additional validation.
                     _sql.Append($"{info.Alias}.{column.EscCol}");
                     return node;
                 }

--- a/src/nORM/Query/JoinBuilder.cs
+++ b/src/nORM/Query/JoinBuilder.cs
@@ -26,7 +26,7 @@ namespace nORM.Query
 
             if (projection?.Body is NewExpression newExpr)
             {
-                var neededColumns = ExtractNeededColumns(newExpr, outerMapping, innerMapping);
+                var neededColumns = ExtractNeededColumns(newExpr, outerMapping, innerMapping, outerAlias, innerAlias);
                 if (neededColumns.Count == 0)
                 {
                     var outerCols = outerMapping.Columns.Select(c => $"{outerAlias}.{c.EscCol}");
@@ -79,11 +79,9 @@ namespace nORM.Query
             }
         }
 
-        public static List<string> ExtractNeededColumns(NewExpression newExpr, TableMapping outerMapping, TableMapping innerMapping)
+        public static List<string> ExtractNeededColumns(NewExpression newExpr, TableMapping outerMapping, TableMapping innerMapping, string outerAlias, string innerAlias)
         {
             var neededColumns = new List<string>();
-            var outerAlias = "T0";
-            var innerAlias = "T1";
 
             foreach (var arg in newExpr.Arguments)
             {

--- a/src/nORM/Query/QueryTranslator.MethodTranslators.cs
+++ b/src/nORM/Query/QueryTranslator.MethodTranslators.cs
@@ -109,7 +109,7 @@ namespace nORM.Query
                     var param = lambda.Parameters[0];
                     if (!t._correlatedParams.TryGetValue(param, out var info))
                     {
-                        info = (t._mapping, "T" + t._joinCounter);
+                        info = (t._mapping, t.EscapeAlias("T" + t._joinCounter));
                         t._correlatedParams[param] = info;
                     }
                     var vctx = new VisitorContext(t._ctx, t._mapping, t._provider, param, info.Alias, t._correlatedParams, t._compiledParams, t._paramMap);
@@ -147,7 +147,7 @@ namespace nORM.Query
                     var param = keySelector.Parameters[0];
                     if (!t._correlatedParams.TryGetValue(param, out var info))
                     {
-                        info = (t._mapping, "T" + t._joinCounter);
+                        info = (t._mapping, t.EscapeAlias("T" + t._joinCounter));
                         t._correlatedParams[param] = info;
                     }
                     var vctx = new VisitorContext(t._ctx, t._mapping, t._provider, param, info.Alias, t._correlatedParams, t._compiledParams, t._paramMap);
@@ -345,7 +345,7 @@ namespace nORM.Query
                 if (node.Arguments.Count > 1 && node.Arguments[1] is LambdaExpression predicate)
                 {
                     var param = predicate.Parameters[0];
-                    var alias = "T" + t._joinCounter;
+                    var alias = t.EscapeAlias("T" + t._joinCounter);
                     if (!t._correlatedParams.ContainsKey(param))
                         t._correlatedParams[param] = (t._mapping, alias);
                     var vctxFS = new VisitorContext(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
@@ -373,7 +373,7 @@ namespace nORM.Query
                 if (node.Arguments.Count > 1 && node.Arguments[1] is LambdaExpression lastPredicate)
                 {
                     var param = lastPredicate.Parameters[0];
-                    var alias = "T" + t._joinCounter;
+                    var alias = t.EscapeAlias("T" + t._joinCounter);
                     if (!t._correlatedParams.ContainsKey(param))
                         t._correlatedParams[param] = (t._mapping, alias);
                     var vctxLast = new VisitorContext(t._ctx, t._mapping, t._provider, param, alias, t._correlatedParams, t._compiledParams, t._paramMap);
@@ -423,7 +423,7 @@ namespace nORM.Query
                     var param = countPredicate.Parameters[0];
                     if (!t._correlatedParams.TryGetValue(param, out var info))
                     {
-                        info = (t._mapping, "T" + t._joinCounter);
+                        info = (t._mapping, t.EscapeAlias("T" + t._joinCounter));
                         t._correlatedParams[param] = info;
                     }
                     var vctxCount = new VisitorContext(t._ctx, t._mapping, t._provider, param, info.Alias, t._correlatedParams, t._compiledParams, t._paramMap);

--- a/tests/ExpressionToSqlVisitorTests.cs
+++ b/tests/ExpressionToSqlVisitorTests.cs
@@ -65,7 +65,8 @@ namespace nORM.Tests
             var provider = setup.Provider;
 
             var (sql, parameters) = Translate<Product>(p => p.Id == 5, connection, provider);
-            var expected = $"(T0.{provider.Escape("Id")} = @p0)";
+            var t0 = provider.Escape("T0");
+            var expected = $"({t0}.{provider.Escape("Id")} = @p0)";
             Assert.Equal(expected, sql);
             Assert.Single(parameters);
             Assert.Equal(5, parameters["@p0"]);
@@ -80,7 +81,8 @@ namespace nORM.Tests
             var provider = setup.Provider;
 
             var (sql, parameters) = Translate(predicate, connection, provider);
-            var expectedSql = $"(T0.{provider.Escape(column)} > @p0)";
+            var t0 = provider.Escape("T0");
+            var expectedSql = $"({t0}.{provider.Escape(column)} > @p0)";
             Assert.Equal(expectedSql, sql);
             Assert.Single(parameters);
             Assert.Equal(expectedParam, parameters["@p0"]);
@@ -96,7 +98,8 @@ namespace nORM.Tests
 
             Expression<Func<Product, bool>> expr = p => p.Id == 5 && p.Id > 5;
             var (sql, parameters) = Translate(expr, connection, provider);
-            var expected = $"((T0.{provider.Escape("Id")} = @p0) AND (T0.{provider.Escape("Id")} > @p0))";
+            var t0 = provider.Escape("T0");
+            var expected = $"(({t0}.{provider.Escape("Id")} = @p0) AND ({t0}.{provider.Escape("Id")} > @p0))";
             Assert.Equal(expected, sql);
             Assert.Single(parameters);
             Assert.Equal(5, parameters["@p0"]);
@@ -111,7 +114,8 @@ namespace nORM.Tests
             var provider = setup.Provider;
 
             var (sql, parameters) = Translate<Product>(p => p.Name!.ToUpper() == "ABC", connection, provider);
-            var expected = $"(UPPER(T0.{provider.Escape("Name")}) = @p0)";
+            var t0 = provider.Escape("T0");
+            var expected = $"(UPPER({t0}.{provider.Escape("Name")}) = @p0)";
             Assert.Equal(expected, sql);
             Assert.Single(parameters);
             Assert.Equal("ABC", parameters["@p0"]);
@@ -126,7 +130,8 @@ namespace nORM.Tests
             var provider = setup.Provider;
 
             var (sql, parameters) = Translate<Product>(p => CustomFunctions.Soundex(p.Name!) == "ABC", connection, provider);
-            var expected = $"(SOUNDEX(T0.{provider.Escape("Name")}) = @p0)";
+            var t0 = provider.Escape("T0");
+            var expected = $"(SOUNDEX({t0}.{provider.Escape("Name")}) = @p0)";
             Assert.Equal(expected, sql);
             Assert.Single(parameters);
             Assert.Equal("ABC", parameters["@p0"]);
@@ -141,7 +146,8 @@ namespace nORM.Tests
             var provider = setup.Provider;
 
             var (sql, parameters) = Translate<JsonEntity>(e => Json.Value<string>(e.ProfileData!, "$.address.city") == "New York", connection, provider);
-            var columnSql = $"T0.{provider.Escape("ProfileData")}";
+            var t0 = provider.Escape("T0");
+            var columnSql = $"{t0}.{provider.Escape("ProfileData")}";
             var expected = $"({provider.TranslateJsonPathAccess(columnSql, "$.address.city")} = @p0)";
             Assert.Equal(expected, sql);
             Assert.Single(parameters);

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -17,7 +17,7 @@ public abstract class TestBase
         var getMapping = typeof(DbContext).GetMethod("GetMapping", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
         var mapping = getMapping.Invoke(ctx, new object[] { typeof(T) });
         var visitorType = typeof(DbContext).Assembly.GetType("nORM.Query.ExpressionToSqlVisitor", true)!;
-        var visitor = Activator.CreateInstance(visitorType, ctx, mapping, ctx.Provider, expr.Parameters[0], "T0", null, null, null)!;
+        var visitor = Activator.CreateInstance(visitorType, ctx, mapping, ctx.Provider, expr.Parameters[0], provider.Escape("T0"), null, null, null)!;
         var sql = (string)visitorType.GetMethod("Translate")!.Invoke(visitor, new object[] { expr.Body })!;
         var parameters = (Dictionary<string, object>)visitorType.GetMethod("GetParameters")!.Invoke(visitor, null)!;
         return (sql, parameters);


### PR DESCRIPTION
## Summary
- Escape generated table aliases using provider-specific quoting
- Remove naive identifier checks and rely on proper alias escaping
- Update tests and query builders to use escaped aliases

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb4fece6a4832c8a8344ac1d88aac4