### PR TITLE
docs: add XML comments for reader utilities

### DIFF
--- a/src/nORM/Query/MaterializerFactory.cs
+++ b/src/nORM/Query/MaterializerFactory.cs
@@ -795,6 +795,14 @@ namespace nORM.Query
                 _fieldCount = fieldCount;
             }
 
+            /// <summary>
+            /// Gets the number of fields that the validation reader exposes.
+            /// </summary>
+            /// <remarks>
+            /// The value is supplied when the <see cref="ValidationDbDataReader"/> is created
+            /// and represents the expected number of columns for validation.
+            /// </remarks>
+            /// <value>The total number of fields defined for validation.</value>
             public override int FieldCount => _fieldCount;
             /// <summary>
             /// Indicates that the value at the specified ordinal is always
@@ -824,10 +832,28 @@ namespace nORM.Query
             public override string GetDataTypeName(int ordinal) => nameof(Object);
             public override Type GetFieldType(int ordinal) => typeof(object);
             public override bool HasRows => false;
+            /// <summary>
+            /// Always reports that the reader remains open.
+            /// </summary>
+            /// <remarks>
+            /// The validation reader operates purely in-memory and therefore never
+            /// transitions to a closed state.
+            /// </remarks>
             public override bool IsClosed => false;
+
+            /// <summary>
+            /// Always returns <c>0</c> because no records are ever affected by the
+            /// validation reader.
+            /// </summary>
             public override int RecordsAffected => 0;
+
             public override object this[int ordinal] => DBNull.Value;
             public override object this[string name] => DBNull.Value;
+
+            /// <summary>
+            /// Returns an enumerator that iterates over an empty result set.
+            /// </summary>
+            /// <returns>An <see cref="IEnumerator"/> that contains no elements.</returns>
             public override IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
             public override bool Read() => false;
             /// <summary>
@@ -843,6 +869,11 @@ namespace nORM.Query
             /// <param name="cancellationToken">Token used to cancel the operation.</param>
             /// <returns>A completed task returning <c>false</c>.</returns>
             public override Task<bool> NextResultAsync(CancellationToken cancellationToken) => Task.FromResult(false);
+            /// <summary>
+            /// Gets the nesting depth of the current row within the result set.
+            /// </summary>
+            /// <remarks>The validation reader has no hierarchy and therefore always returns <c>0</c>.</remarks>
+            /// <value>Always <c>0</c>.</value>
             public override int Depth => 0;
             public override int VisibleFieldCount => _fieldCount;
             /// <summary>Returns the default Boolean value for validation.</summary>
@@ -1084,66 +1115,136 @@ namespace nORM.Query
             public override IEnumerator GetEnumerator() => ((IEnumerable)_inner).GetEnumerator();
 
             // Typed getters with ordinal mapping
+
+            /// <summary>
+            /// Retrieves a Boolean value from the underlying reader using the mapped ordinal.
+            /// </summary>
+            /// <param name="ordinal">The zero-based column ordinal to read.</param>
+            /// <returns>The Boolean value if the ordinal is mapped; otherwise the default value.</returns>
             public override bool GetBoolean(int ordinal)
             {
                 var mapped = MapOrdinal(ordinal);
                 return mapped >= 0 ? _inner.GetBoolean(mapped) : default;
             }
 
+            /// <summary>
+            /// Retrieves a byte from the underlying reader using the mapped ordinal.
+            /// </summary>
+            /// <param name="ordinal">The zero-based column ordinal to read.</param>
+            /// <returns>The byte value if available; otherwise the default value.</returns>
             public override byte GetByte(int ordinal)
             {
                 var mapped = MapOrdinal(ordinal);
                 return mapped >= 0 ? _inner.GetByte(mapped) : default;
             }
 
+            /// <summary>
+            /// Reads a sequence of bytes from the column at the specified ordinal.
+            /// </summary>
+            /// <param name="ordinal">The column ordinal.</param>
+            /// <param name="dataOffset">The index within the field from which to begin the read operation.</param>
+            /// <param name="buffer">The buffer into which the data will be copied.</param>
+            /// <param name="bufferOffset">The index within the buffer at which to start copying.</param>
+            /// <param name="length">The maximum number of bytes to read.</param>
+            /// <returns>The actual number of bytes read.</returns>
             public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
                 => _inner.GetBytes(MapOrdinal(ordinal), dataOffset, buffer, bufferOffset, length);
 
