### PR TITLE
Handle tuple parameters in compiled nORM queries

### DIFF
--- a/src/nORM/Internal/ExpressionCompiler.cs
+++ b/src/nORM/Internal/ExpressionCompiler.cs
@@ -78,8 +78,19 @@ namespace nORM.Internal
 
                 var parameters = cachedPlan.Parameters.ToDictionary(k => k.Key, v => v.Value);
                 if (paramNames != null)
-                    foreach (var name in paramNames)
-                        parameters[name] = value!;
+                {
+                    if (value is System.Runtime.CompilerServices.ITuple tuple)
+                    {
+                        var count = Math.Min(tuple.Length, paramNames.Count);
+                        for (int i = 0; i < count; i++)
+                            parameters[paramNames[i]] = tuple[i]!;
+                    }
+                    else
+                    {
+                        foreach (var name in paramNames)
+                            parameters[name] = value!;
+                    }
+                }
 
                 var execProvider = new NormQueryProvider(ctx);
                 return await execProvider.ExecuteCompiledAsync<List<T>>(cachedPlan, parameters, default).ConfigureAwait(false);

--- a/tests/CompiledQueryTests.cs
+++ b/tests/CompiledQueryTests.cs
@@ -15,6 +15,14 @@ public class CompiledQueryTests
         public string Name { get; set; } = string.Empty;
     }
 
+    public class PersonInfo
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int Age { get; set; }
+        public string City { get; set; } = string.Empty;
+    }
+
     [Fact]
     public async Task Compiled_query_executes_with_different_parameters()
     {
@@ -38,6 +46,28 @@ public class CompiledQueryTests
         var result2 = await compiled(ctx, 2);
         Assert.Single(result2);
         Assert.Equal("Bob", result2[0].Name);
+    }
+
+    [Fact]
+    public async Task Compiled_query_with_tuple_parameter_executes()
+    {
+        using var cn = new SqliteConnection("Data Source=:memory:");
+        cn.Open();
+        using (var cmd = cn.CreateCommand())
+        {
+            cmd.CommandText = "CREATE TABLE PersonInfo(Id INTEGER, Name TEXT, Age INTEGER, City TEXT);" +
+                             "INSERT INTO PersonInfo VALUES(1,'Alice',30,'NY');" +
+                             "INSERT INTO PersonInfo VALUES(2,'Bob',40,'LA');";
+            cmd.ExecuteNonQuery();
+        }
+
+        var compiled = Norm.CompileQuery<DbContext, (int, string), PersonInfo>(
+            (ctx, p) => ctx.Query<PersonInfo>().Where(x => x.Age > p.Item1 && x.City == p.Item2));
+
+        using var ctx = new DbContext(cn, new SqliteProvider());
+        var result = await compiled(ctx, (35, "LA"));
+        Assert.Single(result);
+        Assert.Equal(2, result[0].Id);
     }
 }
 

--- a/tests/nORM.Tests.csproj
+++ b/tests/nORM.Tests.csproj
@@ -12,9 +12,10 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\src\nORM.csproj" />
+    <ProjectReference Include="../src/nORM.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\src\nORM.SourceGenerators\nORM.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="../src/nORM.SourceGenerators/nORM.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>
+


### PR DESCRIPTION
## Summary
- support tuple parameter members when translating expressions to SQL
- extract ITuple values to individual parameters during compiled query execution
- add regression test for tuple-parameter compiled queries
- fix test project references for cross-platform paths

## Testing
- `dotnet test nORM.sln` *(fails: type or namespace 'Core' does not exist in the namespace 'nORM')*


------
https://chatgpt.com/codex/tasks/task_e_68be6d48b78c832c9200e8e8d6cb9833