### PR TITLE
docs: add XML documentation for key public APIs

### DIFF
--- a/src/nORM/Configuration/DbContextOptions.cs
+++ b/src/nORM/Configuration/DbContextOptions.cs
@@ -84,6 +84,11 @@ namespace nORM.Configuration
             return AddGlobalFilter(lambda);
         }
 
+        /// <summary>
+        /// Validates the configured options ensuring all values fall within allowed ranges
+        /// and required settings are provided. Throws <see cref="InvalidOperationException"/>
+        /// if any configuration is invalid.
+        /// </summary>
         public void Validate()
         {
             if (RetryPolicy != null)

--- a/src/nORM/Configuration/EntityTypeBuilder.cs
+++ b/src/nORM/Configuration/EntityTypeBuilder.cs
@@ -120,6 +120,11 @@ namespace nORM.Configuration
                 _property = property;
             }
 
+            /// <summary>
+            /// Sets the database column name for the configured property.
+            /// </summary>
+            /// <param name="name">The column name to map the property to.</param>
+            /// <returns>The parent <see cref="EntityTypeBuilder{TEntity}"/> for chaining.</returns>
             public EntityTypeBuilder<TEntity> HasColumnName(string name)
             {
                 _parent._config.SetColumnName(_property, name);
@@ -138,6 +143,11 @@ namespace nORM.Configuration
                 _name = name;
             }
 
+            /// <summary>
+            /// Assigns a column name for the shadow property.
+            /// </summary>
+            /// <param name="columnName">The column name to use in the database.</param>
+            /// <returns>The parent <see cref="EntityTypeBuilder{TEntity}"/> for chaining.</returns>
             public EntityTypeBuilder<TEntity> HasColumnName(string columnName)
             {
                 _parent._config.SetShadowColumnName(_name, columnName);
@@ -156,6 +166,11 @@ namespace nORM.Configuration
                 PrincipalNavigation = principalNavigation;
             }
 
+            /// <summary>
+            /// Configures the relationship to have a single optional reference back to the principal entity.
+            /// </summary>
+            /// <param name="navigation">Optional expression specifying the navigation property on the dependent type.</param>
+            /// <returns>A builder for configuring the relationship further.</returns>
             public ReferenceCollectionBuilder WithOne(Expression<Func<TDependent, TEntity?>>? navigation = null)
             {
                 PropertyInfo? dependentNav = null;
@@ -177,6 +192,13 @@ namespace nORM.Configuration
                     _dependentNavigation = dependentNavigation;
                 }
 
+                /// <summary>
+                /// Configures the foreign key property used by the dependent entity in the relationship.
+                /// </summary>
+                /// <param name="foreignKeyExpression">Expression selecting the foreign key property on the dependent type.</param>
+                /// <param name="principalKeyExpression">Optional expression selecting the principal key; required when the principal has composite keys.</param>
+                /// <returns>The parent <see cref="EntityTypeBuilder{TEntity}"/> for further configuration.</returns>
+                /// <exception cref="NormConfigurationException">Thrown when the principal key cannot be inferred.</exception>
                 public EntityTypeBuilder<TEntity> HasForeignKey(
                     Expression<Func<TDependent, object>> foreignKeyExpression,
                     Expression<Func<TEntity, object>>? principalKeyExpression = null)

--- a/src/nORM/Configuration/IEntityTypeConfiguration.cs
+++ b/src/nORM/Configuration/IEntityTypeConfiguration.cs
@@ -17,8 +17,29 @@ namespace nORM.Configuration
         List<RelationshipConfiguration> Relationships { get; }
     }
 
+    /// <summary>
+    /// Describes an owned navigation property and its optional configuration.
+    /// </summary>
+    /// <param name="OwnedType">CLR type of the owned entity.</param>
+    /// <param name="Configuration">Optional configuration applied to the owned entity.</param>
     public record OwnedNavigation(Type OwnedType, IEntityTypeConfiguration? Configuration);
+
+    /// <summary>
+    /// Represents a shadow property that does not exist on the CLR type but is mapped to a database column.
+    /// </summary>
+    /// <param name="ClrType">The CLR type of the shadow property.</param>
+    /// <param name="ColumnName">Optional column name override.</param>
     public record ShadowPropertyConfiguration(Type ClrType, string? ColumnName = null);