+            /// <summary>
+            /// Retrieves a single character value from the mapped column.
+            /// </summary>
+            /// <param name="ordinal">The zero-based column ordinal.</param>
+            /// <returns>The character value if the ordinal is mapped; otherwise the default character.</returns>
             public override char GetChar(int ordinal)
             {
                 var mapped = MapOrdinal(ordinal);
                 return mapped >= 0 ? _inner.GetChar(mapped) : default;
             }
 
+            /// <summary>
+            /// Reads a sequence of characters from the column at the specified ordinal.
+            /// </summary>
+            /// <param name="ordinal">The column ordinal.</param>
+            /// <param name="dataOffset">The index within the field from which to begin the read operation.</param>
+            /// <param name="buffer">The destination buffer.</param>
+            /// <param name="bufferOffset">The index within the buffer at which to start copying.</param>
+            /// <param name="length">The maximum number of characters to read.</param>
+            /// <returns>The actual number of characters read.</returns>
             public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length)
                 => _inner.GetChars(MapOrdinal(ordinal), dataOffset, buffer, bufferOffset, length);
 
+            /// <summary>
+            /// Retrieves a <see cref="Guid"/> value using the mapped ordinal.
+            /// </summary>
+            /// <param name="ordinal">The zero-based column ordinal.</param>
+            /// <returns>The <see cref="Guid"/> value if mapped; otherwise the default value.</returns>
             public override Guid GetGuid(int ordinal)
             {
                 var mapped = MapOrdinal(ordinal);
                 return mapped >= 0 ? _inner.GetGuid(mapped) : default;
             }
 
+            /// <summary>
+            /// Retrieves a 16-bit integer using the mapped ordinal.
+            /// </summary>
+            /// <param name="ordinal">The column ordinal to read.</param>
+            /// <returns>The <see cref="short"/> value if mapped; otherwise the default value.</returns>
             public override short GetInt16(int ordinal)
             {
                 var mapped = MapOrdinal(ordinal);
                 return mapped >= 0 ? _inner.GetInt16(mapped) : default;
             }
 
+            /// <summary>
+            /// Retrieves a 32-bit integer using the mapped ordinal.
+            /// </summary>
+            /// <param name="ordinal">The column ordinal to read.</param>
+            /// <returns>The <see cref="int"/> value if mapped; otherwise the default value.</returns>
             public override int GetInt32(int ordinal)
             {
                 var mapped = MapOrdinal(ordinal);
                 return mapped >= 0 ? _inner.GetInt32(mapped) : default;
             }
 
+            /// <summary>
+            /// Retrieves a 64-bit integer using the mapped ordinal.
+            /// </summary>
+            /// <param name="ordinal">The column ordinal to read.</param>
+            /// <returns>The <see cref="long"/> value if mapped; otherwise the default value.</returns>
             public override long GetInt64(int ordinal)
             {
                 var mapped = MapOrdinal(ordinal);
                 return mapped >= 0 ? _inner.GetInt64(mapped) : default;
             }
 
+            /// <summary>
+            /// Retrieves a <see cref="DateTime"/> value using the mapped ordinal.
+            /// </summary>
+            /// <param name="ordinal">The column ordinal to read.</param>
+            /// <returns>The <see cref="DateTime"/> value if mapped; otherwise the default value.</returns>
             public override DateTime GetDateTime(int ordinal)
             {
                 var mapped = MapOrdinal(ordinal);
                 return mapped >= 0 ? _inner.GetDateTime(mapped) : default;
             }
 
+            /// <summary>
+            /// Retrieves a string value from the mapped column.
+            /// </summary>
+            /// <param name="ordinal">The column ordinal.</param>
+            /// <returns>The string value if mapped; otherwise an empty string.</returns>
             public override string GetString(int ordinal)
             {
                 var mapped = MapOrdinal(ordinal);
                 return mapped >= 0 ? _inner.GetString(mapped) : string.Empty;
             }
 
+            /// <summary>
+            /// Retrieves a <see cref="decimal"/> value from the mapped column, with
+            /// additional handling for string-based numeric representations.
+            /// </summary>
+            /// <param name="ordinal">The column ordinal.</param>
+            /// <returns>The decimal value if mapped and convertible; otherwise the default value.</returns>
             public override decimal GetDecimal(int ordinal)
             {
                 var mapped = MapOrdinal(ordinal);
@@ -1168,12 +1269,22 @@ namespace nORM.Query
                 }
             }
 
