### PR TITLE
Dispose SqlBuilder instances in QueryTranslator

### DIFF
--- a/tests/QueryTranslatorDisposeTests.cs
+++ b/tests/QueryTranslatorDisposeTests.cs
@@ -6,10 +6,10 @@ using Xunit;
 
 namespace nORM.Tests;
 
-public class QueryTranslatorObjectPoolTests
+public class QueryTranslatorDisposeTests
 {
     [Fact]
-    public void Dispose_returns_translator_to_pool()
+    public void Dispose_does_not_return_translator_to_pool()
     {
         using var cn = new SqliteConnection("Data Source=:memory:");
         using var ctx = new DbContext(cn, new SqliteProvider());
@@ -23,7 +23,7 @@ public class QueryTranslatorObjectPoolTests
 
         var translator2 = rentMethod.Invoke(null, new object[] { ctx });
 
-        Assert.Same(translator1, translator2);
+        Assert.NotSame(translator1, translator2);
     }
 }
 


### PR DESCRIPTION
## Summary
- Dispose and replace SqlBuilder instances in QueryTranslator's Reset, Clear, and Dispose methods
- Adjust unit test to reflect new disposal behavior

## Testing
- `dotnet test` *(fails: Non-nullable field '_nonKeyColumns' must contain a non-null value in src/nORM/Core/EntityEntry.cs)*

------
https://chatgpt.com/codex/tasks/task_e_68bf503bfcb8832c845ff3b72867f509