### PR TITLE
Replace StringBuilder with span-based SQL builder

### DIFF
--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -5,6 +5,7 @@ using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using nORM.Query;
 using System.Threading;
 using System.Threading.Tasks;
 using nORM.Core;
@@ -30,7 +31,7 @@ namespace nORM.Providers
         public virtual int MaxSqlLength => int.MaxValue;
         public virtual int MaxParameters => int.MaxValue;
         public abstract string Escape(string id);
-        public abstract void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName);
+        public abstract void ApplyPaging(OptimizedSqlBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName);
         public abstract string GetIdentityRetrievalString(TableMapping m);
         public abstract DbParameter CreateParameter(string name, object? value);
         public abstract string? TranslateFunction(string name, Type declaringType, params string[] args);

--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
+using nORM.Query;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Data.Common;
@@ -29,7 +29,7 @@ namespace nORM.Providers
         public override int MaxParameters => 65_535;
         public override string Escape(string id) => $"`{id}`";
         
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
+        public override void ApplyPaging(OptimizedSqlBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
         {
             EnsureValidParameterName(limitParameterName, nameof(limitParameterName));
             EnsureValidParameterName(offsetParameterName, nameof(offsetParameterName));

--- a/src/nORM/Providers/PostgresProvider.cs
+++ b/src/nORM/Providers/PostgresProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Linq;
+using nORM.Query;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,7 +33,7 @@ namespace nORM.Providers
         public override int MaxParameters => 32_767;
         public override string Escape(string id) => $"\"{id}\"";
         
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
+        public override void ApplyPaging(OptimizedSqlBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
         {
             EnsureValidParameterName(limitParameterName, nameof(limitParameterName));
             EnsureValidParameterName(offsetParameterName, nameof(offsetParameterName));

--- a/src/nORM/Providers/SqlServerProvider.cs
+++ b/src/nORM/Providers/SqlServerProvider.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
+using nORM.Query;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
@@ -25,7 +25,7 @@ namespace nORM.Providers
         public override int MaxParameters => 2_100;
         public override string Escape(string id) => $"[{id}]";
         
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
+        public override void ApplyPaging(OptimizedSqlBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
         {
             EnsureValidParameterName(limitParameterName, nameof(limitParameterName));
             EnsureValidParameterName(offsetParameterName, nameof(offsetParameterName));

--- a/src/nORM/Providers/SqliteProvider.cs
+++ b/src/nORM/Providers/SqliteProvider.cs
@@ -4,7 +4,7 @@ using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
+using nORM.Query;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
@@ -55,7 +55,7 @@ namespace nORM.Providers
             pragmaCmd.ExecuteNonQuery();
         }
         
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
+        public override void ApplyPaging(OptimizedSqlBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
         {
             EnsureValidParameterName(limitParameterName, nameof(limitParameterName));
             EnsureValidParameterName(offsetParameterName, nameof(offsetParameterName));

--- a/src/nORM/Query/ExpressionToSqlVisitor.cs
+++ b/src/nORM/Query/ExpressionToSqlVisitor.cs
@@ -9,8 +9,6 @@ using System.Globalization;
 using nORM.Core;
 using nORM.Mapping;
 using nORM.Providers;
-using System.Text;
-using Microsoft.Extensions.ObjectPool;
 
 #nullable enable
 
@@ -51,8 +49,6 @@ namespace nORM.Query
                 { typeof(string).GetMethod(nameof(string.EndsWith), new[] { typeof(string) })!, HandleStringEndsWith }
             };
 
-        private static readonly ObjectPool<StringBuilder> _stringBuilderPool =
-            new DefaultObjectPool<StringBuilder>(new StringBuilderPooledObjectPolicy());
 
         internal ExpressionToSqlVisitor() { }
 
@@ -118,19 +114,10 @@ namespace nORM.Query
 
         public string Translate(Expression expression)
         {
-            var sb = _stringBuilderPool.Get();
-            try
-            {
-                using var builder = new OptimizedSqlBuilder(sb);
-                _sql = builder;
-                Visit(expression);
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Clear();
-                _stringBuilderPool.Return(sb);
-            }
+            using var builder = new OptimizedSqlBuilder();
+            _sql = builder;
+            Visit(expression);
+            return builder.ToSqlString();
         }
 
         protected override Expression VisitBinary(BinaryExpression node)

--- a/src/nORM/Query/JoinBuilder.cs
+++ b/src/nORM/Query/JoinBuilder.cs
@@ -32,13 +32,13 @@ namespace nORM.Query
                     var outerCols = outerMapping.Columns.Select(c => $"{outerAlias}.{c.EscCol}");
                     var innerCols = innerMapping.Columns.Select(c => $"{innerAlias}.{c.EscCol}");
                     joinSql.AppendSelect(System.ReadOnlySpan<char>.Empty);
-                    joinSql.InnerBuilder.AppendJoin(", ", outerCols.Concat(innerCols));
+                    joinSql.AppendJoin(", ", outerCols.Concat(innerCols));
                     joinSql.Append(' ');
                 }
                 else
                 {
                     joinSql.AppendSelect(System.ReadOnlySpan<char>.Empty);
-                    joinSql.InnerBuilder.AppendJoin(", ", neededColumns);
+                    joinSql.AppendJoin(", ", neededColumns);
                     joinSql.Append(' ');
                 }
             }
@@ -47,7 +47,7 @@ namespace nORM.Query
                 var outerCols = outerMapping.Columns.Select(c => $"{outerAlias}.{c.EscCol}");
                 var innerCols = innerMapping.Columns.Select(c => $"{innerAlias}.{c.EscCol}");
                 joinSql.AppendSelect(System.ReadOnlySpan<char>.Empty);
-                joinSql.InnerBuilder.AppendJoin(", ", outerCols.Concat(innerCols));
+                joinSql.AppendJoin(", ", outerCols.Concat(innerCols));
                 joinSql.Append(' ');
             }
 

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -385,7 +385,7 @@ namespace nORM.Query
                     _t._sql.AppendFragment(" HAVING ").Append(_t._having.ToSqlString());
                 if (_t._orderBy.Count > 0)
                     _t._sql.AppendFragment(" ORDER BY ").Append(PooledStringBuilder.JoinOrderBy(_t._orderBy));
-                _t._ctx.Provider.ApplyPaging(_t._sql.InnerBuilder, _t._take, _t._skip, _t._takeParam, _t._skipParam);
+                _t._ctx.Provider.ApplyPaging(_t._sql, _t._take, _t._skip, _t._takeParam, _t._skipParam);
 
                 var singleResult = _t._singleResult || _t._methodName is "First" or "FirstOrDefault" or "Single" or "SingleOrDefault"
                     or "ElementAt" or "ElementAtOrDefault" or "Last" or "LastOrDefault" || isScalar;
@@ -740,13 +740,13 @@ namespace nORM.Query
                         var outerCols = outerMapping.Columns.Select(c => $"{outerAlias}.{c.EscCol}");
                         var innerCols = innerMapping.Columns.Select(c => $"{innerAlias}.{c.EscCol}");
                         joinSql.AppendSelect(ReadOnlySpan<char>.Empty);
-                        joinSql.InnerBuilder.AppendJoin(", ", outerCols.Concat(innerCols));
+                        joinSql.AppendJoin(", ", outerCols.Concat(innerCols));
                         joinSql.Append(' ');
                     }
                     else
                     {
                         joinSql.AppendSelect(ReadOnlySpan<char>.Empty);
-                        joinSql.InnerBuilder.AppendJoin(", ", neededColumns);
+                        joinSql.AppendJoin(", ", neededColumns);
                         joinSql.Append(' ');
                     }
                 }
@@ -754,7 +754,7 @@ namespace nORM.Query
                 {
                     var innerCols = innerMapping.Columns.Select(c => $"{innerAlias}.{c.EscCol}");
                     joinSql.AppendSelect(ReadOnlySpan<char>.Empty);
-                    joinSql.InnerBuilder.AppendJoin(", ", innerCols);
+                    joinSql.AppendJoin(", ", innerCols);
                     joinSql.Append(' ');
                 }
                 else
@@ -762,7 +762,7 @@ namespace nORM.Query
                     var outerCols = outerMapping.Columns.Select(c => $"{outerAlias}.{c.EscCol}");
                     var innerCols = innerMapping.Columns.Select(c => $"{innerAlias}.{c.EscCol}");
                     joinSql.AppendSelect(ReadOnlySpan<char>.Empty);
-                    joinSql.InnerBuilder.AppendJoin(", ", outerCols.Concat(innerCols));
+                    joinSql.AppendJoin(", ", outerCols.Concat(innerCols));
                     joinSql.Append(' ');
                 }
 