+            /// <summary>
+            /// Retrieves a double-precision floating-point value using the mapped ordinal.
+            /// </summary>
+            /// <param name="ordinal">The column ordinal.</param>
+            /// <returns>The <see cref="double"/> value if mapped; otherwise the default value.</returns>
             public override double GetDouble(int ordinal)
             {
                 var mapped = MapOrdinal(ordinal);
                 return mapped >= 0 ? _inner.GetDouble(mapped) : default;
             }
 
+            /// <summary>
+            /// Retrieves a single-precision floating-point value using the mapped ordinal.
+            /// </summary>
+            /// <param name="ordinal">The column ordinal.</param>
+            /// <returns>The <see cref="float"/> value if mapped; otherwise the default value.</returns>
             public override float GetFloat(int ordinal)
             {
                 var mapped = MapOrdinal(ordinal);
@@ -1199,14 +1310,28 @@ namespace nORM.Query
                 TableName = tableName ?? string.Empty;
             }
 
+            /// <summary>
+            /// Determines whether the specified <see cref="MaterializerCacheKey"/> is equal to the current instance.
+            /// </summary>
+            /// <param name="other">The cache key to compare with the current key.</param>
+            /// <returns><c>true</c> if the keys represent the same configuration; otherwise, <c>false</c>.</returns>
             public bool Equals(MaterializerCacheKey other) =>
                 MappingTypeHash == other.MappingTypeHash &&
                 TargetTypeHash == other.TargetTypeHash &&
                 ProjectionHash == other.ProjectionHash &&
                 string.Equals(TableName, other.TableName, StringComparison.Ordinal);
 
+            /// <summary>
+            /// Determines whether the specified object is equal to the current <see cref="MaterializerCacheKey"/>.
+            /// </summary>
+            /// <param name="obj">The object to compare with the current key.</param>
+            /// <returns><c>true</c> if <paramref name="obj"/> is a <see cref="MaterializerCacheKey"/> and represents the same configuration; otherwise, <c>false</c>.</returns>
             public override bool Equals(object? obj) => obj is MaterializerCacheKey other && Equals(other);
 
+            /// <summary>
+            /// Generates a hash code for the current key instance.
+            /// </summary>
+            /// <returns>A hash code that can be used in hashing algorithms and data structures.</returns>
             public override int GetHashCode() => HashCode.Combine(MappingTypeHash, TargetTypeHash, ProjectionHash, TableName);
         }
 

--- a/src/nORM/Query/QueryExecutor.cs
+++ b/src/nORM/Query/QueryExecutor.cs
@@ -465,27 +465,154 @@ namespace nORM.Query
             public override object this[int ordinal] => _inner[ordinal + _offset];
             public override object this[string name] => _inner[name];
 
+            /// <summary>
+            /// Retrieves a Boolean value from the underlying reader adjusted by the offset.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The Boolean value for the column.</returns>
             public override bool GetBoolean(int ordinal) => _inner.GetBoolean(ordinal + _offset);
+
+            /// <summary>
+            /// Retrieves a byte value from the underlying reader adjusted by the offset.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The byte value for the column.</returns>
             public override byte GetByte(int ordinal) => _inner.GetByte(ordinal + _offset);
+
+            /// <summary>
+            /// Reads a sequence of bytes from the specified column starting at the given offset.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <param name="dataOffset">Index within the field from which to begin the read operation.</param>
+            /// <param name="buffer">Destination array for the bytes.</param>
+            /// <param name="bufferOffset">Index within the buffer at which to start placing the data.</param>
+            /// <param name="length">Maximum number of bytes to read.</param>
+            /// <returns>The actual number of bytes read.</returns>
             public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
                 => _inner.GetBytes(ordinal + _offset, dataOffset, buffer, bufferOffset, length);
+
+            /// <summary>
+            /// Retrieves a single character from the specified column.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The character value for the column.</returns>
             public override char GetChar(int ordinal) => _inner.GetChar(ordinal + _offset);
+
+            /// <summary>
+            /// Reads a sequence of characters from the specified column starting at the given offset.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <param name="dataOffset">Index within the field from which to begin the read operation.</param>
+            /// <param name="buffer">Destination array for the characters.</param>
+            /// <param name="bufferOffset">Index within the buffer at which to start placing the data.</param>
+            /// <param name="length">Maximum number of characters to read.</param>
+            /// <returns>The actual number of characters read.</returns>
             public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length)
                 => _inner.GetChars(ordinal + _offset, dataOffset, buffer, bufferOffset, length);
+
+            /// <summary>
+            /// Gets the data type name for the column at the specified ordinal.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The database-specific type name.</returns>
             public override string GetDataTypeName(int ordinal) => _inner.GetDataTypeName(ordinal + _offset);
