### PR TITLE
Add XML documentation for core nORM APIs

### DIFF
--- a/src/nORM/Mapping/TableMapping.cs
+++ b/src/nORM/Mapping/TableMapping.cs
@@ -168,6 +168,14 @@ namespace nORM.Mapping
             }
         }
 
+        /// <summary>
+        /// Represents the mapping of a relationship from the principal entity to a dependent entity type.
+        /// </summary>
+        /// <param name="NavProp">The navigation property on the principal entity that exposes the related data.</param>
+        /// <param name="DependentType">The CLR type of the dependent entity.</param>
+        /// <param name="PrincipalKey">The key column on the principal entity used as the relationship principal.</param>
+        /// <param name="ForeignKey">The foreign key column on the dependent entity referencing the principal key.</param>
+        /// <param name="CascadeDelete">Specifies whether deletes on the principal entity cascade to dependents.</param>
         public record Relation(PropertyInfo NavProp, Type DependentType, Column PrincipalKey, Column ForeignKey, bool CascadeDelete = true);
     }
 }

--- a/src/nORM/Migration/IMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/IMigrationSqlGenerator.cs
@@ -2,10 +2,23 @@ using System.Collections.Generic;
 
 namespace nORM.Migration
 {
+    /// <summary>
+    /// Defines a service capable of translating schema differences into database-specific SQL statements.
+    /// </summary>
     public interface IMigrationSqlGenerator
     {
+        /// <summary>
+        /// Generates the SQL statements required to migrate the database from the old schema to the new schema.
+        /// </summary>
+        /// <param name="diff">The schema differences between the current database and the target model.</param>
+        /// <returns>A collection of SQL statements for applying and reverting the schema changes.</returns>
         MigrationSqlStatements GenerateSql(SchemaDiff diff);
     }
 
+    /// <summary>
+    /// Represents the SQL statements required to apply a migration and to roll it back.
+    /// </summary>
+    /// <param name="Up">The statements that upgrade the schema to the new version.</param>
+    /// <param name="Down">The statements that revert the schema to the previous version.</param>
     public record MigrationSqlStatements(IReadOnlyList<string> Up, IReadOnlyList<string> Down);
 }

--- a/src/nORM/Migration/Migration.cs
+++ b/src/nORM/Migration/Migration.cs
@@ -15,7 +15,18 @@ namespace nORM.Migration
         public long Version { get; }
         public string Name { get; }
         
+        /// <summary>
+        /// Applies the migration by bringing the database schema to the new state.
+        /// </summary>
+        /// <param name="connection">An open connection to the target database.</param>
+        /// <param name="transaction">The transaction within which the migration should run.</param>
         public abstract void Up(DbConnection connection, DbTransaction transaction);
+
+        /// <summary>
+        /// Reverts the migration, returning the database schema to the previous state.
+        /// </summary>
+        /// <param name="connection">An open connection to the target database.</param>
+        /// <param name="transaction">The transaction within which the rollback should run.</param>
         public abstract void Down(DbConnection connection, DbTransaction transaction);
     }
 }

--- a/src/nORM/Migration/MySqlMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/MySqlMigrationSqlGenerator.cs
@@ -21,6 +21,11 @@ namespace nORM.Migration
             { typeof(Guid).FullName!, "CHAR(36)" }
         };
 
+        /// <summary>
+        /// Generates MySQL-specific SQL statements that apply the schema changes described by the provided diff.
+        /// </summary>
+        /// <param name="diff">The differences between the current and desired database schema.</param>
+        /// <returns>A pair of SQL statement lists for migrating up and rolling back.</returns>
         public MigrationSqlStatements GenerateSql(SchemaDiff diff)
         {
             var up = new List<string>();

--- a/src/nORM/Migration/PostgresMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/PostgresMigrationSqlGenerator.cs
@@ -21,6 +21,11 @@ namespace nORM.Migration
             { typeof(Guid).FullName!, "UUID" }
         };
 
