### PR TITLE
Add XML documentation for core utilities

### DIFF
--- a/src/nORM/Mapping/Column.cs
+++ b/src/nORM/Mapping/Column.cs
@@ -144,6 +144,15 @@ namespace nORM.Mapping
             return (Func<object, object?>)dm.CreateDelegate(typeof(Func<object, object?>));
         }
 
+        /// <summary>
+        /// Creates a compiled delegate capable of setting the value of the specified property on a
+        /// target object instance. The delegate performs the necessary boxing or casting so that
+        /// repeated property assignments can be performed without the overhead of reflection.
+        /// </summary>
+        /// <param name="property">The property for which a setter delegate should be created.</param>
+        /// <returns>
+        /// An <see cref="Action{T1,T2}"/> that assigns a value to the provided object's property.
+        /// </returns>
         private static Action<object, object?> CreateSetterDelegate(PropertyInfo property)
         {
             var dm = new DynamicMethod("set_" + property.Name, null, new[] { typeof(object), typeof(object) }, property.DeclaringType!.Module, true);

--- a/src/nORM/Mapping/TableMapping.cs
+++ b/src/nORM/Mapping/TableMapping.cs
@@ -96,6 +96,12 @@ namespace nORM.Mapping
             DiscoverRelations(ctx);
         }
 
+        /// <summary>
+        /// Inspects the entity type and associated configuration to build the collection of
+        /// relationships that describe how this entity links to dependents. Both explicitly
+        /// configured relationships and convention-based matches are considered.
+        /// </summary>
+        /// <param name="ctx">The <see cref="DbContext"/> used to resolve related entity mappings.</param>
         private void DiscoverRelations(DbContext ctx)
         {
             if (_fluentConfig?.Relationships.Count > 0)

--- a/src/nORM/Migration/MySqlMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/MySqlMigrationSqlGenerator.cs
@@ -57,6 +57,13 @@ namespace nORM.Migration
             return new MigrationSqlStatements(up, down);
         }
 
+        /// <summary>
+        /// Resolves the MySQL column definition for the supplied column schema. Unmapped
+        /// CLR types default to <c>LONGTEXT</c> to ensure the migration can be executed
+        /// even when a specific mapping is unknown.
+        /// </summary>
+        /// <param name="column">The column metadata describing the CLR type.</param>
+        /// <returns>The corresponding MySQL data type.</returns>
         private static string GetSqlType(ColumnSchema column)
             => TypeMap.TryGetValue(column.ClrType, out var sql) ? sql : "LONGTEXT";
     }

--- a/src/nORM/Migration/PostgresMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/PostgresMigrationSqlGenerator.cs
@@ -57,6 +57,13 @@ namespace nORM.Migration
             return new MigrationSqlStatements(up, down);
         }
 
+        /// <summary>
+        /// Maps a <see cref="ColumnSchema"/> instance to the appropriate PostgreSQL column
+        /// type. When a CLR type is not explicitly mapped, <c>TEXT</c> is used as a safe
+        /// default.
+        /// </summary>
+        /// <param name="column">The column metadata describing the desired CLR type.</param>
+        /// <returns>The PostgreSQL data type name.</returns>
         private static string GetSqlType(ColumnSchema column)
             => TypeMap.TryGetValue(column.ClrType, out var sql) ? sql : "TEXT";
     }

--- a/src/nORM/Migration/SqlServerMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/SqlServerMigrationSqlGenerator.cs
@@ -57,6 +57,12 @@ namespace nORM.Migration
             return new MigrationSqlStatements(up, down);
         }
 
+        /// <summary>
+        /// Determines the SQL Server column type corresponding to the supplied column schema.
+        /// Types not present in the internal mapping fall back to <c>NVARCHAR(MAX)</c>.
+        /// </summary>
+        /// <param name="column">The column description including the CLR type.</param>
+        /// <returns>The SQL Server data type name.</returns>
         private static string GetSqlType(ColumnSchema column)
             => TypeMap.TryGetValue(column.ClrType, out var sql) ? sql : "NVARCHAR(MAX)";
     }

--- a/src/nORM/Migration/SqliteMigrationSqlGenerator.cs
+++ b/src/nORM/Migration/SqliteMigrationSqlGenerator.cs
@@ -75,6 +75,13 @@ namespace nORM.Migration
             return new MigrationSqlStatements(up, down);
         }
 
