### PR TITLE
Optimize command handling

### DIFF
--- a/src/nORM/Internal/CommandPool.cs
+++ b/src/nORM/Internal/CommandPool.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Data;
+using System.Data.Common;
+
+namespace nORM.Internal
+{
+    internal sealed class CommandPool
+    {
+        [ThreadStatic]
+        private static DbCommand? _cachedCommand;
+
+        public static DbCommand Get(DbConnection connection, string sql)
+        {
+            var cmd = _cachedCommand;
+            if (cmd == null || cmd.Connection != connection)
+            {
+                cmd?.Dispose();
+                cmd = connection.CreateCommand();
+                _cachedCommand = cmd;
+            }
+
+            cmd.Parameters.Clear();
+            cmd.CommandText = sql;
+            cmd.CommandType = CommandType.Text;
+            return cmd;
+        }
+    }
+}

--- a/src/nORM/Internal/DbCommandExtensions.cs
+++ b/src/nORM/Internal/DbCommandExtensions.cs
@@ -16,5 +16,31 @@ namespace nORM.Internal
                 cmd.Parameters.Add(param);
             }
         }
+
+        public static void SetParametersFast(this DbCommand cmd, ReadOnlySpan<(string name, object value)> parameters)
+        {
+            var cmdParams = cmd.Parameters;
+
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                DbParameter param;
+                if (i < cmdParams.Count)
+                {
+                    param = cmdParams[i];
+                    param.ParameterName = parameters[i].name;
+                }
+                else
+                {
+                    param = cmd.CreateParameter();
+                    param.ParameterName = parameters[i].name;
+                    cmdParams.Add(param);
+                }
+
+                ParameterAssign.AssignValue(param, parameters[i].value);
+            }
+
+            while (cmdParams.Count > parameters.Length)
+                cmdParams.RemoveAt(cmdParams.Count - 1);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- pool DbCommand objects per-thread to reduce allocation overhead
- reuse DbParameter instances with SetParametersFast
- streamline DbContext raw SQL and stored procedure paths to use pooled commands

## Testing
- `dotnet build src/nORM.csproj`
- `dotnet test tests/nORM.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68be979a0d74832c8d919a273487081d