### PR TITLE
Handle boolean member access in fast path

### DIFF
--- a/src/nORM/Query/FastPathQueryExecutor.cs
+++ b/src/nORM/Query/FastPathQueryExecutor.cs
@@ -18,22 +18,60 @@ namespace nORM.Query
 
         private readonly record struct WhereInfo(string Property, object Value);
 
-        public static bool TryExecute<T>(Expression expr, DbContext ctx, out Task<List<T>> result) where T : class, new()
+        public static bool TryExecute<T>(Expression expr, DbContext ctx, out Task<object> result) where T : class, new()
         {
             result = default!;
 
             if (ctx.Options.GlobalFilters.Count > 0 || ctx.Options.TenantProvider != null)
                 return false;
 
+            if (IsSimpleCountPattern(expr, out var hasPredicate))
+            {
+                if (hasPredicate)
+                {
+                    return false;
+                }
+
+                result = ExecuteSimpleCount<T>(ctx);
+                return true;
+            }
+
             if (IsSimpleWherePattern(expr, out var whereInfo, out var takeCount))
             {
-                result = ExecuteSimpleWhere<T>(ctx, whereInfo, takeCount);
+                result = ExecuteSimpleWhere<T>(ctx, whereInfo, takeCount).ContinueWith(t => (object)t.Result);
                 return true;
             }
 
             if (IsSimpleTakePattern(expr, out takeCount))
             {
-                result = ExecuteSimpleTake<T>(ctx, takeCount);
+                result = ExecuteSimpleTake<T>(ctx, takeCount).ContinueWith(t => (object)t.Result);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsSimpleCountPattern(Expression expr, out bool hasPredicate)
+        {
+            hasPredicate = false;
+            if (expr is not MethodCallExpression countCall ||
+                (countCall.Method.Name != nameof(Queryable.Count) && countCall.Method.Name != nameof(Queryable.LongCount)))
+            {
+                return false;
+            }
+
+            if (countCall.Arguments.Count == 2)
+            {
+                if (Unwrap(countCall.Arguments[0]) is not ConstantExpression) return false;
+                if (countCall.Arguments[1] is not LambdaExpression) return false;
+                hasPredicate = true;
+                return true;
+            }
+
+            if (countCall.Arguments.Count == 1)
+            {
+                if (Unwrap(countCall.Arguments[0]) is not ConstantExpression) return false;
+                hasPredicate = false;
                 return true;
             }
 
@@ -210,6 +248,19 @@ namespace nORM.Query
                 results.Add(entity);
             }
             return results;
+        }
+
+        private static async Task<object> ExecuteSimpleCount<T>(DbContext ctx) where T : class
+        {
+            var map = ctx.GetMapping(typeof(T));
+            var sql = $"SELECT COUNT(*) FROM {map.EscTable}";
+
+            await ctx.EnsureConnectionAsync(default).ConfigureAwait(false);
+            await using var cmd = ctx.Connection.CreateCommand();
+            cmd.CommandText = sql;
+
+            var result = await cmd.ExecuteScalarAsync(default).ConfigureAwait(false);
+            return Convert.ToInt32(result);
         }
     }
 }

--- a/src/nORM/Query/FastPathQueryExecutor.cs
+++ b/src/nORM/Query/FastPathQueryExecutor.cs
@@ -64,6 +64,14 @@ namespace nORM.Query
                 return false;
 
             var body = lambda.Body;
+
+            // Support boolean member access: u => u.IsActive
+            if (body is MemberExpression meBoolean && meBoolean.Type == typeof(bool))
+            {
+                info = new WhereInfo(meBoolean.Member.Name, true);
+                return true;
+            }
+
             if (body is BinaryExpression be && be.NodeType == ExpressionType.Equal && be.Left is MemberExpression me)
             {
                 try

--- a/tests/FastPathQueryExecutorTests.cs
+++ b/tests/FastPathQueryExecutorTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using nORM.Core;
@@ -32,11 +34,40 @@ public class FastPathQueryExecutorTests
 
         using var ctx = new DbContext(cn, new SqliteProvider());
         var query = ctx.Query<User>().Where(u => u.IsActive);
-        var success = FastPathQueryExecutor.TryExecute(query.Expression, ctx, out var task);
+        var success = FastPathQueryExecutor.TryExecute<User>(query.Expression, ctx, out var task);
         Assert.True(success);
 
-        var results = await task.ConfigureAwait(false);
+        var results = (List<User>)await task.ConfigureAwait(false);
         Assert.Single(results);
         Assert.True(results[0].IsActive);
+    }
+
+    [Fact]
+    public async Task Count_without_predicate_uses_fast_path()
+    {
+        using var cn = new SqliteConnection("Data Source=:memory:");
+        cn.Open();
+        using (var cmd = cn.CreateCommand())
+        {
+            cmd.CommandText =
+                "CREATE TABLE \"User\"(Id INTEGER, IsActive INTEGER);" +
+                "INSERT INTO \"User\" VALUES(1,1);" +
+                "INSERT INTO \"User\" VALUES(2,0);";
+            cmd.ExecuteNonQuery();
+        }
+
+        using var ctx = new DbContext(cn, new SqliteProvider());
+        var query = ctx.Query<User>();
+        var expr = Expression.Call(
+            typeof(Queryable),
+            nameof(Queryable.Count),
+            new[] { typeof(User) },
+            query.Expression);
+
+        var success = FastPathQueryExecutor.TryExecute<User>(expr, ctx, out var task);
+        Assert.True(success);
+
+        var count = (int)await task.ConfigureAwait(false);
+        Assert.Equal(2, count);
     }
 }

--- a/tests/FastPathQueryExecutorTests.cs
+++ b/tests/FastPathQueryExecutorTests.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using nORM.Core;
+using nORM.Providers;
+using nORM.Query;
+using Xunit;
+
+namespace nORM.Tests;
+
+public class FastPathQueryExecutorTests
+{
+    private class User
+    {
+        public int Id { get; set; }
+        public bool IsActive { get; set; }
+    }
+
+    [Fact]
+    public async Task Where_boolean_member_uses_fast_path()
+    {
+        using var cn = new SqliteConnection("Data Source=:memory:");
+        cn.Open();
+        using (var cmd = cn.CreateCommand())
+        {
+            cmd.CommandText =
+                "CREATE TABLE \"User\"(Id INTEGER, IsActive INTEGER);" +
+                "INSERT INTO \"User\" VALUES(1,1);" +
+                "INSERT INTO \"User\" VALUES(2,0);";
+            cmd.ExecuteNonQuery();
+        }
+
+        using var ctx = new DbContext(cn, new SqliteProvider());
+        var query = ctx.Query<User>().Where(u => u.IsActive);
+        var success = FastPathQueryExecutor.TryExecute(query.Expression, ctx, out var task);
+        Assert.True(success);
+
+        var results = await task.ConfigureAwait(false);
+        Assert.Single(results);
+        Assert.True(results[0].IsActive);
+    }
+}


### PR DESCRIPTION
## Summary
- handle boolean member access in fast path query executor where patterns
- add test ensuring boolean Where predicates use fast path

## Testing
- `dotnet test` *(fails: ISaveChangesInterceptor, OwnedAttribute, QueryPlan, DatabaseProvider, GenerateMaterializerAttribute, IDbParameterFactory, Migration types missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bea04b1c98832cbae92f0e2e7ecfea