+        /// <summary>
+        /// Converts the supplied <see cref="ColumnSchema"/> into a SQLite column type. When
+        /// an exact mapping is not found, the method defaults to <c>TEXT</c>, which can store
+        /// arbitrary data.
+        /// </summary>
+        /// <param name="column">The column definition to map.</param>
+        /// <returns>The SQLite data type as a string.</returns>
         private static string GetSqlType(ColumnSchema column)
             => TypeMap.TryGetValue(column.ClrType, out var sql) ? sql : "TEXT";
     }

--- a/src/nORM/Navigation/BatchedNavigationLoader.cs
+++ b/src/nORM/Navigation/BatchedNavigationLoader.cs
@@ -52,6 +52,12 @@ namespace nORM.Navigation
             return (List<object>)await tcs.Task.ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Callback invoked by the internal timer to trigger processing of pending navigation
+        /// loads. The method ensures only one batch is processed at a time by using an atomic
+        /// flag and dispatches the work to the thread pool.
+        /// </summary>
+        /// <param name="state">Unused timer state object.</param>
         private void TimerTick(object? state)
         {
             if (Interlocked.Exchange(ref _processing, 1) == 1) return;
@@ -158,6 +164,12 @@ namespace nORM.Navigation
             return results;
         }
 
+        /// <summary>
+        /// Removes any queued navigation load requests associated with the specified entity.
+        /// This is typically called when an entity is disposed or otherwise no longer requires
+        /// lazy-loading operations.
+        /// </summary>
+        /// <param name="entity">The entity whose pending navigation loads should be cleared.</param>
         internal void RemovePendingLoadsForEntity(object entity)
         {
             _batchSemaphore.Wait();

--- a/src/nORM/Navigation/NavigationPropertyExtensions.cs
+++ b/src/nORM/Navigation/NavigationPropertyExtensions.cs
@@ -30,6 +30,11 @@ namespace nORM.Navigation
         private static readonly ConditionalWeakTable<DbContext, BatchedNavigationLoader> _navigationLoaders = new();
         private static readonly ConcurrentDictionary<BatchedNavigationLoader, byte> _activeLoaders = new();
 
+        /// <summary>
+        /// Registers a <see cref="BatchedNavigationLoader"/> so that pending navigation requests
+        /// can be tracked and cleaned up when entities are disposed.
+        /// </summary>
+        /// <param name="loader">The loader instance to register.</param>
         internal static void RegisterLoader(BatchedNavigationLoader loader) => _activeLoaders[loader] = 0;
         internal static void UnregisterLoader(BatchedNavigationLoader loader) => _activeLoaders.TryRemove(loader, out _);
 

--- a/src/nORM/Providers/DynamicBatchSizer.cs
+++ b/src/nORM/Providers/DynamicBatchSizer.cs
@@ -32,6 +32,16 @@ namespace nORM.Providers
             public int OptimalBatchSize { get; set; } = 1000;
         }
 
+        /// <summary>
+        /// Determines an efficient batch size for bulk operations by analyzing a sample of
+        /// records and considering historical performance, memory usage and provider limits.
+        /// </summary>
+        /// <typeparam name="T">Type of the entity being processed.</typeparam>
+        /// <param name="sample">Sample records used to estimate sizes and costs.</param>
+        /// <param name="mapping">Mapping information for the entity.</param>
+        /// <param name="operationKey">Key identifying the operation for caching performance history.</param>
+        /// <param name="totalRecords">Optional total record count to further constrain the batch size.</param>
+        /// <returns>Calculated sizing information including optimal batch size and estimates.</returns>
         public BatchSizingResult CalculateOptimalBatchSize<T>(
             IEnumerable<T> sample,
             TableMapping mapping,

--- a/src/nORM/Providers/PostgresProvider.cs
+++ b/src/nORM/Providers/PostgresProvider.cs
@@ -218,6 +218,12 @@ AFTER INSERT OR UPDATE OR DELETE ON {table}
 FOR EACH ROW EXECUTE FUNCTION {functionName}();";
         }
 
