### PR TITLE
Add XML documentation across internal utilities and migration runners

### DIFF
--- a/src/nORM/Internal/CommandInterceptorExtensions.cs
+++ b/src/nORM/Internal/CommandInterceptorExtensions.cs
@@ -257,6 +257,20 @@ namespace nORM.Internal
             }
         }
 
+        /// <summary>
+        /// Executes <see cref="DbCommand.ExecuteReader(CommandBehavior)"/> while wrapping the
+        /// call with the currently registered command interceptors. This allows interceptors
+        /// to observe, modify or suppress the command execution and to be notified about
+        /// success or failure.
+        /// </summary>
+        /// <param name="command">The database command to execute.</param>
+        /// <param name="ctx">The <see cref="DbContext"/> associated with the command.</param>
+        /// <param name="behavior">Behavior flags that influence reader execution.</param>
+        /// <returns>The <see cref="DbDataReader"/> returned by the command execution.</returns>
+        /// <remarks>
+        /// The method synchronously waits for any asynchronous interceptor callbacks and
+        /// therefore should only be used in fully synchronous flows.
+        /// </remarks>
         public static DbDataReader ExecuteReaderWithInterception(this DbCommand command, DbContext ctx, CommandBehavior behavior)
         {
             var interceptors = ctx.Options.CommandInterceptors;

--- a/src/nORM/Internal/CommandPool.cs
+++ b/src/nORM/Internal/CommandPool.cs
@@ -7,6 +7,17 @@ namespace nORM.Internal
     internal sealed class CommandPool
     {
         // Removed thread-static caching. Commands are cheap to create and callers typically dispose them.
+
+        /// <summary>
+        /// Creates a new <see cref="DbCommand"/> for the specified SQL statement using the provided
+        /// connection. The command is returned with a clean parameter collection and configured for
+        /// text execution.
+        /// </summary>
+        /// <param name="connection">The open database connection from which the command is created.</param>
+        /// <param name="sql">The SQL text that the command should execute.</param>
+        /// <returns>A freshly instantiated <see cref="DbCommand"/> ready for parameterization and execution.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="connection"/> or
+        /// <paramref name="sql"/> is <c>null</c>.</exception>
         public static DbCommand Get(DbConnection connection, string sql)
         {
             if (connection is null) throw new ArgumentNullException(nameof(connection));

--- a/src/nORM/Internal/ExpressionUtils.cs
+++ b/src/nORM/Internal/ExpressionUtils.cs
@@ -24,6 +24,14 @@ namespace nORM.Internal
             return new Complexity { NodeCount = visitor.NodeCount, Depth = visitor.MaxDepth };
         }
 
+        /// <summary>
+        /// Validates that an expression tree is within the supported complexity limits. The method
+        /// throws an <see cref="InvalidOperationException"/> when the number of nodes or the depth
+        /// of the expression exceeds predefined thresholds, protecting the system from pathologically
+        /// large or recursive expressions.
+        /// </summary>
+        /// <param name="expression">The expression tree to analyze.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the expression is too complex or too deep.</exception>
         public static void ValidateExpression(Expression expression)
         {
             var complexity = AnalyzeExpressionComplexity(expression);
@@ -33,6 +41,13 @@ namespace nORM.Internal
                 throw new InvalidOperationException($"Expression too deep: {complexity.Depth} levels");
         }
 
+        /// <summary>
+        /// Calculates an appropriate timeout to use when compiling an expression tree. The timeout is
+        /// scaled based on the expression's complexity to avoid excessive waits for large trees while
+        /// still allowing simple expressions to compile quickly.
+        /// </summary>
+        /// <param name="expression">The expression for which a compilation timeout is required.</param>
+        /// <returns>A <see cref="TimeSpan"/> representing the maximum allowed compilation time.</returns>
         public static TimeSpan GetCompilationTimeout(Expression expression)
         {
             var complexity = AnalyzeExpressionComplexity(expression);
@@ -63,6 +78,14 @@ namespace nORM.Internal
             }
         }
 
+        /// <summary>
+        /// Compiles the provided <see cref="LambdaExpression"/> into a delegate and falls back to
+        /// interpreter-based execution if the compilation is cancelled or not supported on the
+        /// current platform.
+        /// </summary>
+        /// <param name="expression">The lambda expression to compile.</param>
+        /// <param name="token">Token used to cancel the compilation operation.</param>
+        /// <returns>A <see cref="Delegate"/> representing the compiled expression or an interpreted version.</returns>
         public static Delegate CompileWithFallback(LambdaExpression expression, CancellationToken token)
         {
             if (!RuntimeFeature.IsDynamicCodeSupported || !RuntimeFeature.IsDynamicCodeCompiled)
@@ -90,6 +113,12 @@ namespace nORM.Internal
             public int MaxDepth { get; private set; }
             private int _currentDepth;
 
+            /// <summary>
+            /// Visits a node within the expression tree and tracks overall complexity metrics
+            /// such as total node count and maximum traversal depth.
+            /// </summary>
+            /// <param name="node">The current expression node.</param>
+            /// <returns>The visited expression node.</returns>
             public override Expression? Visit(Expression? node)
             {
                 if (node == null)

--- a/src/nORM/Internal/LockFreeObjectPool.cs
+++ b/src/nORM/Internal/LockFreeObjectPool.cs
@@ -17,6 +17,12 @@ internal sealed class LockFreeObjectPool<T> where T : class, new()
         return item;
     }
 
+    /// <summary>
+    /// Returns an object to the pool. The instance remains associated with the current
+    /// thread via <see cref="ThreadLocal{T}"/> storage and, if it implements
+    /// <see cref="IResettable"/>, its state is reset to be reused safely on the next request.
+    /// </summary>
+    /// <param name="item">The instance to return to the pool.</param>
     public void Return(T item)
     {
         // Item stays in thread-local storage

--- a/src/nORM/Internal/ParameterOptimizer.cs
+++ b/src/nORM/Internal/ParameterOptimizer.cs
@@ -20,6 +20,15 @@ namespace nORM.Internal
             [typeof(Guid)] = DbType.Guid
         };
 
+        /// <summary>
+        /// Adds a parameter to the command, attempting to infer the optimal <see cref="DbType"/> and
+        /// size based on the supplied value. When a <paramref name="knownType"/> is provided and the
+        /// value is <c>null</c>, the mapping is still applied to avoid provider ambiguity.
+        /// </summary>
+        /// <param name="cmd">The command to which the parameter is added.</param>
+        /// <param name="name">The parameter name including prefix (e.g. <c>@Id</c>).</param>
+        /// <param name="value">The value to bind to the parameter.</param>
+        /// <param name="knownType">Optional type hint used when <paramref name="value"/> is <c>null</c>.</param>
         public static void AddOptimizedParam(this DbCommand cmd, string name, object? value, Type? knownType = null)
         {
             var param = cmd.CreateParameter();
@@ -51,6 +60,13 @@ namespace nORM.Internal
             cmd.Parameters.Add(param);
         }
 
+        /// <summary>
+        /// Adds a parameter without additional type metadata by delegating to
+        /// <see cref="AddOptimizedParam(DbCommand,string,object?,Type?)"/>.
+        /// </summary>
+        /// <param name="cmd">The command to which the parameter is added.</param>
+        /// <param name="name">The parameter name including prefix.</param>
+        /// <param name="value">The value to bind to the parameter.</param>
         public static void AddParam(this DbCommand cmd, string name, object? value)
             => AddOptimizedParam(cmd, name, value, null);
     }

--- a/src/nORM/Internal/PooledStringBuilder.cs
+++ b/src/nORM/Internal/PooledStringBuilder.cs
@@ -12,14 +12,32 @@ internal static class PooledStringBuilder
     private static readonly ObjectPool<StringBuilder> _pool =
         new DefaultObjectPool<StringBuilder>(new StringBuilderPooledObjectPolicy());
 
+    /// <summary>
+    /// Retrieves a <see cref="StringBuilder"/> instance from the shared pool. Callers must return
+    /// the instance via <see cref="Return"/> when finished to avoid unnecessary allocations.
+    /// </summary>
+    /// <returns>A <see cref="StringBuilder"/> instance ready for use.</returns>
     public static StringBuilder Rent() => _pool.Get();
 
+    /// <summary>
+    /// Returns a previously rented <see cref="StringBuilder"/> to the pool after clearing its
+    /// content so it can be reused without carrying state between operations.
+    /// </summary>
+    /// <param name="sb">The <see cref="StringBuilder"/> instance to return.</param>
     public static void Return(StringBuilder sb)
     {
         sb.Clear();
         _pool.Return(sb);
     }
 
+    /// <summary>
+    /// Concatenates the specified string values using a pooled <see cref="StringBuilder"/> and
+    /// returns the resulting string. The builder is automatically returned to the pool even if
+    /// an exception occurs during iteration.
+    /// </summary>
+    /// <param name="values">The sequence of string values to join.</param>
+    /// <param name="separator">The separator inserted between values. Defaults to a comma and space.</param>
+    /// <returns>The concatenated string.</returns>
     public static string Join(IEnumerable<string> values, string separator = ", ")
     {
         var sb = Rent();

--- a/src/nORM/Internal/ShadowPropertyInfo.cs
+++ b/src/nORM/Internal/ShadowPropertyInfo.cs
@@ -27,16 +27,92 @@ namespace nORM.Internal
         public override bool CanRead => true;
         public override bool CanWrite => true;
 
+        /// <summary>
+        /// Returns no accessor methods because a shadow property has no backing members.
+        /// </summary>
+        /// <param name="nonPublic">Ignored.</param>
+        /// <returns>An empty array.</returns>
         public override MethodInfo[] GetAccessors(bool nonPublic) => Array.Empty<MethodInfo>();
+
+        /// <summary>
+        /// Gets the <c>get</c> accessor method. Always returns <c>null</c> for shadow properties
+        /// because they do not expose runtime accessors.
+        /// </summary>
+        /// <param name="nonPublic">Ignored.</param>
+        /// <returns><c>null</c> in all cases.</returns>
         public override MethodInfo? GetGetMethod(bool nonPublic) => null;
+
+        /// <summary>
+        /// Retrieves index parameters for the property. Shadow properties are not indexers so an empty
+        /// array is returned.
+        /// </summary>
+        /// <returns>An empty <see cref="ParameterInfo"/> array.</returns>
         public override ParameterInfo[] GetIndexParameters() => Array.Empty<ParameterInfo>();
+
+        /// <summary>
+        /// Gets the <c>set</c> accessor method. Shadow properties do not have accessors and therefore
+        /// this method always returns <c>null</c>.
+        /// </summary>
+        /// <param name="nonPublic">Ignored.</param>
+        /// <returns><c>null</c>.</returns>
         public override MethodInfo? GetSetMethod(bool nonPublic) => null;
+
+        /// <summary>
+        /// Attempting to read the value of a shadow property is not supported and will always throw
+        /// <see cref="NotSupportedException"/>.
+        /// </summary>
+        /// <param name="obj">The object instance. Ignored.</param>
+        /// <param name="index">Index values. Ignored.</param>
+        /// <returns>Nothing; this method always throws.</returns>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
         public override object? GetValue(object? obj, object?[]? index) => throw new NotSupportedException();
+
+        /// <summary>
+        /// Attempting to assign a value to a shadow property is not supported and will always throw
+        /// <see cref="NotSupportedException"/>.
+        /// </summary>
+        /// <param name="obj">The object instance. Ignored.</param>
+        /// <param name="value">The value to set. Ignored.</param>
+        /// <param name="index">Index values. Ignored.</param>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
         public override void SetValue(object? obj, object? value, object?[]? index) => throw new NotSupportedException();
-        public override object? GetValue(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture) => throw new NotSupportedException();
-        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture) => throw new NotSupportedException();
+
+        /// <summary>
+        /// Overload of <see cref="GetValue(object,object?[])"/> that also accepts binding information.
+        /// Always throws <see cref="NotSupportedException"/> for shadow properties.
+        /// </summary>
+        public override object? GetValue(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        /// Overload of <see cref="SetValue(object,object,object?[])"/> that also accepts binding information.
+        /// Always throws <see cref="NotSupportedException"/> for shadow properties.
+        /// </summary>
+        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        /// Shadow properties do not carry custom attributes; this method therefore returns an empty array.
+        /// </summary>
+        /// <param name="inherit">Ignored.</param>
+        /// <returns>An empty attribute array.</returns>
         public override object[] GetCustomAttributes(bool inherit) => Array.Empty<object>();
+
+        /// <summary>
+        /// Shadow properties do not carry custom attributes; this method therefore returns an empty array.
+        /// </summary>
+        /// <param name="attributeType">The type of attribute to search for. Ignored.</param>
+        /// <param name="inherit">Ignored.</param>
+        /// <returns>An empty attribute array.</returns>
         public override object[] GetCustomAttributes(Type attributeType, bool inherit) => Array.Empty<object>();
+
+        /// <summary>
+        /// Indicates whether a custom attribute is defined. Always returns <c>false</c> for shadow properties
+        /// because they cannot have attributes.
+        /// </summary>
+        /// <param name="attributeType">The attribute type to search for.</param>
+        /// <param name="inherit">Ignored.</param>
+        /// <returns><c>false</c> in all cases.</returns>
         public override bool IsDefined(Type attributeType, bool inherit) => false;
     }
 }