+
+            /// <summary>
+            /// Retrieves a <see cref="DateTime"/> value from the specified column.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The <see cref="DateTime"/> value for the column.</returns>
             public override DateTime GetDateTime(int ordinal) => _inner.GetDateTime(ordinal + _offset);
+
+            /// <summary>
+            /// Retrieves a <see cref="decimal"/> value from the specified column.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The decimal value for the column.</returns>
             public override decimal GetDecimal(int ordinal) => _inner.GetDecimal(ordinal + _offset);
+
+            /// <summary>
+            /// Retrieves a double-precision floating-point value from the specified column.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The <see cref="double"/> value for the column.</returns>
             public override double GetDouble(int ordinal) => _inner.GetDouble(ordinal + _offset);
+
+            /// <summary>
+            /// Gets the runtime type of the column at the specified ordinal.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The <see cref="Type"/> of the data stored in the column.</returns>
             public override Type GetFieldType(int ordinal) => _inner.GetFieldType(ordinal + _offset);
+
+            /// <summary>
+            /// Retrieves a single-precision floating-point value from the specified column.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The <see cref="float"/> value for the column.</returns>
             public override float GetFloat(int ordinal) => _inner.GetFloat(ordinal + _offset);
+
+            /// <summary>
+            /// Retrieves a <see cref="Guid"/> value from the specified column.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The <see cref="Guid"/> value for the column.</returns>
             public override Guid GetGuid(int ordinal) => _inner.GetGuid(ordinal + _offset);
+
+            /// <summary>
+            /// Retrieves a 16-bit integer from the specified column.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The <see cref="short"/> value for the column.</returns>
             public override short GetInt16(int ordinal) => _inner.GetInt16(ordinal + _offset);
+
+            /// <summary>
+            /// Retrieves a 32-bit integer from the specified column.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The <see cref="int"/> value for the column.</returns>
             public override int GetInt32(int ordinal) => _inner.GetInt32(ordinal + _offset);
+
+            /// <summary>
+            /// Retrieves a 64-bit integer from the specified column.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The <see cref="long"/> value for the column.</returns>
             public override long GetInt64(int ordinal) => _inner.GetInt64(ordinal + _offset);
+
+            /// <summary>
+            /// Gets the name of the column at the specified ordinal.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The column name.</returns>
             public override string GetName(int ordinal) => _inner.GetName(ordinal + _offset);
+
+            /// <summary>
+            /// Retrieves the column ordinal given its name, compensating for the offset.
+            /// </summary>
+            /// <param name="name">The name of the column.</param>
+            /// <returns>The zero-based column ordinal.</returns>
             public override int GetOrdinal(string name) => _inner.GetOrdinal(name) - _offset;
+
+            /// <summary>
+            /// Retrieves a string value from the specified column.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The string value for the column.</returns>
             public override string GetString(int ordinal) => _inner.GetString(ordinal + _offset);
+
+            /// <summary>
+            /// Retrieves the value of the specified column as an object.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns>The value of the column.</returns>
             public override object GetValue(int ordinal) => _inner.GetValue(ordinal + _offset);
+
+            /// <summary>
+            /// Populates the provided array with values from the current row, accounting for the offset.
+            /// </summary>
+            /// <param name="values">Destination array for the values.</param>
+            /// <returns>The number of values copied into the array.</returns>
             public override int GetValues(object[] values)
             {
                 var temp = new object[values.Length + _offset];
@@ -497,6 +624,12 @@ namespace nORM.Query
                     Array.Fill(values, DBNull.Value, len, values.Length - len);
                 return Math.Max(0, len);
             }
+
+            /// <summary>
+            /// Determines whether the column at the specified ordinal contains <c>DBNull</c>.
+            /// </summary>
+            /// <param name="ordinal">Column ordinal relative to the offset.</param>
+            /// <returns><c>true</c> if the column is <c>DBNull</c>; otherwise, <c>false</c>.</returns>
             public override bool IsDBNull(int ordinal) => _inner.IsDBNull(ordinal + _offset);
             /// <summary>
             /// Asynchronously determines whether the specified column is <c>DBNull</c>.


### PR DESCRIPTION
## Summary
- document ValidationDbDataReader public API
- clarify typed getters for OptimizedOrdinalShimReader
- add comments to OffsetDbDataReader accessors

## Testing
- `dotnet test` *(fails: The type or namespace name 'Core' does not exist in the namespace 'nORM')*

------
https://chatgpt.com/codex/tasks/task_e_68c16b8c7d28832c932ee108b81d6d7b