+        /// <summary>
+        /// Ensures that the provided connection is compatible with the PostgreSQL provider
+        /// by verifying its runtime type.
+        /// </summary>
+        /// <param name="connection">The connection instance to validate.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the connection is not an Npgsql connection.</exception>
         protected override void ValidateConnection(DbConnection connection)
         {
             base.ValidateConnection(connection);

--- a/src/nORM/Providers/SqliteProvider.cs
+++ b/src/nORM/Providers/SqliteProvider.cs
@@ -228,6 +228,12 @@ BEGIN
 END;";
         }
 
+        /// <summary>
+        /// Verifies that the provided connection is a <see cref="SqliteConnection"/>, as required
+        /// by this provider.
+        /// </summary>
+        /// <param name="connection">The connection to validate.</param>
+        /// <exception cref="InvalidOperationException">Thrown if the connection is not compatible.</exception>
         protected override void ValidateConnection(DbConnection connection)
         {
             base.ValidateConnection(connection);

--- a/src/nORM/Query/IncludeProcessor.cs
+++ b/src/nORM/Query/IncludeProcessor.cs
@@ -132,6 +132,20 @@ namespace nORM.Query
             }
         }
 
+        /// <summary>
+        /// Reads a single level of related entities from the <paramref name="reader"/> and
+        /// associates them with their corresponding parent objects. The method materializes
+        /// each record, optionally tracks it, and groups children by foreign key so they can
+        /// be assigned back to their principals.
+        /// </summary>
+        /// <param name="relation">The relationship metadata describing the association.</param>
+        /// <param name="childMap">Mapping information for the dependent type.</param>
+        /// <param name="materializer">Delegate that converts a data record into an entity.</param>
+        /// <param name="parents">The parent entities for which related data is being loaded.</param>
+        /// <param name="reader">Data reader positioned at the result set for this level.</param>
+        /// <param name="ct">Cancellation token for the asynchronous operation.</param>
+        /// <param name="noTracking">If <c>true</c>, entities are not tracked by the context.</param>
+        /// <returns>A list of all materialized child entities for the level.</returns>
         private async Task<IList> ProcessLevelAsync(
             TableMapping.Relation relation,
             TableMapping childMap,

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -656,6 +656,14 @@ namespace nORM.Query
             b[0] = value;
             hasher.Append(b);
         }
+        /// <summary>
+        /// Executes a DELETE statement represented by the provided LINQ expression. The method
+        /// validates the generated plan, constructs the final SQL and executes it, returning the
+        /// number of affected rows.
+        /// </summary>
+        /// <param name="expression">The LINQ expression describing the entities to delete.</param>
+        /// <param name="ct">A token used to cancel the asynchronous operation.</param>
+        /// <returns>The count of rows removed from the database.</returns>
         private async Task<int> ExecuteDeleteInternalAsync(Expression expression, CancellationToken ct)
         {
             var sw = Stopwatch.StartNew();

--- a/src/nORM/Query/OptimizedSqlBuilder.cs
+++ b/src/nORM/Query/OptimizedSqlBuilder.cs
@@ -141,6 +141,11 @@ namespace nORM.Query
             ArrayPool<char>.Shared.Return(buffer);
         }
 
+        /// <summary>
+        /// Ensures that the internal buffer has enough space to accommodate the specified
+        /// number of additional characters, resizing and copying the buffer when necessary.
+        /// </summary>
+        /// <param name="additional">The number of characters that need to be appended.</param>
         private void EnsureCapacity(int additional)
         {
             var required = _position + additional;

--- a/src/nORM/Query/QueryExecutor.cs
+++ b/src/nORM/Query/QueryExecutor.cs
@@ -177,6 +177,14 @@ namespace nORM.Query
             return 0;
         }
 
+        /// <summary>
+        /// Materializes the results of a LINQ <c>GroupJoin</c> operation by streaming records from
+        /// the provided command and constructing the grouped results in memory.
+        /// </summary>
+        /// <param name="plan">The query plan describing mappings and selectors.</param>
+        /// <param name="cmd">The database command to execute.</param>
+        /// <param name="ct">Token used to cancel the operation.</param>
+        /// <returns>An <see cref="IList"/> containing the grouped join results.</returns>
         private async Task<IList> MaterializeGroupJoinAsync(QueryPlan plan, DbCommand cmd, CancellationToken ct)
         {
             var info = plan.GroupJoinInfo!;

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -498,6 +498,15 @@ namespace nORM.Query
             _parameterManager.Index = subTranslator.ParameterIndex;
             return subPlan.Sql;
         }
