### PR TITLE
fix: resolve benchmark type warnings

### DIFF
--- a/benchmarks/OrmBenchmarks.cs
+++ b/benchmarks/OrmBenchmarks.cs
@@ -275,7 +275,7 @@ namespace nORM.Benchmarks
                     Age = reader.GetInt32(reader.GetOrdinal("Age")),
                     City = reader.GetString(reader.GetOrdinal("City")),
                     Department = reader.GetString(reader.GetOrdinal("Department")),
-                    Salary = reader.GetDecimal(reader.GetOrdinal("Salary"))
+                    Salary = (double)reader.GetDecimal(reader.GetOrdinal("Salary"))
                 });
             }
 
@@ -342,7 +342,7 @@ namespace nORM.Benchmarks
         {
             var result = await NormAsyncExtensions.ToListAsync(_nOrmContext!.Query<BenchmarkUser>()
                 .Join(
-                    _nOrmContext.Query<BenchmarkOrder>(),
+                    _nOrmContext!.Query<BenchmarkOrder>(),
                     u => u.Id,
                     o => o.UserId,
                     (u, o) => new JoinDto { Name = u.Name, Amount = o.Amount, ProductName = o.ProductName }


### PR DESCRIPTION
## Summary
- cast salary retrieval to double in raw ADO benchmarks
- ensure nORM context is marked non-null in join benchmark

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb708a3adc832c8934e3c4a20c427d