### PR TITLE
Reuse parameter collections in ParameterManager.Reset

### DIFF
--- a/src/nORM/Query/ParameterManager.cs
+++ b/src/nORM/Query/ParameterManager.cs
@@ -32,9 +32,9 @@ namespace nORM.Query
 
         public void Reset()
         {
-            Parameters = new Dictionary<string, object>();
-            CompiledParameters = new List<string>();
-            ParameterMap = new Dictionary<ParameterExpression, string>();
+            Parameters.Clear();
+            CompiledParameters.Clear();
+            ParameterMap.Clear();
             Volatile.Write(ref _index, 0);
         }
     }


### PR DESCRIPTION
## Summary
- Avoid unnecessary allocation in `ParameterManager.Reset`
- Clear existing parameter collections instead of creating new ones

## Testing
- `dotnet test` *(fails: DatabaseProvider could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf10248664832c9d9b2dac7a9aab6c