--- a/src/nORM/Internal/ShadowPropertyStore.cs
+++ b/src/nORM/Internal/ShadowPropertyStore.cs
@@ -10,12 +10,24 @@ namespace nORM.Internal
     {
         private static readonly ConditionalWeakTable<object, ConcurrentDictionary<string, object?>> _values = new();
 
+        /// <summary>
+        /// Associates a value with a shadow property on the given entity instance.
+        /// </summary>
+        /// <param name="entity">The entity instance that carries the shadow property.</param>
+        /// <param name="name">The shadow property name.</param>
+        /// <param name="value">The value to store.</param>
         public static void Set(object entity, string name, object? value)
         {
             var dict = _values.GetOrCreateValue(entity);
             dict[name] = value;
         }
 
+        /// <summary>
+        /// Retrieves the value previously associated with the specified shadow property, if any.
+        /// </summary>
+        /// <param name="entity">The entity instance.</param>
+        /// <param name="name">The shadow property name.</param>
+        /// <returns>The stored value, or <c>null</c> if no value has been set.</returns>
         public static object? Get(object entity, string name)
         {
             return _values.TryGetValue(entity, out var dict) && dict.TryGetValue(name, out var val) ? val : null;

--- a/src/nORM/Migration/MySqlMigrationRunner.cs
+++ b/src/nORM/Migration/MySqlMigrationRunner.cs
@@ -75,6 +75,12 @@ namespace nORM.Migration
             return pending.Select(p => $"{p.Version}_{p.Name}").ToArray();
         }
 
+        /// <summary>
+        /// Scans the migrations assembly and returns migrations that have not yet been applied to the
+        /// target database.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A list of pending <see cref="Migration"/> instances ordered by version.</returns>
         private async Task<List<Migration>> GetPendingMigrationsInternalAsync(CancellationToken ct)
         {
             var all = _migrationsAssembly.GetTypes()
@@ -88,6 +94,12 @@ namespace nORM.Migration
             return all.Where(m => !appliedVersions.Contains(m.Version)).ToList();
         }
 
+        /// <summary>
+        /// Records in the history table that the specified migration has been successfully applied.
+        /// </summary>
+        /// <param name="migration">The migration that was applied.</param>
+        /// <param name="transaction">The active transaction.</param>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
         private async Task MarkMigrationAppliedAsync(Migration migration, DbTransaction transaction, CancellationToken ct)
         {
             await using var cmd = _connection.CreateCommand();
@@ -99,6 +111,11 @@ namespace nORM.Migration
             await ExecuteNonQueryAsync(cmd, ct).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieves the set of migration versions that have already been applied to the database.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A set containing the version numbers of applied migrations.</returns>
         private async Task<HashSet<long>> GetAppliedMigrationVersionsAsync(CancellationToken ct)
         {
             var versions = new HashSet<long>();
@@ -119,6 +136,10 @@ namespace nORM.Migration
             return versions;
         }
 
+        /// <summary>
+        /// Creates the migration history table if it does not already exist.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
         private async Task EnsureHistoryTableAsync(CancellationToken ct)
         {
             await using var cmd = _connection.CreateCommand();
@@ -126,16 +147,40 @@ namespace nORM.Migration
             await ExecuteNonQueryAsync(cmd, ct).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Executes a non-query command, optionally routing through interceptors when a context is available.
+        /// </summary>
+        /// <param name="cmd">The command to execute.</param>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>The number of rows affected.</returns>
         private Task<int> ExecuteNonQueryAsync(DbCommand cmd, CancellationToken ct)
             => _context != null ? cmd.ExecuteNonQueryWithInterceptionAsync(_context, ct) : cmd.ExecuteNonQueryAsync(ct);
 
+        /// <summary>
+        /// Executes a reader command, optionally routing through interceptors when a context is available.
+        /// </summary>
+        /// <param name="cmd">The command to execute.</param>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A <see cref="DbDataReader"/> containing the results.</returns>
         private Task<DbDataReader> ExecuteReaderAsync(DbCommand cmd, CancellationToken ct)
             => _context != null ? cmd.ExecuteReaderWithInterceptionAsync(_context, CommandBehavior.Default, ct) : cmd.ExecuteReaderAsync(ct);
 
         private sealed class GenericParameterFactory : IDbParameterFactory
         {
             private readonly DbConnection _connection;
+
+            /// <summary>
+            /// Initializes a new instance of the parameter factory using the provided connection.
+            /// </summary>
             public GenericParameterFactory(DbConnection connection) => _connection = connection;
+
+            /// <summary>
+            /// Creates a simple <see cref="DbParameter"/> with the given name and value using the
+            /// underlying provider's <see cref="DbCommand"/> implementation.
+            /// </summary>
+            /// <param name="name">The parameter name including provider-specific prefix.</param>
+            /// <param name="value">The value to assign.</param>
+            /// <returns>The configured <see cref="DbParameter"/> instance.</returns>
             public DbParameter CreateParameter(string name, object? value)
             {
                 using var cmd = _connection.CreateCommand();

--- a/src/nORM/Migration/PostgresMigrationRunner.cs
+++ b/src/nORM/Migration/PostgresMigrationRunner.cs
@@ -75,6 +75,12 @@ namespace nORM.Migration
             return pending.Select(p => $"{p.Version}_{p.Name}").ToArray();
         }
 
+        /// <summary>
+        /// Scans the migrations assembly and returns migrations that have not yet been applied to the
+        /// target PostgreSQL database.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A list of pending <see cref="Migration"/> instances ordered by version.</returns>
         private async Task<List<Migration>> GetPendingMigrationsInternalAsync(CancellationToken ct)
         {
             var all = _migrationsAssembly.GetTypes()
@@ -88,6 +94,12 @@ namespace nORM.Migration
             return all.Where(m => !appliedVersions.Contains(m.Version)).ToList();
         }
 
+        /// <summary>
+        /// Records in the history table that the specified migration has been successfully applied.
+        /// </summary>
+        /// <param name="migration">The migration that was applied.</param>
+        /// <param name="transaction">The active transaction.</param>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
         private async Task MarkMigrationAppliedAsync(Migration migration, DbTransaction transaction, CancellationToken ct)
         {
             await using var cmd = _connection.CreateCommand();
@@ -99,6 +111,11 @@ namespace nORM.Migration
             await ExecuteNonQueryAsync(cmd, ct).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieves the set of migration versions that have already been applied to the database.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A set containing the version numbers of applied migrations.</returns>
         private async Task<HashSet<long>> GetAppliedMigrationVersionsAsync(CancellationToken ct)
         {
             var versions = new HashSet<long>();
@@ -119,6 +136,10 @@ namespace nORM.Migration
             return versions;
         }
 
+        /// <summary>
+        /// Creates the migration history table if it does not already exist.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
         private async Task EnsureHistoryTableAsync(CancellationToken ct)
         {
             await using var cmd = _connection.CreateCommand();
@@ -126,16 +147,40 @@ namespace nORM.Migration
             await ExecuteNonQueryAsync(cmd, ct).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Executes a non-query command, optionally routing through interceptors when a context is available.
+        /// </summary>
+        /// <param name="cmd">The command to execute.</param>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>The number of rows affected.</returns>
         private Task<int> ExecuteNonQueryAsync(DbCommand cmd, CancellationToken ct)
             => _context != null ? cmd.ExecuteNonQueryWithInterceptionAsync(_context, ct) : cmd.ExecuteNonQueryAsync(ct);
 
+        /// <summary>
+        /// Executes a reader command, optionally routing through interceptors when a context is available.
+        /// </summary>
+        /// <param name="cmd">The command to execute.</param>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A <see cref="DbDataReader"/> containing the results.</returns>
         private Task<DbDataReader> ExecuteReaderAsync(DbCommand cmd, CancellationToken ct)
             => _context != null ? cmd.ExecuteReaderWithInterceptionAsync(_context, CommandBehavior.Default, ct) : cmd.ExecuteReaderAsync(ct);
 
         private sealed class GenericParameterFactory : IDbParameterFactory
         {
             private readonly DbConnection _connection;
+
+            /// <summary>
+            /// Initializes a new instance of the parameter factory using the provided connection.
+            /// </summary>
             public GenericParameterFactory(DbConnection connection) => _connection = connection;
+
+            /// <summary>
+            /// Creates a simple <see cref="DbParameter"/> with the given name and value using the
+            /// underlying provider's <see cref="DbCommand"/> implementation.
+            /// </summary>
+            /// <param name="name">The parameter name including provider-specific prefix.</param>
+            /// <param name="value">The value to assign.</param>
+            /// <returns>The configured <see cref="DbParameter"/> instance.</returns>
             public DbParameter CreateParameter(string name, object? value)
             {
                 using var cmd = _connection.CreateCommand();

--- a/src/nORM/Migration/SqlServerMigrationRunner.cs
+++ b/src/nORM/Migration/SqlServerMigrationRunner.cs
@@ -75,6 +75,12 @@ namespace nORM.Migration
             return pending.Select(p => $"{p.Version}_{p.Name}").ToArray();
         }
 
+        /// <summary>
+        /// Scans the migrations assembly and returns migrations that have not yet been applied to the
+        /// target SQL Server database.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A list of pending <see cref="Migration"/> instances ordered by version.</returns>
         private async Task<List<Migration>> GetPendingMigrationsInternalAsync(CancellationToken ct)
         {
             var all = _migrationsAssembly.GetTypes()
@@ -88,6 +94,12 @@ namespace nORM.Migration
             return all.Where(m => !appliedVersions.Contains(m.Version)).ToList();
         }
 
+        /// <summary>
+        /// Records in the history table that the specified migration has been successfully applied.
+        /// </summary>
+        /// <param name="migration">The migration that was applied.</param>
+        /// <param name="transaction">The active transaction.</param>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
         private async Task MarkMigrationAppliedAsync(Migration migration, DbTransaction transaction, CancellationToken ct)
         {
             await using var cmd = _connection.CreateCommand();
@@ -99,6 +111,11 @@ namespace nORM.Migration
             await ExecuteNonQueryAsync(cmd, ct).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieves the set of migration versions that have already been applied to the database.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A set containing the version numbers of applied migrations.</returns>
         private async Task<HashSet<long>> GetAppliedMigrationVersionsAsync(CancellationToken ct)
         {
             var versions = new HashSet<long>();
@@ -119,6 +136,10 @@ namespace nORM.Migration
             return versions;
         }
 
+        /// <summary>
+        /// Creates the migration history table if it does not already exist.
+        /// </summary>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
         private async Task EnsureHistoryTableAsync(CancellationToken ct)
         {
             await using var cmd = _connection.CreateCommand();
@@ -126,9 +147,21 @@ namespace nORM.Migration
             await ExecuteNonQueryAsync(cmd, ct).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Executes a non-query command, optionally routing through interceptors when a context is available.
+        /// </summary>
+        /// <param name="cmd">The command to execute.</param>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>The number of rows affected.</returns>
         private Task<int> ExecuteNonQueryAsync(DbCommand cmd, CancellationToken ct)
             => _context != null ? cmd.ExecuteNonQueryWithInterceptionAsync(_context, ct) : cmd.ExecuteNonQueryAsync(ct);
 
+        /// <summary>
+        /// Executes a reader command, optionally routing through interceptors when a context is available.
+        /// </summary>
+        /// <param name="cmd">The command to execute.</param>
+        /// <param name="ct">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A <see cref="DbDataReader"/> containing the results.</returns>
         private Task<DbDataReader> ExecuteReaderAsync(DbCommand cmd, CancellationToken ct)
             => _context != null ? cmd.ExecuteReaderWithInterceptionAsync(_context, CommandBehavior.Default, ct) : cmd.ExecuteReaderAsync(ct);
     }


### PR DESCRIPTION
## Summary
- add detailed XML comments for command interception and pooling helpers
- document expression utilities, parameter optimization, and string builder pooling
- flesh out migration runner internals with XML comments for database history operations

## Testing
- `dotnet test` *(fails: type or namespace name could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68c165c53554832ca4cc1b1543d852ca