+        /// <summary>
+        /// Retrieves the timestamp associated with a named temporal tag from the special
+        /// <c>__NormTemporalTags</c> table. Tags are used to reference specific points in time
+        /// for temporal queries.
+        /// </summary>
+        /// <param name="tagName">The name of the temporal tag.</param>
+        /// <param name="ct">Optional cancellation token.</param>
+        /// <returns>The timestamp stored for the specified tag.</returns>
+        /// <exception cref="NormQueryException">Thrown if the tag does not exist.</exception>
         private async Task<DateTime> GetTimestampForTagAsync(string tagName, CancellationToken ct = default)
         {
             await _ctx.EnsureConnectionAsync(ct).ConfigureAwait(false);

--- a/src/nORM/Scaffolding/DatabaseScaffolder.cs
+++ b/src/nORM/Scaffolding/DatabaseScaffolder.cs
@@ -225,6 +225,10 @@ namespace nORM.Scaffolding
             return name;
         }
 
+        /// <summary>
+        /// Converts a database object name to PascalCase by removing separators and capitalizing
+        /// the first letter of each segment.
+        /// </summary>
         private static string ToPascalCase(string name)
         {
             if (string.IsNullOrWhiteSpace(name)) return name;
@@ -248,14 +252,28 @@ namespace nORM.Scaffolding
             }
         }
 
+        /// <summary>
+        /// Combines schema and table names into a single unescaped string.
+        /// </summary>
         private static string EscapeQualified(string schema, string table) => $"{schema}.{table}";
 
+        /// <summary>
+        /// Returns a schema-qualified table name if a schema is provided; otherwise returns the
+        /// table name without modification.
+        /// </summary>
         private static string EscapeQualifiedIfNeeded(string? schema, string table) =>
             string.IsNullOrEmpty(schema) ? table : $"{schema}.{table}";
 
+        /// <summary>
+        /// Escapes schema and table identifiers using the given provider's rules.
+        /// </summary>
         private static string EscapeQualified(DatabaseProvider provider, string? schema, string table)
             => string.IsNullOrEmpty(schema) ? provider.Escape(table) : $"{provider.Escape(schema!)}.{provider.Escape(table)}";
 
+        /// <summary>
+        /// Escapes a potentially schema-qualified identifier by quoting each part according to
+        /// the database connection type.
+        /// </summary>
         private static string EscapeIdentifier(DbConnection connection, string identifier)
         {
             // Support schema-qualified names by escaping each part separately.
@@ -272,6 +290,10 @@ namespace nORM.Scaffolding
             return string.Join(".", parts.Select(Quote));
         }
 
+        /// <summary>
+        /// Escapes an identifier so it is valid in generated C# code, prefixing with '@' if it is
+        /// a keyword or otherwise invalid.
+        /// </summary>
         private static string EscapeCSharpIdentifier(string identifier)
         {
             if (string.IsNullOrEmpty(identifier)) return identifier;
@@ -282,12 +304,18 @@ namespace nORM.Scaffolding
             return needsAt ? "@" + identifier : identifier;
         }
 
+        /// <summary>
+        /// Extracts the unqualified name component from a schema-qualified identifier.
+        /// </summary>
         private static string GetUnqualifiedName(string identifier)
         {
             var idx = identifier.LastIndexOf('.');
             return idx >= 0 ? identifier[(idx + 1)..] : identifier;
         }
 
+        /// <summary>
+        /// Retrieves the schema portion of a qualified identifier, or <c>null</c> if none exists.
+        /// </summary>
         private static string? GetSchemaNameOrNull(string identifier)
         {
             var idx = identifier.LastIndexOf('.');


### PR DESCRIPTION
## Summary
- add detailed XML comments for mapping helpers and relation discovery
- document SQL type resolution and provider connection validation
- improve navigation, query, and scaffolding utilities with inline docs

## Testing
- `dotnet test` *(fails: DatabaseProvider not found, missing references)*

------
https://chatgpt.com/codex/tasks/task_e_68c170894a44832c918fb44cdc785103