@@ -806,13 +806,13 @@ namespace nORM.Query
                     var outerCols = outerMapping.Columns.Select(c => $"{outerAlias}.{c.EscCol}");
                     var innerCols = crossMapping.Columns.Select(c => $"{crossAlias}.{c.EscCol}");
                     crossSql.AppendSelect(ReadOnlySpan<char>.Empty);
-                    crossSql.InnerBuilder.AppendJoin(", ", outerCols.Concat(innerCols));
+                    crossSql.AppendJoin(", ", outerCols.Concat(innerCols));
                     crossSql.Append(' ');
                 }
                 else
                 {
                     crossSql.AppendSelect(ReadOnlySpan<char>.Empty);
-                    crossSql.InnerBuilder.AppendJoin(", ", neededColumns);
+                    crossSql.AppendJoin(", ", neededColumns);
                     crossSql.Append(' ');
                 }
             }
@@ -820,7 +820,7 @@ namespace nORM.Query
             {
                 var innerCols = crossMapping.Columns.Select(c => $"{crossAlias}.{c.EscCol}");
                 crossSql.AppendSelect(ReadOnlySpan<char>.Empty);
-                crossSql.InnerBuilder.AppendJoin(", ", innerCols);
+                crossSql.AppendJoin(", ", innerCols);
                 crossSql.Append(' ');
             }
             else