+        /// <summary>
+        /// Produces PostgreSQL-compatible SQL statements to transition between schema versions.
+        /// </summary>
+        /// <param name="diff">The description of schema changes to apply.</param>
+        /// <returns>A set of statements to apply the changes and to revert them.</returns>
         public MigrationSqlStatements GenerateSql(SchemaDiff diff)
         {
             var up = new List<string>();

--- a/src/nORM/Migration/SchemaSnapshot.cs
+++ b/src/nORM/Migration/SchemaSnapshot.cs
@@ -27,6 +27,11 @@ namespace nORM.Migration
 
     public static class SchemaSnapshotBuilder
     {
+        /// <summary>
+        /// Builds a snapshot of the entity schema by inspecting the types in the provided assembly.
+        /// </summary>
+        /// <param name="assembly">The assembly containing the entity types to scan.</param>
+        /// <returns>A snapshot describing the tables and columns inferred from the assembly.</returns>
         public static SchemaSnapshot Build(Assembly assembly)
         {
             var snapshot = new SchemaSnapshot();
@@ -81,6 +86,12 @@ namespace nORM.Migration
 
     public static class SchemaDiffer
     {
+        /// <summary>
+        /// Computes the difference between two schema snapshots.
+        /// </summary>
+        /// <param name="oldSnapshot">The snapshot representing the current database schema.</param>
+        /// <param name="newSnapshot">The snapshot representing the desired schema.</param>
+        /// <returns>A <see cref="SchemaDiff"/> describing the operations required to transform the schema.</returns>
         public static SchemaDiff Diff(SchemaSnapshot oldSnapshot, SchemaSnapshot newSnapshot)
         {
             var diff = new SchemaDiff();

--- a/src/nORM/Migration/SqlServerMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/SqlServerMigrationSqlGenerator.cs
@@ -21,6 +21,11 @@ namespace nORM.Migration
             { typeof(Guid).FullName!, "UNIQUEIDENTIFIER" }
         };
 
+        /// <summary>
+        /// Generates SQL Server specific statements for applying the provided schema changes.
+        /// </summary>
+        /// <param name="diff">The computed differences between the current and desired schema.</param>
+        /// <returns>The SQL statements to upgrade and downgrade the database schema.</returns>
         public MigrationSqlStatements GenerateSql(SchemaDiff diff)
         {
             var up = new List<string>();

--- a/src/nORM/Migration/SqliteMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/SqliteMigrationSqlGenerator.cs
@@ -21,6 +21,11 @@ namespace nORM.Migration
             { typeof(Guid).FullName!, "TEXT" }
         };
 
+        /// <summary>
+        /// Creates SQLite SQL statements for the operations described by the schema diff.
+        /// </summary>
+        /// <param name="diff">The set of schema changes to be applied.</param>
+        /// <returns>The statements needed to apply and rollback the changes.</returns>
         public MigrationSqlStatements GenerateSql(SchemaDiff diff)
         {
             var up = new List<string>();

--- a/src/nORM/Navigation/BatchedNavigationLoader.cs
+++ b/src/nORM/Navigation/BatchedNavigationLoader.cs
@@ -162,6 +162,9 @@ namespace nORM.Navigation
             }
         }
 
+        /// <summary>
+        /// Releases resources used by the loader and unregisters it from the navigation system.
+        /// </summary>
         public void Dispose()
         {
             NavigationPropertyExtensions.UnregisterLoader(this);

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -436,10 +436,28 @@ namespace nORM.Navigation
             EntityType = entityType;
         }
         
+        /// <summary>
+        /// Determines whether the specified navigation property has already been loaded for the entity.
+        /// </summary>
+        /// <param name="propertyName">The name of the navigation property.</param>
+        /// <returns><c>true</c> if the property is considered loaded; otherwise, <c>false</c>.</returns>
         public bool IsLoaded(string propertyName) => _loadedProperties.ContainsKey(propertyName);
+
+        /// <summary>
+        /// Marks the specified navigation property as loaded within this context.
+        /// </summary>
+        /// <param name="propertyName">The name of the navigation property.</param>
         public void MarkAsLoaded(string propertyName) => _loadedProperties[propertyName] = 0;
+
+        /// <summary>
+        /// Marks the specified navigation property as unloaded so it will be reloaded on next access.
+        /// </summary>
+        /// <param name="propertyName">The name of the navigation property.</param>
         public void MarkAsUnloaded(string propertyName) => _loadedProperties.TryRemove(propertyName, out _);
 
+        /// <summary>
+        /// Clears the loaded-property cache.
+        /// </summary>
         public void Dispose() => _loadedProperties.Clear();
     }
 
@@ -485,8 +503,16 @@ namespace nORM.Navigation
         /// </summary>
         public IEnumerator<T> GetEnumerator() => GetOrLoadCollection().GetEnumerator();
 
+        /// <summary>
+        /// Returns a non-generic enumerator for the collection.
+        /// </summary>
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+        /// <summary>
+        /// Asynchronously enumerates the items in the collection, ensuring the navigation is loaded.
+        /// </summary>
+        /// <param name="ct">A cancellation token used to cancel the asynchronous iteration.</param>
+        /// <returns>An asynchronous enumerator over the collection.</returns>
         public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken ct = default)
         {
             if (!_context.IsLoaded(_property.Name))
@@ -571,6 +597,11 @@ namespace nORM.Navigation
             _isLoaded = false;
         }
 
+        /// <summary>
+        /// Gets the referenced entity value, loading it from the database if it has not been loaded yet.
+        /// </summary>
+        /// <param name="ct">A cancellation token that can be used to cancel the asynchronous operation.</param>
+        /// <returns>The referenced entity, or <c>null</c> if no related entity exists.</returns>
         public async Task<T?> GetValueAsync(CancellationToken ct = default)
         {
             if (!_isLoaded)
@@ -579,6 +610,10 @@ namespace nORM.Navigation
             return _value;
         }
 
+        /// <summary>
+        /// Sets the referenced entity and marks the navigation as loaded.
+        /// </summary>
+        /// <param name="value">The entity to assign to the navigation property.</param>
         public void SetValue(T? value)
         {
             lock (_loadLock)
@@ -589,6 +624,9 @@ namespace nORM.Navigation
             }
         }
 
