### PR TITLE
Handle platform-specific expression compilation with interpreter fallback

### DIFF
--- a/src/nORM/Internal/ExpressionCompiler.cs
+++ b/src/nORM/Internal/ExpressionCompiler.cs
@@ -91,7 +91,7 @@ namespace nORM.Internal
             ExpressionUtils.ValidateExpression(expression);
             var timeout = ExpressionUtils.GetCompilationTimeout(expression);
             using var cts = new CancellationTokenSource(timeout);
-            var del = ExpressionUtils.CompileWithTimeout(Expression.Lambda(expression), cts.Token);
+            var del = ExpressionUtils.CompileWithFallback(Expression.Lambda(expression), cts.Token);
             return del.DynamicInvoke();
         }
 

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -1403,7 +1403,7 @@ namespace nORM.Query
             ExpressionUtils.ValidateExpression(lambda);
             var timeout = ExpressionUtils.GetCompilationTimeout(lambda);
             using var cts = new CancellationTokenSource(timeout);
-            var invoker = ExpressionUtils.CompileWithTimeout(lambda, cts.Token);
+            var invoker = ExpressionUtils.CompileWithFallback(lambda, cts.Token);
 
             return obj =>
             {
@@ -1443,7 +1443,7 @@ namespace nORM.Query
             ExpressionUtils.ValidateExpression(lambda);
             var timeout = ExpressionUtils.GetCompilationTimeout(lambda);
             using var cts = new CancellationTokenSource(timeout);
-            return ExpressionUtils.CompileWithTimeout(lambda, cts.Token);
+            return ExpressionUtils.CompileWithFallback(lambda, cts.Token);
         }
 
         private sealed class ParameterReplacer : ExpressionVisitor


### PR DESCRIPTION
## Summary
- add CompileWithFallback to ExpressionUtils for platform-aware compilation
- use fallback compilation in QueryTranslator and ExpressionCompiler

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bb551db528832cb28066b843d0c977