@@ -828,7 +828,7 @@ namespace nORM.Query
                 var outerCols = outerMapping.Columns.Select(c => $"{outerAlias}.{c.EscCol}");
                 var innerCols = crossMapping.Columns.Select(c => $"{crossAlias}.{c.EscCol}");
                 crossSql.AppendSelect(ReadOnlySpan<char>.Empty);
-                crossSql.InnerBuilder.AppendJoin(", ", outerCols.Concat(innerCols));
+                crossSql.AppendJoin(", ", outerCols.Concat(innerCols));
                 crossSql.Append(' ');
             }
 
@@ -896,7 +896,7 @@ namespace nORM.Query
             }
             var limitParam = _ctx.Provider.ParamPrefix + "p" + _parameterManager.GetNextIndex();
             _params[limitParam] = 1;
-            _ctx.Provider.ApplyPaging(subSqlBuilder.InnerBuilder, 1, null, limitParam, null);
+            _ctx.Provider.ApplyPaging(subSqlBuilder, 1, null, limitParam, null);
 
             switch (node.Method.Name)
             {
@@ -1243,7 +1243,7 @@ namespace nORM.Query
                 }
 
                 _sql.AppendSelect(ReadOnlySpan<char>.Empty);
-                _sql.InnerBuilder.AppendJoin(", ", selectItems);
+                _sql.AppendJoin(", ", selectItems);
             }
             finally
             {

--- a/tests/BulkInsertTests.cs
+++ b/tests/BulkInsertTests.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using nORM.Core;
 using nORM.Providers;
+using nORM.Query;
 using nORM.Mapping;
 using Xunit;
 
@@ -26,7 +26,7 @@ public class BulkInsertTests
         public override int MaxParameters => 999;
         public override string Escape(string id) => $"\"{id}\"";
 
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
+        public override void ApplyPaging(OptimizedSqlBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
         {
             if (limitParameterName != null) sb.Append(" LIMIT ").Append(limitParameterName);
             if (offsetParameterName != null) sb.Append(" OFFSET ").Append(offsetParameterName);

--- a/tests/MySqlProviderTests.cs
+++ b/tests/MySqlProviderTests.cs
@@ -1,5 +1,5 @@
-using System.Text;
 using nORM.Providers;
+using nORM.Query;
 using Xunit;
 
 namespace nORM.Tests;
@@ -10,9 +10,10 @@ public class MySqlProviderTests
     public void ApplyPaging_with_only_offset_adds_max_limit()
     {
         var provider = new MySqlProvider(new SqliteParameterFactory());
-        var sb = new StringBuilder("SELECT * FROM `Product`");
+        var sb = new OptimizedSqlBuilder();
+        sb.Append("SELECT * FROM `Product`");
         var offsetParam = provider.ParamPrefix + "p0";
         provider.ApplyPaging(sb, null, 20, null, offsetParam);
-        Assert.Equal($"SELECT * FROM `Product` LIMIT {offsetParam}, 18446744073709551615", sb.ToString());
+        Assert.Equal($"SELECT * FROM `Product` LIMIT {offsetParam}, 18446744073709551615", sb.ToSqlString());
     }
 }

--- a/tests/SaveChangesBatchingTests.cs
+++ b/tests/SaveChangesBatchingTests.cs
@@ -2,10 +2,10 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Text;
 using Microsoft.Data.Sqlite;
 using nORM.Core;
 using nORM.Providers;
+using nORM.Query;
 using nORM.Enterprise;
 using nORM.Mapping;
 using nORM.Configuration;
@@ -21,7 +21,7 @@ public class SaveChangesBatchingTests
         public override int MaxParameters => 5;
         public override string Escape(string id) => $"\"{id}\"";
 
-        public override void ApplyPaging(StringBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
+        public override void ApplyPaging(OptimizedSqlBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
         {
             if (limitParameterName != null) sb.Append(" LIMIT ").Append(limitParameterName);
             if (offsetParameterName != null) sb.Append(" OFFSET ").Append(offsetParameterName);


### PR DESCRIPTION
## Summary
- implement span-based `OptimizedSqlBuilder` with pooled char buffers
- refactor providers and translators to use the new builder for paging and joins
- update navigation utilities and tests to the span-based builder

## Testing
- `dotnet build src/nORM.csproj` *(fails: CS8618 Non-nullable field must contain a non-null value when exiting constructor)*
- `dotnet test` *(fails: type or namespace not found in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bee49853a4832ca941cf58c825f37f