### PR TITLE
Handle SQLite reader conversions and parameter DbType

### DIFF
--- a/src/nORM/Query/ParameterManager.cs
+++ b/src/nORM/Query/ParameterManager.cs
@@ -55,7 +55,7 @@ namespace nORM.Query
                 case long l: p.DbType = System.Data.DbType.Int64; p.Value = l; return;
                 case short s: p.DbType = System.Data.DbType.Int16; p.Value = s; return;
                 case byte b: p.DbType = System.Data.DbType.Byte; p.Value = b; return;
-                case bool bo: p.DbType = System.Data.DbType.Int32; p.Value = bo ? 1 : 0; return; // SQLite
+                case bool bo: p.DbType = System.Data.DbType.Boolean; p.Value = bo; return; // Use Boolean type
                 case double d: p.DbType = System.Data.DbType.Double; p.Value = d; return;
                 case float f: p.DbType = System.Data.DbType.Double; p.Value = (double)f; return;
                 case decimal m: p.DbType = System.Data.DbType.Decimal; p.Value = m; return;


### PR DESCRIPTION
## Summary
- Improve parameterized constructor materialization to convert reader values and support nullable types
- Explicitly set DbType for common parameters, using Boolean for bool and ISO strings for DateTime

## Testing
- `dotnet test` *(fails: type or namespace name could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb2b86654832ca9779bc3a2a3f937