+
+    /// <summary>
+    /// Configuration details for a relationship between entities including navigation and key information.
+    /// </summary>
+    /// <param name="PrincipalNavigation">Navigation property on the principal entity.</param>
+    /// <param name="DependentType">CLR type of the dependent entity.</param>
+    /// <param name="DependentNavigation">Optional navigation property on the dependent entity.</param>
+    /// <param name="PrincipalKey">Key property on the principal entity.</param>
+    /// <param name="ForeignKey">Foreign key property on the dependent entity.</param>
+    /// <param name="CascadeDelete">Whether dependent entities should be cascade deleted.</param>
     public record RelationshipConfiguration(PropertyInfo PrincipalNavigation, Type DependentType,
         PropertyInfo? DependentNavigation, PropertyInfo? PrincipalKey, PropertyInfo ForeignKey, bool CascadeDelete = true);
 }

--- a/src/nORM/Core/ChangeTracker.cs
+++ b/src/nORM/Core/ChangeTracker.cs
@@ -168,6 +168,9 @@ namespace nORM.Core
                 _dirtyEntries.TryAdd(entry, 0);
             }
         }
+        /// <summary>
+        /// Removes all tracked entity entries and resets the change tracker to an empty state.
+        /// </summary>
         public void Clear()
         {
             _entriesByReference.Clear();

--- a/src/nORM/Core/ConnectionManager.cs
+++ b/src/nORM/Core/ConnectionManager.cs
@@ -91,6 +91,13 @@ namespace nORM.Core
                 .ToList();
         }
 
+        /// <summary>
+        /// Retrieves an open connection to the primary node for write operations.
+        /// Implements a simple circuit breaker and failover mechanism.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>An open <see cref="DbConnection"/> suitable for write operations.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when no primary node is available.</exception>
         public async Task<DbConnection> GetWriteConnectionAsync(CancellationToken ct = default)
         {
             lock (_circuitBreakerLock)
@@ -127,6 +134,12 @@ namespace nORM.Core
             }
         }
 
+        /// <summary>
+        /// Retrieves an open connection optimized for read operations, using available read replicas
+        /// and falling back to the primary node when necessary.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>An open <see cref="DbConnection"/> suitable for read operations.</returns>
         public async Task<DbConnection> GetReadConnectionAsync(CancellationToken ct = default)
         {
             var replicas = _availableReadReplicas;
@@ -280,6 +293,10 @@ namespace nORM.Core
             }
         }
 
+        /// <summary>
+        /// Disposes the manager and all pooled connections, terminating background tasks
+        /// and releasing unmanaged resources.
+        /// </summary>
         public void Dispose()
         {
             if (_disposed)

--- a/src/nORM/Core/ConnectionPool.cs
+++ b/src/nORM/Core/ConnectionPool.cs
@@ -171,7 +171,7 @@ namespace nORM.Core
         {
             if (_disposed) return;
 
-            // ADD: reentrancy guard — System.Threading.Timer may overlap callbacks
+            // ADD: reentrancy guard Â— System.Threading.Timer may overlap callbacks
             if (Interlocked.Exchange(ref _cleanupRunning, 1) == 1) return;
 
             try
@@ -241,6 +241,10 @@ namespace nORM.Core
             _semaphore.Dispose();
         }
 
+        /// <summary>
+        /// Asynchronously disposes the connection pool and all pooled connections.
+        /// </summary>
+        /// <returns>A task that completes when disposal is finished.</returns>
         public async ValueTask DisposeAsync()
         {
             Dispose();

--- a/src/nORM/Core/DatabaseFacade.cs
+++ b/src/nORM/Core/DatabaseFacade.cs
@@ -16,6 +16,12 @@ namespace nORM.Core
 
         public DbTransaction? CurrentTransaction => _context.CurrentTransaction;
 
+        /// <summary>
+        /// Begins a new database transaction for the current context.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A <see cref="DbContextTransaction"/> representing the started transaction.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when a transaction is already active.</exception>
         public async Task<DbContextTransaction> BeginTransactionAsync(CancellationToken ct = default)
         {
             if (_context.CurrentTransaction != null)

--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -169,6 +169,11 @@ namespace nORM.Core
                 Interlocked.Exchange(ref _currentTransaction, null);
         }
 
+        /// <summary>
+        /// Checks whether the database connection is healthy by executing a lightweight query.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns><c>true</c> if the connection is healthy; otherwise <c>false</c>.</returns>
         public async Task<bool> IsHealthyAsync(CancellationToken ct = default)
         {
             try
@@ -253,6 +258,11 @@ namespace nORM.Core
             };
             return Options;
         }
+        /// <summary>
+        /// Persists all tracked changes to the database using the configured retry policy.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>The total number of state entries written to the database.</returns>
         public Task<int> SaveChangesAsync(CancellationToken ct = default)
             => SaveChangesWithRetryAsync(ct);
 

--- a/src/nORM/Core/DbContextTransaction.cs
+++ b/src/nORM/Core/DbContextTransaction.cs
@@ -25,6 +25,10 @@ namespace nORM.Core
             Dispose();
         }
 