+        /// <summary>
+        /// Implicitly converts the reference to a task that retrieves the value.
+        /// </summary>
         public static implicit operator Task<T?>(LazyNavigationReference<T> reference) => reference.GetValueAsync();
     }
 }

--- a/src/nORM/Providers/DatabaseProvider.cs
+++ b/src/nORM/Providers/DatabaseProvider.cs
@@ -30,14 +30,68 @@ namespace nORM.Providers
         public virtual string ParamPrefix => ParameterPrefixChar.ToString();
         public virtual int MaxSqlLength => int.MaxValue;
         public virtual int MaxParameters => int.MaxValue;
+
+        /// <summary>
+        /// Escapes an identifier (such as a table or column name) for inclusion in SQL statements.
+        /// </summary>
+        /// <param name="id">The identifier to escape.</param>
+        /// <returns>The escaped identifier.</returns>
         public abstract string Escape(string id);
+
+        /// <summary>
+        /// Applies provider-specific paging clauses to the supplied SQL builder.
+        /// </summary>
+        /// <param name="sb">The builder containing the base SQL statement.</param>
+        /// <param name="limit">The maximum number of rows to return.</param>
+        /// <param name="offset">The number of rows to skip before starting to return rows.</param>
+        /// <param name="limitParameterName">The parameter name used for the limit value.</param>
+        /// <param name="offsetParameterName">The parameter name used for the offset value.</param>
         public abstract void ApplyPaging(OptimizedSqlBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName);
+
+        /// <summary>
+        /// Returns SQL that retrieves the identity value generated for an inserted row.
+        /// </summary>
+        /// <param name="m">The mapping for the table being inserted into.</param>
+        /// <returns>A SQL fragment that retrieves the generated identity.</returns>
         public abstract string GetIdentityRetrievalString(TableMapping m);
+
+        /// <summary>
+        /// Creates a database parameter with the given name and value.
+        /// </summary>
+        /// <param name="name">The parameter name, including prefix.</param>
+        /// <param name="value">The parameter value.</param>
+        /// <returns>A parameter configured for the underlying provider.</returns>
         public abstract DbParameter CreateParameter(string name, object? value);
+
+        /// <summary>
+        /// Translates a .NET method invocation into its SQL equivalent for the provider.
+        /// </summary>
+        /// <param name="name">The name of the method being translated.</param>
+        /// <param name="declaringType">The type that declares the method.</param>
+        /// <param name="args">The SQL arguments to the function.</param>
+        /// <returns>The translated SQL expression, or <c>null</c> if the method is not supported.</returns>
         public abstract string? TranslateFunction(string name, Type declaringType, params string[] args);
+
+        /// <summary>
+        /// Translates a JSON path access expression for the provider.
+        /// </summary>
+        /// <param name="columnName">The name of the JSON column.</param>
+        /// <param name="jsonPath">The JSON path to access within the column.</param>
+        /// <returns>The SQL fragment that accesses the specified JSON path.</returns>
         public abstract string TranslateJsonPathAccess(string columnName, string jsonPath);
 
+        /// <summary>
+        /// Generates the SQL required to create a history table for temporal table support.
+        /// </summary>
+        /// <param name="mapping">The table mapping representing the entity.</param>
+        /// <returns>The SQL statement that creates the history table.</returns>
         public abstract string GenerateCreateHistoryTableSql(TableMapping mapping);
+
+        /// <summary>
+        /// Generates the SQL required to create triggers for maintaining the temporal history table.
+        /// </summary>
+        /// <param name="mapping">The table mapping representing the entity.</param>
+        /// <returns>The SQL script containing the trigger definitions.</returns>
         public abstract string GenerateTemporalTriggersSql(TableMapping mapping);
 
         public virtual char LikeEscapeChar => '\\';
@@ -323,6 +377,16 @@ namespace nORM.Providers
         #endregion
 
         #region SQL Generation
