### PR TITLE
Handle window function parameter name collisions

### DIFF
--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -475,7 +475,12 @@ namespace nORM.Query
                     defaultSql = $", {defSql}";
                 }
 
-                var offsetParam = _provider.ParamPrefix + "p" + _parameterManager.GetNextIndex();
+                string offsetParam;
+                do
+                {
+                    offsetParam = _provider.ParamPrefix + "p" + _parameterManager.GetNextIndex();
+                }
+                while (_params.ContainsKey(offsetParam));
                 _params[offsetParam] = wf.Offset;
                 return $"{wf.FunctionName}({valueSql}, {offsetParam}{defaultSql}) OVER ({overClause})";
             }

--- a/tests/WindowFunctionParameterTests.cs
+++ b/tests/WindowFunctionParameterTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using nORM.Core;
+using nORM.Query;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class WindowFunctionParameterTests : TestBase
+{
+    private class Item
+    {
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public void Offset_parameter_does_not_collide_with_existing_parameter()
+    {
+        var setup = CreateProvider(ProviderKind.Sqlite);
+        using var connection = setup.Connection;
+        var provider = setup.Provider;
+        using var ctx = new DbContext(connection, provider);
+        var translator = new QueryTranslator(ctx);
+
+        // Pre-populate parameter dictionary with an existing entry
+        var pmField = typeof(QueryTranslator).GetField("_parameterManager", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var pm = (ParameterManager)pmField.GetValue(translator)!;
+        var existingName = provider.ParamPrefix + "p0";
+        pm.Parameters[existingName] = 999;
+        pm.Index = 0; // Force next parameter to start from p0
+
+        // Build query that introduces a window function offset parameter
+        var query = ctx.Query<Item>()
+            .WithLag(i => i.Id, 1, (i, prev) => new { i.Id, Prev = prev });
+
+        var plan = translator.Translate(query.Expression);
+
+        Assert.Equal(2, plan.Parameters.Count); // original + offset
+        Assert.Equal(999, plan.Parameters[existingName]); // original value preserved
+        Assert.Contains(plan.Parameters, kv => kv.Key != existingName && kv.Value.Equals(1));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure window function offset parameter names are unique
- add regression test for offset parameter collision

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5640eb68832cabe6c9c9d4f9eadd