### PR TITLE
Use FrozenDictionary for method translators

### DIFF
--- a/src/nORM/Query/ExpressionToSqlVisitor.cs
+++ b/src/nORM/Query/ExpressionToSqlVisitor.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Globalization;
+using System.Collections.Frozen;
 using nORM.Core;
 using nORM.Mapping;
 using nORM.Providers;
@@ -36,12 +37,13 @@ namespace nORM.Query
         private readonly Dictionary<ConstKey, string> _constParamMap = new();
         private readonly Dictionary<(ParameterExpression Param, string Member), string> _memberParamMap = new();
 
-        private readonly Dictionary<string, IMethodTranslator> _translators = new()
-        {
-            ["Contains"] = new ContainsTranslator(),
-            ["StartsWith"] = new StartsWithTranslator(),
-            ["EndsWith"] = new EndsWithTranslator()
-        };
+        private static readonly FrozenDictionary<string, IMethodTranslator> _translators =
+            new Dictionary<string, IMethodTranslator>
+            {
+                ["Contains"] = new ContainsTranslator(),
+                ["StartsWith"] = new StartsWithTranslator(),
+                ["EndsWith"] = new EndsWithTranslator()
+            }.ToFrozenDictionary(StringComparer.Ordinal);
 
         private static readonly Dictionary<MethodInfo, Action<ExpressionToSqlVisitor, MethodCallExpression>> _fastMethodHandlers =
             new()


### PR DESCRIPTION
## Summary
- switch method translator lookup to `FrozenDictionary` for faster hot-path access

## Testing
- `dotnet test` *(fails: type or namespace name 'ISaveChangesInterceptor' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee45d7b68832cbbc5886443a35ab7