### PR TITLE
Handle MemberInit in join projection translation

### DIFF
--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -1470,7 +1470,16 @@ namespace nORM.Query
         {
             protected override Expression VisitMember(MemberExpression node)
             {
-                if (node.Expression is NewExpression newExpr && newExpr.Members != null)
+                if (node.Expression is MemberInitExpression memberInit)
+                {
+                    foreach (var binding in memberInit.Bindings)
+                    {
+                        if (binding is MemberAssignment assignment &&
+                            assignment.Member.Name == node.Member.Name)
+                            return Visit(assignment.Expression);
+                    }
+                }
+                else if (node.Expression is NewExpression newExpr && newExpr.Members != null)
                 {
                     for (int i = 0; i < newExpr.Members.Count; i++)
                     {

--- a/tests/JoinTests.cs
+++ b/tests/JoinTests.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using System.Collections.Generic;
+using nORM.Providers;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class JoinTests : TestBase
+{
+    private class Order
+    {
+        public int Id { get; set; }
+        public int UserId { get; set; }
+        public decimal Amount { get; set; }
+    }
+
+    private class JoinDto
+    {
+        public decimal Amount { get; set; }
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void Where_on_join_projection_translates(ProviderKind providerKind)
+    {
+        var setup = CreateProvider(providerKind);
+        using var connection = setup.Connection;
+        var provider = setup.Provider;
+
+        var (sql, _, _) = TranslateQuery<Order, JoinDto>(q =>
+            q.Join(q, o => o.Id, o2 => o2.Id, (o, o2) => new JoinDto { Amount = o2.Amount })
+             .Where(x => x.Amount > 100),
+            connection, provider);
+
+        Assert.Contains(provider.Escape("Amount"), sql);
+    }
+
+    public static IEnumerable<object[]> Providers()
+    {
+        yield return new object[] { ProviderKind.Sqlite };
+        yield return new object[] { ProviderKind.SqlServer };
+        yield return new object[] { ProviderKind.MySql };
+    }
+}


### PR DESCRIPTION
## Summary
- support MemberInit expressions in `ProjectionMemberReplacer` so `Where` clauses on join projections translate correctly
- add regression test ensuring join projection properties translate across providers

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb7410f318832c939c35464c5d2514