### PR TITLE
Add fast-path SQL builder and provider interface

### DIFF
--- a/src/nORM/Providers/IFastProvider.cs
+++ b/src/nORM/Providers/IFastProvider.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace nORM.Providers
+{
+    public interface IFastProvider
+    {
+        void BuildSimpleSelect(Span<char> buffer, ReadOnlySpan<char> table,
+            ReadOnlySpan<char> columns, out int length);
+        char ParameterPrefixChar { get; }
+    }
+}

--- a/src/nORM/Providers/SqliteProvider.cs
+++ b/src/nORM/Providers/SqliteProvider.cs
@@ -26,8 +26,22 @@ namespace nORM.Providers
         public override int MaxSqlLength => 1_000_000;
         public override int MaxParameters => 999;
         public override string Escape(string id) => $"\"{id}\"";
+        public override char ParameterPrefixChar => '@';
 
         public override CommandType StoredProcedureCommandType => CommandType.Text;
+
+        public override void BuildSimpleSelect(Span<char> buffer, ReadOnlySpan<char> table,
+            ReadOnlySpan<char> columns, out int length)
+        {
+            "SELECT ".CopyTo(buffer);
+            var pos = 7;
+            columns.CopyTo(buffer.Slice(pos));
+            pos += columns.Length;
+            " FROM ".CopyTo(buffer.Slice(pos));
+            pos += 6;
+            table.CopyTo(buffer.Slice(pos));
+            length = pos + table.Length;
+        }
 
         public override async Task InitializeConnectionAsync(DbConnection connection, CancellationToken ct)
         {


### PR DESCRIPTION
## Summary
- add IFastProvider for span-based SQL construction
- implement fast-path BuildSimpleSelect in DatabaseProvider
- optimize SqliteProvider with direct span operations and constant parameter prefix

## Testing
- `dotnet build src/nORM.csproj`
- `dotnet test` *(fails: type or namespace name 'Core' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68be7b592144832c8d09ccd492900ce9