+        /// <summary>
+        /// Builds an INSERT statement for the specified table mapping.
+        /// </summary>
+        /// <param name="m">The table mapping describing the entity.</param>
+        /// <returns>A parameterized INSERT SQL statement.</returns>
+        /// <summary>
+        /// Builds an INSERT statement for the specified table mapping.
+        /// </summary>
+        /// <param name="m">The table mapping describing the entity.</param>
+        /// <returns>A parameterized INSERT SQL statement.</returns>
         public string BuildInsert(TableMapping m)
         {
             return _sqlCache.GetOrAdd((m.Type, "INSERT"), _ => {
@@ -337,6 +401,11 @@ namespace nORM.Providers
             });
         }
 
+        /// <summary>
+        /// Builds an UPDATE statement for the specified table mapping.
+        /// </summary>
+        /// <param name="m">The table mapping describing the entity.</param>
+        /// <returns>A parameterized UPDATE SQL statement.</returns>
         public string BuildUpdate(TableMapping m)
         {
             return _sqlCache.GetOrAdd((m.Type, "UPDATE"), _ =>
@@ -355,6 +424,11 @@ namespace nORM.Providers
             });
         }
 
+        /// <summary>
+        /// Builds a DELETE statement for the specified table mapping.
+        /// </summary>
+        /// <param name="m">The table mapping describing the entity.</param>
+        /// <returns>A parameterized DELETE SQL statement.</returns>
         public string BuildDelete(TableMapping m)
         {
             return _sqlCache.GetOrAdd((m.Type, "DELETE"), _ =>

--- a/src/nORM/Providers/MySqlProvider.cs
+++ b/src/nORM/Providers/MySqlProvider.cs
@@ -27,8 +27,18 @@ namespace nORM.Providers
         }
         public override int MaxSqlLength => 4_194_304;
         public override int MaxParameters => 65_535;
+
+        /// <inheritdoc />
         public override string Escape(string id) => $"`{id}`";
-        
+
+        /// <summary>
+        /// Appends a MySQL <c>LIMIT</c> clause to the SQL builder to paginate results.
+        /// </summary>
+        /// <param name="sb">The SQL builder being appended to.</param>
+        /// <param name="limit">The maximum number of rows to return.</param>
+        /// <param name="offset">The number of rows to skip before returning results.</param>
+        /// <param name="limitParameterName">Parameter name for the limit value.</param>
+        /// <param name="offsetParameterName">Parameter name for the offset value.</param>
         public override void ApplyPaging(OptimizedSqlBuilder sb, int? limit, int? offset, string? limitParameterName, string? offsetParameterName)
         {
             EnsureValidParameterName(limitParameterName, nameof(limitParameterName));
@@ -52,11 +62,20 @@ namespace nORM.Providers
             }
         }
         
+        /// <summary>
+        /// Returns a SQL fragment that retrieves the last auto-incremented identity value.
+        /// </summary>
         public override string GetIdentityRetrievalString(TableMapping m) => "; SELECT LAST_INSERT_ID();";
-        
+
+        /// <summary>
+        /// Creates a new <see cref="DbParameter"/> for use with MySQL commands.
+        /// </summary>
         public override DbParameter CreateParameter(string name, object? value) =>
             _parameterFactory.CreateParameter(name, value);
 
+        /// <summary>
+        /// Translates selected .NET methods to their MySQL SQL equivalents.
+        /// </summary>
         public override string? TranslateFunction(string name, Type declaringType, params string[] args)
         {
             if (declaringType == typeof(string))
@@ -100,9 +119,15 @@ namespace nORM.Providers
             return null;
         }
 
+        /// <summary>
+        /// Translates access to a JSON value using MySQL's <c>JSON_EXTRACT</c> function.
+        /// </summary>
         public override string TranslateJsonPathAccess(string columnName, string jsonPath)
             => $"JSON_UNQUOTE(JSON_EXTRACT({columnName}, '{jsonPath}'))";
 
+        /// <summary>
+        /// Generates the SQL statement to create the temporal history table for an entity.
+        /// </summary>
         public override string GenerateCreateHistoryTableSql(TableMapping mapping)
         {
             var historyTable = Escape(mapping.TableName + "_History");
@@ -118,6 +143,9 @@ CREATE TABLE {historyTable} (
 ) ENGINE=InnoDB;";
         }
 
+        /// <summary>
+        /// Generates the SQL needed to create triggers that populate the temporal history table.
+        /// </summary>
         public override string GenerateTemporalTriggersSql(TableMapping mapping)
         {
             var table = Escape(mapping.TableName);


### PR DESCRIPTION
## Summary
- document migration infrastructure and schema diff utilities
- add XML docs for navigation context and lazy loading helpers
- expand provider documentation for SQL generation methods

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c15d5bab88832c953009948b63cfbf