### PR TITLE
Handle decimals in MaterializerFactory

### DIFF
--- a/src/nORM/Internal/Methods.cs
+++ b/src/nORM/Internal/Methods.cs
@@ -18,7 +18,7 @@ namespace nORM.Internal
         public static readonly MethodInfo GetInt64 = typeof(IDataRecord).GetMethod(nameof(IDataRecord.GetInt64))!;
         public static readonly MethodInfo GetFloat = typeof(IDataRecord).GetMethod(nameof(IDataRecord.GetFloat))!;
         public static readonly MethodInfo GetDouble = typeof(IDataRecord).GetMethod(nameof(IDataRecord.GetDouble))!;
-        public static readonly MethodInfo GetDecimal = typeof(IDataRecord).GetMethod(nameof(IDataRecord.GetDecimal))!;
+        public static readonly MethodInfo GetDecimal = typeof(DbDataReader).GetMethod(nameof(DbDataReader.GetDecimal))!;
         public static readonly MethodInfo GetDateTime = typeof(IDataRecord).GetMethod(nameof(IDataRecord.GetDateTime))!;
         public static readonly MethodInfo GetGuid = typeof(IDataRecord).GetMethod(nameof(IDataRecord.GetGuid))!;
         public static readonly MethodInfo GetString = typeof(IDataRecord).GetMethod(nameof(IDataRecord.GetString))!;

--- a/src/nORM/Query/MaterializerFactory.cs
+++ b/src/nORM/Query/MaterializerFactory.cs
@@ -569,11 +569,14 @@ namespace nORM.Query
 
             Expression call = underlyingType.Name switch
             {
-                nameof(Int32) => Expression.Call(reader, Methods.GetInt32, Expression.Constant(index)),
-                nameof(String) => Expression.Call(reader, Methods.GetString, Expression.Constant(index)),
+                nameof(Int32)    => Expression.Call(reader, Methods.GetInt32, Expression.Constant(index)),
+                nameof(String)   => Expression.Call(reader, Methods.GetString, Expression.Constant(index)),
                 nameof(DateTime) => Expression.Call(reader, Methods.GetDateTime, Expression.Constant(index)),
-                nameof(Boolean) => Expression.Call(reader, Methods.GetBoolean, Expression.Constant(index)),
-                _ => Expression.Call(reader, Methods.GetValue, Expression.Constant(index))
+                nameof(Boolean)  => Expression.Call(reader, Methods.GetBoolean, Expression.Constant(index)),
+                nameof(Decimal)  => Expression.Call(reader, Methods.GetDecimal, Expression.Constant(index)),
+                _ => Expression.Convert(
+                        Expression.Call(reader, Methods.GetValue, Expression.Constant(index)),
+                        underlyingType)
             };
 
             if (call.Type != propertyType)


### PR DESCRIPTION
## Summary
- Handle decimal properties in MaterializerFactory optimized reader call
- Safely convert fallback values to the expected type
- Expose `GetDecimal` on the Methods helper

## Testing
- `dotnet test` *(fails: The type or namespace name 'Core' does not exist in the namespace 'nORM')*


------
https://chatgpt.com/codex/tasks/task_e_68becddce660832cb94ef6a4930f2a84