+        /// <summary>
+        /// Asynchronously commits the underlying transaction and disposes the wrapper.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
         public async Task CommitAsync(CancellationToken ct = default)
         {
             if (_transaction != null)
@@ -38,6 +42,10 @@ namespace nORM.Core
             Dispose();
         }
 
+        /// <summary>
+        /// Asynchronously rolls back the underlying transaction and disposes the wrapper.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
         public async Task RollbackAsync(CancellationToken ct = default)
         {
             if (_transaction != null)
@@ -56,6 +64,10 @@ namespace nORM.Core
             }
         }
 
+        /// <summary>
+        /// Asynchronously disposes the transaction and clears it from the context.
+        /// </summary>
+        /// <returns>A task representing the dispose operation.</returns>
         public async ValueTask DisposeAsync()
         {
             if (!_completed)

--- a/src/nORM/Migration/MySqlMigrationRunner.cs
+++ b/src/nORM/Migration/MySqlMigrationRunner.cs
@@ -32,6 +32,10 @@ namespace nORM.Migration
             }
         }
 
+        /// <summary>
+        /// Applies all pending migrations to the MySQL database.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
         public async Task ApplyMigrationsAsync(CancellationToken ct = default)
         {
             await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
@@ -47,6 +51,11 @@ namespace nORM.Migration
             await transaction.CommitAsync(ct).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Determines whether there are migrations that have not yet been applied.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns><c>true</c> if pending migrations exist; otherwise <c>false</c>.</returns>
         public async Task<bool> HasPendingMigrationsAsync(CancellationToken ct = default)
         {
             await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
@@ -54,6 +63,11 @@ namespace nORM.Migration
             return pending.Any();
         }
 
+        /// <summary>
+        /// Retrieves the identifiers of all pending migrations.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>An array containing the pending migration identifiers.</returns>
         public async Task<string[]> GetPendingMigrationsAsync(CancellationToken ct = default)
         {
             await EnsureHistoryTableAsync(ct).ConfigureAwait(false);

--- a/src/nORM/Migration/PostgresMigrationRunner.cs
+++ b/src/nORM/Migration/PostgresMigrationRunner.cs
@@ -32,6 +32,10 @@ namespace nORM.Migration
             }
         }
 
+        /// <summary>
+        /// Applies all pending migrations to the PostgreSQL database.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
         public async Task ApplyMigrationsAsync(CancellationToken ct = default)
         {
             await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
@@ -47,6 +51,11 @@ namespace nORM.Migration
             await transaction.CommitAsync(ct).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Determines whether there are migrations that have not yet been applied.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns><c>true</c> if pending migrations exist; otherwise <c>false</c>.</returns>
         public async Task<bool> HasPendingMigrationsAsync(CancellationToken ct = default)
         {
             await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
@@ -54,6 +63,11 @@ namespace nORM.Migration
             return pending.Any();
         }
 
+        /// <summary>
+        /// Retrieves the identifiers of all pending migrations.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>An array containing the pending migration identifiers.</returns>
         public async Task<string[]> GetPendingMigrationsAsync(CancellationToken ct = default)
         {
             await EnsureHistoryTableAsync(ct).ConfigureAwait(false);

--- a/src/nORM/Migration/SqlServerMigrationRunner.cs
+++ b/src/nORM/Migration/SqlServerMigrationRunner.cs
@@ -32,6 +32,10 @@ namespace nORM.Migration
             }
         }
 
+        /// <summary>
+        /// Applies all pending migrations to the SQL Server database.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
         public async Task ApplyMigrationsAsync(CancellationToken ct = default)
         {
             await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
@@ -47,6 +51,11 @@ namespace nORM.Migration
             await transaction.CommitAsync(ct).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Determines whether there are migrations that have not yet been applied.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns><c>true</c> if pending migrations exist; otherwise <c>false</c>.</returns>
         public async Task<bool> HasPendingMigrationsAsync(CancellationToken ct = default)
         {
             await EnsureHistoryTableAsync(ct).ConfigureAwait(false);
@@ -54,6 +63,11 @@ namespace nORM.Migration
             return pending.Any();
         }
 
+        /// <summary>
+        /// Retrieves the identifiers of all pending migrations.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>An array containing the pending migration identifiers.</returns>
         public async Task<string[]> GetPendingMigrationsAsync(CancellationToken ct = default)
         {
             await EnsureHistoryTableAsync(ct).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add XML comments for validation on `DbContextOptions`
- document builder APIs such as `HasColumnName`, `WithOne`, and `HasForeignKey`
- flesh out transaction and migration runner async methods with XML documentation

## Testing
- `dotnet build nORM.sln` *(fails: type or namespace name 'Owned' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68c158a7eedc832c98a8a759ce60ccb5