### PR TITLE
Add span-based SQL builder

### DIFF
--- a/src/nORM/Query/SpanSqlBuilder.cs
+++ b/src/nORM/Query/SpanSqlBuilder.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace nORM.Query
+{
+    /// <summary>
+    /// Span-based SQL builder for zero-allocation query construction.
+    /// </summary>
+    internal ref struct SpanSqlBuilder
+    {
+        private Span<char> _buffer;
+        private int _position;
+
+        public SpanSqlBuilder(Span<char> buffer)
+        {
+            _buffer = buffer;
+            _position = 0;
+        }
+
+        /// <summary>Append text to the builder.</summary>
+        public void Append(ReadOnlySpan<char> text)
+        {
+            text.CopyTo(_buffer.Slice(_position));
+            _position += text.Length;
+        }
+
+        /// <summary>Returns the built SQL as a string.</summary>
+        public override string ToString()
+            => new string(_buffer.Slice(0, _position));
+    }
+}


### PR DESCRIPTION
## Summary
- add `SpanSqlBuilder` for zero-allocation SQL building using spans

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bd7f4535ec832cadf8e7c02053d54b