### PR TITLE
docs: expand xml comments for core and mapping types

### DIFF
--- a/src/nORM/Configuration/DbContextOptions.cs
+++ b/src/nORM/Configuration/DbContextOptions.cs
@@ -31,7 +31,7 @@ namespace nORM.Configuration
         /// <summary>
         /// Gets or sets the base timeout applied to all commands.
         /// This property is obsolete and provided for backward compatibility. Use
-        /// <see cref="TimeoutConfiguration.BaseTimeout"/> instead.
+        /// <see cref="AdaptiveTimeoutManager.TimeoutConfiguration.BaseTimeout"/> instead.
         /// </summary>
         [Obsolete("Use TimeoutConfiguration.BaseTimeout instead")]
         public TimeSpan CommandTimeout

--- a/src/nORM/Core/AsyncConnectionManager.cs
+++ b/src/nORM/Core/AsyncConnectionManager.cs
@@ -16,6 +16,12 @@ namespace nORM.Core
         private readonly DbConnection _connection;
         private readonly ILogger _logger;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncConnectionManager"/> class.
+        /// </summary>
+        /// <param name="connection">The underlying database connection to manage.</param>
+        /// <param name="maxConcurrency">Maximum number of concurrent operations allowed.</param>
+        /// <param name="logger">Logger used to record diagnostic information.</param>
         public AsyncConnectionManager(DbConnection connection, int maxConcurrency, ILogger logger)
         {
             _connection = connection ?? throw new ArgumentNullException(nameof(connection));
@@ -23,6 +29,15 @@ namespace nORM.Core
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
+        /// <summary>
+        /// Executes the provided asynchronous <paramref name="operation"/> ensuring
+        /// exclusive access to the underlying connection for the duration of the call.
+        /// </summary>
+        /// <typeparam name="T">The result type produced by the operation.</typeparam>
+        /// <param name="operation">Delegate that performs work using an open <see cref="DbConnection"/>.</param>
+        /// <param name="ct">Token used to cancel the asynchronous work.</param>
+        /// <returns>The value returned by the executed operation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="operation"/> is <c>null</c>.</exception>
         public async Task<T> ExecuteWithConnectionAsync<T>(Func<DbConnection, CancellationToken, Task<T>> operation, CancellationToken ct = default)
         {
             if (operation == null) throw new ArgumentNullException(nameof(operation));

--- a/src/nORM/Core/ChangeTracker.cs
+++ b/src/nORM/Core/ChangeTracker.cs
@@ -10,6 +10,11 @@ using RefComparer = System.Collections.Generic.ReferenceEqualityComparer;
 #nullable enable
 namespace nORM.Core
 {
+    /// <summary>
+    /// Keeps track of entity instances and monitors their state so that changes can be
+    /// persisted to the database. The tracker manages identity resolution and
+    /// coordinates change detection for entities attached to a <see cref="DbContext"/>.
+    /// </summary>
     public sealed class ChangeTracker
     {
         private readonly ConcurrentDictionary<object, EntityEntry> _entriesByReference = new(RefComparer.Instance);
@@ -18,6 +23,12 @@ namespace nORM.Core
         private readonly ConcurrentDictionary<EntityEntry, byte> _dirtyNonNotifyingEntries = new();
         private readonly ConcurrentDictionary<EntityEntry, byte> _dirtyEntries = new();
         private readonly DbContextOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangeTracker"/> class using the
+        /// specified context options.
+        /// </summary>
+        /// <param name="options">Options that influence change-tracking behavior.</param>
         public ChangeTracker(DbContextOptions options)
         {
             _options = options;
@@ -174,6 +185,10 @@ namespace nORM.Core
                 }
             }
         }
+        /// <summary>
+        /// Gets an enumeration of the <see cref="EntityEntry"/> instances currently
+        /// tracked by the context.
+        /// </summary>
         public IEnumerable<EntityEntry> Entries => _entriesByReference.Values;
         /// <summary>
         /// Forces change detection for all entities that have been marked as dirty,

--- a/src/nORM/Core/ConnectionManager.cs
+++ b/src/nORM/Core/ConnectionManager.cs
@@ -39,6 +39,15 @@ namespace nORM.Core
         private readonly TimeSpan _baseDelay = TimeSpan.FromSeconds(1);
         private readonly TimeSpan _maxDelay = TimeSpan.FromSeconds(30);
 
+        /// <summary>
+        /// Initializes a new <see cref="ConnectionManager"/> that manages database connections
+        /// across a topology of nodes. Connection pools are created for each node and an
+        /// optional background health check loop is started.
+        /// </summary>
+        /// <param name="topology">Topology describing available database nodes.</param>
+        /// <param name="provider">Database provider responsible for creating connections.</param>
+        /// <param name="logger">Logger used for diagnostic output.</param>
+        /// <param name="healthCheckInterval">Optional interval between health check executions.</param>
         public ConnectionManager(DatabaseTopology topology, DatabaseProvider provider, ILogger logger, TimeSpan? healthCheckInterval = null)
         {
             _topology = topology ?? throw new ArgumentNullException(nameof(topology));

--- a/src/nORM/Core/DatabaseFacade.cs
+++ b/src/nORM/Core/DatabaseFacade.cs
@@ -5,6 +5,10 @@ using System.Threading.Tasks;
 
 namespace nORM.Core
 {
+    /// <summary>
+    /// Provides access to database-specific functionality for a <see cref="DbContext"/>,
+    /// such as transaction management.
+    /// </summary>
     public class DatabaseFacade
     {
         private readonly DbContext _context;
@@ -14,6 +18,9 @@ namespace nORM.Core
             _context = context;
         }
 
+        /// <summary>
+        /// Gets the active <see cref="DbTransaction"/> for the context, if one exists.
+        /// </summary>
         public DbTransaction? CurrentTransaction => _context.CurrentTransaction;
 
         /// <summary>

--- a/src/nORM/Core/DatabaseTopology.cs
+++ b/src/nORM/Core/DatabaseTopology.cs
@@ -9,14 +9,27 @@ namespace nORM.Core
     /// </summary>
     public class DatabaseTopology
     {
+        /// <summary>
+        /// Describes a single database node participating in the topology.
+        /// </summary>
         public class DatabaseNode
         {
+            /// <summary>Connection string used to reach the node.</summary>
             public string ConnectionString { get; set; } = string.Empty;
+
+            /// <summary>The role the node plays within the topology.</summary>
             public DatabaseRole Role { get; set; }
                 = DatabaseRole.Primary;
+
+            /// <summary>Relative priority used when selecting nodes.</summary>
             public int Priority { get; set; }
                 = 0;
+
             private int _isHealthy = 1;
+
+            /// <summary>
+            /// Indicates whether the node is considered healthy and eligible for use.
+            /// </summary>
             public bool IsHealthy
             {
                 get => Volatile.Read(ref _isHealthy) == 1;
@@ -24,6 +37,8 @@ namespace nORM.Core
             }
 
             private long _lastHealthCheckTicks = DateTime.UtcNow.Ticks;
+
+            /// <summary>Timestamp of the last health check performed against the node.</summary>
             public DateTime LastHealthCheck
             {
                 get => new DateTime(Volatile.Read(ref _lastHealthCheckTicks), DateTimeKind.Utc);
@@ -31,21 +46,36 @@ namespace nORM.Core
             }
 
             private long _averageLatencyTicks;
+
+            /// <summary>
+            /// Gets or sets the moving average latency observed when communicating with the node.
+            /// </summary>
             public TimeSpan AverageLatency
             {
                 get => TimeSpan.FromTicks(Volatile.Read(ref _averageLatencyTicks));
                 set => Volatile.Write(ref _averageLatencyTicks, value.Ticks);
             }
+
+            /// <summary>Geographic region where the node is located.</summary>
             public string Region { get; set; } = string.Empty;
         }
 
+        /// <summary>
+        /// Enumerates the roles that a database node can fulfill.
+        /// </summary>
         public enum DatabaseRole
         {
+            /// <summary>The primary writable node.</summary>
             Primary,
+            /// <summary>A read-only replica used for load balancing.</summary>
             ReadReplica,
+            /// <summary>A secondary writable node that can assume the primary role during failover.</summary>
             SecondaryMaster
         }
 
+        /// <summary>
+        /// Collection of nodes that make up the topology.
+        /// </summary>
         public List<DatabaseNode> Nodes { get; } = new();
 
         /// <summary>

--- a/src/nORM/Core/DbConcurrencyException.cs
+++ b/src/nORM/Core/DbConcurrencyException.cs
@@ -7,8 +7,25 @@ namespace nORM.Core
     /// </summary>
     public class DbConcurrencyException : Exception
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DbConcurrencyException"/> class.
+        /// </summary>
         public DbConcurrencyException() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DbConcurrencyException"/> class
+        /// with a specified error <paramref name="message"/>.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
         public DbConcurrencyException(string? message) : base(message) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DbConcurrencyException"/> class
+        /// with a specified error <paramref name="message"/> and a reference to the
+        /// inner <paramref name="innerException"/> that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public DbConcurrencyException(string? message, Exception? innerException) : base(message, innerException) { }
     }
 }

--- a/src/nORM/Core/Norm.cs
+++ b/src/nORM/Core/Norm.cs
@@ -9,8 +9,19 @@ using nORM.Internal;
 
 namespace nORM.Core
 {
+    /// <summary>
+    /// Provides helpers for compiling query expressions into high-performance delegates.
+    /// </summary>
     public static class Norm
     {
+        /// <summary>
+        /// Compiles the supplied query expression into a reusable delegate that executes the query asynchronously.
+        /// </summary>
+        /// <typeparam name="TContext">Type of the <see cref="DbContext"/>.</typeparam>
+        /// <typeparam name="TParam">Type of the parameter passed to the query.</typeparam>
+        /// <typeparam name="T">Element type returned by the query.</typeparam>
+        /// <param name="queryExpression">Expression describing the query to compile.</param>
+        /// <returns>A delegate that executes the query and returns the results as a <see cref="List{T}"/>.</returns>
         public static Func<TContext, TParam, Task<List<T>>> CompileQuery<TContext, TParam, T>(Expression<Func<TContext, TParam, IQueryable<T>>> queryExpression)
             where TContext : DbContext
             where T : class

--- a/src/nORM/Core/NormAsyncExtensions.cs
+++ b/src/nORM/Core/NormAsyncExtensions.cs
@@ -184,6 +184,13 @@ namespace nORM.Core
                 "For Entity Framework queries, use Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.FirstOrDefaultAsync().");
         }
 
+        /// <summary>
+        /// Executes a bulk delete for the entities matching the query.
+        /// </summary>
+        /// <typeparam name="T">Type of the entity.</typeparam>
+        /// <param name="source">Query identifying entities to delete.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>The number of affected rows.</returns>
         public static Task<int> ExecuteDeleteAsync<T>(this IQueryable<T> source, CancellationToken ct = default)
             where T : class
         {
@@ -197,6 +204,14 @@ namespace nORM.Core
                 "Make sure you started with context.Query<T>().");
         }
 
+        /// <summary>
+        /// Executes a bulk update for entities matching the query using the provided property assignments.
+        /// </summary>
+        /// <typeparam name="T">Type of the entity.</typeparam>
+        /// <param name="source">Query identifying entities to update.</param>
+        /// <param name="set">Delegate specifying property assignments.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>The number of affected rows.</returns>
         public static Task<int> ExecuteUpdateAsync<T>(this IQueryable<T> source, Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> set, CancellationToken ct = default)
             where T : class
         {
@@ -209,8 +224,11 @@ namespace nORM.Core
                 "ExecuteUpdateAsync extension can only be used with nORM queries. " +
                 "Make sure you started with context.Query<T>().");
         }
-        
+
         // Join operations for nORM - these don't conflict since they return IQueryable
+        /// <summary>
+        /// Performs an inner join between two queryable sources.
+        /// </summary>
         public static IQueryable<TResult> Join<TOuter, TInner, TKey, TResult>(
             this IQueryable<TOuter> outer,
             IQueryable<TInner> inner,
@@ -220,7 +238,10 @@ namespace nORM.Core
         {
             return Queryable.Join(outer, inner, outerKeySelector, innerKeySelector, resultSelector);
         }
-        
+
+        /// <summary>
+        /// Performs a group join between two queryable sources.
+        /// </summary>
         public static IQueryable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(
             this IQueryable<TOuter> outer,
             IQueryable<TInner> inner,

--- a/src/nORM/Core/NormException.cs
+++ b/src/nORM/Core/NormException.cs
@@ -6,11 +6,28 @@ using System.Data.Common;
 
 namespace nORM.Core
 {
+    /// <summary>
+    /// Base exception type for nORM that enriches <see cref="DbException"/> with SQL and parameter information.
+    /// </summary>
     public class NormException : DbException
     {
+        /// <summary>
+        /// Gets the SQL statement that caused the exception, if available.
+        /// </summary>
         public string? SqlStatement { get; }
+
+        /// <summary>
+        /// Gets the parameters used with the SQL statement, if any.
+        /// </summary>
         public IReadOnlyDictionary<string, object>? Parameters { get; }
-        
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="NormException"/>.
+        /// </summary>
+        /// <param name="message">Human-readable error message.</param>
+        /// <param name="sql">SQL statement associated with the error.</param>
+        /// <param name="parameters">Parameters supplied with the SQL statement.</param>
+        /// <param name="inner">The original exception that triggered this error.</param>
         public NormException(string message, string? sql, IReadOnlyDictionary<string, object>? parameters, Exception? inner = null)
             : base(message, inner)
         {

--- a/src/nORM/Core/NormExceptionHandler.cs
+++ b/src/nORM/Core/NormExceptionHandler.cs
@@ -8,17 +8,34 @@ using Microsoft.Extensions.Logging;
 
 namespace nORM.Core
 {
+    /// <summary>
+    /// Provides rich exception handling for database operations, logging contextual information
+    /// and translating low-level exceptions into <see cref="NormException"/> instances.
+    /// </summary>
     public class NormExceptionHandler
     {
         private readonly ILogger _logger;
         private readonly string _correlationId;
 
+        /// <summary>
+        /// Creates a new <see cref="NormExceptionHandler"/> that uses the specified logger for diagnostics.
+        /// </summary>
+        /// <param name="logger">Logger used to record successes and failures.</param>
         public NormExceptionHandler(ILogger logger)
         {
             _logger = logger;
             _correlationId = Guid.NewGuid().ToString("N")[..8];
         }
 
+        /// <summary>
+        /// Executes the provided operation and wraps any thrown exception into a <see cref="NormException"/> with
+        /// additional context information and logging.
+        /// </summary>
+        /// <typeparam name="T">Type of the result returned by the operation.</typeparam>
+        /// <param name="operation">The asynchronous operation to execute.</param>
+        /// <param name="operationName">Human-readable name of the operation for logging.</param>
+        /// <param name="context">Optional additional context values.</param>
+        /// <returns>The result of the operation if successful.</returns>
         public async Task<T> ExecuteWithExceptionHandling<T>(Func<Task<T>> operation, string operationName, Dictionary<string, object>? context = null)
         {
             var stopwatch = Stopwatch.StartNew();
@@ -84,16 +101,36 @@ namespace nORM.Core
         }
     }
 
+    /// <summary>
+    /// Represents database-specific failures such as constraint violations or other provider errors.
+    /// </summary>
     public class NormDatabaseException : NormException
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="NormDatabaseException"/>.
+        /// </summary>
+        /// <param name="message">Human-readable error message.</param>
+        /// <param name="sql">SQL statement that caused the failure, if available.</param>
+        /// <param name="parameters">Parameters supplied with the SQL statement.</param>
+        /// <param name="inner">The original provider exception.</param>
         public NormDatabaseException(string message, string? sql, IReadOnlyDictionary<string, object>? parameters, Exception? inner)
             : base(message, sql, parameters, inner)
         {
         }
     }
 
+    /// <summary>
+    /// Thrown when a database operation exceeds the configured timeout.
+    /// </summary>
     public class NormTimeoutException : NormException
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="NormTimeoutException"/>.
+        /// </summary>
+        /// <param name="message">Human-readable error message.</param>
+        /// <param name="sql">SQL statement being executed, if known.</param>
+        /// <param name="parameters">Parameters supplied to the statement.</param>
+        /// <param name="inner">The original timeout exception.</param>
         public NormTimeoutException(string message, string? sql, IReadOnlyDictionary<string, object>? parameters, Exception? inner)
             : base(message, sql, parameters, inner)
         {

--- a/src/nORM/Core/NormMemoryCacheProvider.cs
+++ b/src/nORM/Core/NormMemoryCacheProvider.cs
@@ -21,6 +21,10 @@ namespace nORM.Core
         private readonly ConcurrentDictionary<string, CancellationTokenSource> _tagTokens = new();
         private readonly Func<object?>? _getTenantId;
 
+        /// <summary>
+        /// Creates a new <see cref="NormMemoryCacheProvider"/> optionally scoped by tenant.
+        /// </summary>
+        /// <param name="getTenantId">Delegate that returns the current tenant identifier or <c>null</c> for single-tenant usage.</param>
         public NormMemoryCacheProvider(Func<object?>? getTenantId = null)
         {
             _getTenantId = getTenantId;
@@ -44,11 +48,26 @@ namespace nORM.Core
             return $"TENANT:{tenant}:{tag}";
         }
 
+        /// <summary>
+        /// Attempts to retrieve a cached value.
+        /// </summary>
+        /// <param name="key">The unique cache key.</param>
+        /// <param name="value">The cached value, if present.</param>
+        /// <typeparam name="T">Type of the cached item.</typeparam>
+        /// <returns><c>true</c> if the item was found; otherwise <c>false</c>.</returns>
         public bool TryGet<T>(string key, out T? value)
         {
             return _cache.TryGetValue(key, out value);
         }
 
+        /// <summary>
+        /// Stores a value in the cache with the specified expiration and tags.
+        /// </summary>
+        /// <param name="key">Key under which the value is stored.</param>
+        /// <param name="value">Value to cache.</param>
+        /// <param name="expiration">Absolute expiration for the cache entry.</param>
+        /// <param name="tags">Tags used to group related cache entries.</param>
+        /// <typeparam name="T">Type of the value being cached.</typeparam>
         public void Set<T>(string key, T value, TimeSpan expiration, IEnumerable<string> tags)
         {
             var options = new MemoryCacheEntryOptions()

--- a/src/nORM/Core/NormQueryException.cs
+++ b/src/nORM/Core/NormQueryException.cs
@@ -3,8 +3,18 @@ using System.Collections.Generic;
 
 namespace nORM.Core
 {
+    /// <summary>
+    /// Exception thrown when a query fails to execute or produces an error result.
+    /// </summary>
     public class NormQueryException : NormException
     {
+        /// <summary>
+        /// Initializes a new <see cref="NormQueryException"/>.
+        /// </summary>
+        /// <param name="message">Human-readable error message.</param>
+        /// <param name="sql">Offending SQL statement, if available.</param>
+        /// <param name="parameters">Parameters used in the statement.</param>
+        /// <param name="inner">Underlying exception that triggered this error.</param>
         public NormQueryException(string message, string? sql = null,
             IReadOnlyDictionary<string, object>? parameters = null, Exception? inner = null)
             : base(message, sql, parameters, inner)

--- a/src/nORM/Core/NormUnsupportedFeatureException.cs
+++ b/src/nORM/Core/NormUnsupportedFeatureException.cs
@@ -7,6 +7,11 @@ namespace nORM.Core
     /// </summary>
     public class NormUnsupportedFeatureException : NormException
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="NormUnsupportedFeatureException"/>.
+        /// </summary>
+        /// <param name="message">Description of the unsupported feature.</param>
+        /// <param name="inner">Optional inner exception.</param>
         public NormUnsupportedFeatureException(string message, Exception? inner = null)
             : base(message, null, null, inner)
         {

--- a/src/nORM/Core/NormUsageException.cs
+++ b/src/nORM/Core/NormUsageException.cs
@@ -7,6 +7,11 @@ namespace nORM.Core
     /// </summary>
     public class NormUsageException : NormException
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="NormUsageException"/>.
+        /// </summary>
+        /// <param name="message">Description of the incorrect usage.</param>
+        /// <param name="inner">Optional inner exception.</param>
         public NormUsageException(string message, Exception? inner = null)
             : base(message, null, null, inner)
         {

--- a/src/nORM/Core/NormValidator.cs
+++ b/src/nORM/Core/NormValidator.cs
@@ -13,6 +13,10 @@ using Microsoft.SqlServer.TransactSql.ScriptDom;
 
 namespace nORM.Core
 {
+    /// <summary>
+    /// Provides runtime validation helpers for entities, bulk operations and raw SQL statements
+    /// to guard against misuse and excessively large payloads.
+    /// </summary>
     public static class NormValidator
     {
         private const int MaxEntityDepth = 10;
@@ -25,6 +29,13 @@ namespace nORM.Core
             new DefaultObjectPool<HashSet<object>>(new HashSetPolicy(), Environment.ProcessorCount * 2);
         private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PropertyCache = new();
 
+        /// <summary>
+        /// Validates a single entity instance to ensure it does not contain excessively deep
+        /// or cyclic graphs that could lead to stack overflows or performance issues.
+        /// </summary>
+        /// <typeparam name="T">Type of the entity being validated.</typeparam>
+        /// <param name="entity">Entity instance to validate.</param>
+        /// <param name="parameterName">Name of the parameter for exception messages.</param>
         public static void ValidateEntity<T>(T entity, string parameterName = "entity") where T : class
         {
             if (entity == null)
@@ -146,6 +157,12 @@ namespace nORM.Core
             }
         }
 
+        /// <summary>
+        /// Validates that a bulk operation contains a reasonable number of entities and none are null.
+        /// </summary>
+        /// <typeparam name="T">Type of the entities involved in the operation.</typeparam>
+        /// <param name="entities">Collection of entities to validate.</param>
+        /// <param name="operation">Name of the bulk operation (for error messages).</param>
         public static void ValidateBulkOperation<T>(IEnumerable<T> entities, string operation) where T : class
         {
             if (entities == null)

--- a/src/nORM/Core/QueryTrackingBehavior.cs
+++ b/src/nORM/Core/QueryTrackingBehavior.cs
@@ -1,8 +1,18 @@
 namespace nORM.Core
 {
+    /// <summary>
+    /// Specifies how entities returned from queries are tracked by the <see cref="DbContext"/>.
+    /// </summary>
     public enum QueryTrackingBehavior
     {
+        /// <summary>
+        /// Track all entities so that changes can be detected and persisted.
+        /// </summary>
         TrackAll,
+
+        /// <summary>
+        /// Do not track entities; queries return detached objects.
+        /// </summary>
         NoTracking
     }
 }

--- a/src/nORM/Core/SetPropertyCalls.cs
+++ b/src/nORM/Core/SetPropertyCalls.cs
@@ -3,8 +3,19 @@ using System.Linq.Expressions;
 
 namespace nORM.Core
 {
+    /// <summary>
+    /// Represents a fluent builder used to specify property assignments for bulk update operations.
+    /// </summary>
+    /// <typeparam name="T">Type of the entity being updated.</typeparam>
     public sealed class SetPropertyCalls<T>
     {
+        /// <summary>
+        /// Specifies a property to set to the given value during a bulk update.
+        /// </summary>
+        /// <typeparam name="TProperty">Type of the property value.</typeparam>
+        /// <param name="property">Expression pointing to the property to update.</param>
+        /// <param name="value">New value to assign.</param>
+        /// <returns>The same <see cref="SetPropertyCalls{T}"/> instance for chaining.</returns>
         public SetPropertyCalls<T> SetProperty<TProperty>(Expression<Func<T, TProperty>> property, TProperty value) => this;
     }
 }

--- a/src/nORM/Core/TemporalExtensions.cs
+++ b/src/nORM/Core/TemporalExtensions.cs
@@ -5,8 +5,18 @@ using System.Reflection;
 
 namespace nORM.Core
 {
+    /// <summary>
+    /// Provides helper methods for querying temporal tables at specific points in time.
+    /// </summary>
     public static class TemporalExtensions
     {
+        /// <summary>
+        /// Creates a query that returns entity states as of the specified timestamp.
+        /// </summary>
+        /// <typeparam name="T">Type of the entity.</typeparam>
+        /// <param name="source">Queryable source representing a temporal table.</param>
+        /// <param name="timestamp">Point in time to query.</param>
+        /// <returns>A queryable that yields entity values at the given timestamp.</returns>
         public static IQueryable<T> AsOf<T>(this IQueryable<T> source, DateTime timestamp)
         {
             var method = ((MethodInfo)MethodBase.GetCurrentMethod()!).MakeGenericMethod(typeof(T));
@@ -14,6 +24,13 @@ namespace nORM.Core
             return source.Provider.CreateQuery<T>(call);
         }
 
+        /// <summary>
+        /// Creates a query that uses a temporal history table tag to filter results.
+        /// </summary>
+        /// <typeparam name="T">Type of the entity.</typeparam>
+        /// <param name="source">Queryable source representing a temporal table.</param>
+        /// <param name="tagName">Name of the history tag to apply.</param>
+        /// <returns>A queryable filtered by the specified temporal tag.</returns>
         public static IQueryable<T> AsOf<T>(this IQueryable<T> source, string tagName)
         {
             var method = ((MethodInfo)MethodBase.GetCurrentMethod()!).MakeGenericMethod(typeof(T));

--- a/src/nORM/Enterprise/IDbCacheProvider.cs
+++ b/src/nORM/Enterprise/IDbCacheProvider.cs
@@ -5,10 +5,35 @@ using System.Collections.Generic;
 
 namespace nORM.Enterprise
 {
+    /// <summary>
+    /// Defines a caching mechanism that can be used by the framework to store and
+    /// retrieve results of database operations.
+    /// </summary>
     public interface IDbCacheProvider
     {
+        /// <summary>
+        /// Attempts to retrieve a cached value for the specified <paramref name="key"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of the cached value.</typeparam>
+        /// <param name="key">The unique identifier of the cache entry.</param>
+        /// <param name="value">When this method returns, contains the cached value if it was found.</param>
+        /// <returns><c>true</c> if the value exists in the cache; otherwise, <c>false</c>.</returns>
         bool TryGet<T>(string key, out T? value);
+
+        /// <summary>
+        /// Stores a value in the cache with the specified expiration policy and tags.
+        /// </summary>
+        /// <typeparam name="T">Type of the value being cached.</typeparam>
+        /// <param name="key">The unique identifier for the cache entry.</param>
+        /// <param name="value">The value to cache.</param>
+        /// <param name="expiration">How long the entry should remain in the cache.</param>
+        /// <param name="tags">A collection of tags used to later invalidate related entries.</param>
         void Set<T>(string key, T value, TimeSpan expiration, IEnumerable<string> tags);
+
+        /// <summary>
+        /// Invalidates all cache entries associated with the specified <paramref name="tag"/>.
+        /// </summary>
+        /// <param name="tag">The tag identifying which cache entries to remove.</param>
         void InvalidateTag(string tag);
     }
 }

--- a/src/nORM/Enterprise/IDbCommandInterceptor.cs
+++ b/src/nORM/Enterprise/IDbCommandInterceptor.cs
@@ -64,6 +64,10 @@ namespace nORM.Enterprise
         /// </summary>
         protected ILogger Logger { get; }
 
+        /// <summary>
+        /// Initializes a new instance of the interceptor using the provided logger.
+        /// </summary>
+        /// <param name="logger">Logger used to emit diagnostic messages.</param>
         protected BaseDbCommandInterceptor(ILogger logger)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/nORM/Enterprise/ITenantProvider.cs
+++ b/src/nORM/Enterprise/ITenantProvider.cs
@@ -2,8 +2,15 @@
 
 namespace nORM.Enterprise
 {
+    /// <summary>
+    /// Provides access to the current tenant identifier in multi-tenant applications.
+    /// </summary>
     public interface ITenantProvider
     {
+        /// <summary>
+        /// Retrieves the identifier of the tenant associated with the current execution context.
+        /// </summary>
+        /// <returns>A value representing the current tenant.</returns>
         object GetCurrentTenantId();
     }
 }

--- a/src/nORM/Enterprise/InterceptionResult.cs
+++ b/src/nORM/Enterprise/InterceptionResult.cs
@@ -11,7 +11,14 @@ namespace nORM.Enterprise
     /// <typeparam name="T">Type of the result.</typeparam>
     public readonly struct InterceptionResult<T>
     {
+        /// <summary>
+        /// Gets a value indicating whether the command execution should be suppressed.
+        /// </summary>
         public bool IsSuppressed { get; }
+
+        /// <summary>
+        /// Gets the result to return when <see cref="IsSuppressed"/> is <c>true</c>.
+        /// </summary>
         [MaybeNull]
         public T Result { get; }
 

--- a/src/nORM/Enterprise/RetryPolicy.cs
+++ b/src/nORM/Enterprise/RetryPolicy.cs
@@ -6,10 +6,25 @@ using Microsoft.Data.SqlClient;
 
 namespace nORM.Enterprise
 {
+    /// <summary>
+    /// Defines how transient database failures should be retried.
+    /// </summary>
     public class RetryPolicy
     {
+        /// <summary>
+        /// Maximum number of retry attempts for a single operation.
+        /// </summary>
         public int MaxRetries { get; set; } = 3;
+
+        /// <summary>
+        /// Base delay applied between retry attempts.
+        /// </summary>
         public TimeSpan BaseDelay { get; set; } = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// Delegate that determines whether a given <see cref="DbException"/> is
+        /// considered transient and should trigger a retry.
+        /// </summary>
         public Func<DbException, bool> ShouldRetry { get; set; } = ex =>
             ex is SqlException sqlEx && sqlEx.Number is 4060 or 40197 or 40501 or 40613 or 49918 or 49919 or 49920 or 1205 or 1222;
     }

--- a/src/nORM/Internal/ConcurrentLruCache.cs
+++ b/src/nORM/Internal/ConcurrentLruCache.cs
@@ -22,6 +22,11 @@ namespace nORM.Internal
         private long _hits;
         private long _misses;
 
+        /// <summary>
+        /// Initializes a new concurrent LRU cache.
+        /// </summary>
+        /// <param name="maxSize">Maximum number of items the cache can hold.</param>
+        /// <param name="timeToLive">Optional time-to-live for cache entries.</param>
         public ConcurrentLruCache(int maxSize = 1000, TimeSpan? timeToLive = null)
         {
             if (maxSize <= 0) throw new ArgumentOutOfRangeException(nameof(maxSize));
@@ -149,8 +154,19 @@ namespace nORM.Internal
             }
         }
 
+        /// <summary>
+        /// Gets the total number of cache hits.
+        /// </summary>
         public long Hits => Interlocked.Read(ref _hits);
+
+        /// <summary>
+        /// Gets the total number of cache misses.
+        /// </summary>
         public long Misses => Interlocked.Read(ref _misses);
+
+        /// <summary>
+        /// Gets the ratio of hits to total lookups.
+        /// </summary>
         public double HitRate => Hits + Misses == 0 ? 0 : (double)Hits / (Hits + Misses);
 
         /// <summary>

--- a/src/nORM/Mapping/ColumnMappingCache.cs
+++ b/src/nORM/Mapping/ColumnMappingCache.cs
@@ -15,6 +15,9 @@ using nORM.Providers;
 
 namespace nORM.Mapping
 {
+    /// <summary>
+    /// Provides cached reflection-based metadata describing how entity properties map to database columns.
+    /// </summary>
     public static class ColumnMappingCache
     {
         private static readonly ConcurrentDictionary<Type, CachedTypeInfo> _typeCache = new();

--- a/src/nORM/Mapping/DiscriminatorColumnAttribute.cs
+++ b/src/nORM/Mapping/DiscriminatorColumnAttribute.cs
@@ -2,10 +2,21 @@ using System;
 
 namespace nORM.Mapping
 {
+    /// <summary>
+    /// Specifies the property that holds the discriminator value for table-per-hierarchy mappings.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public sealed class DiscriminatorColumnAttribute : Attribute
     {
+        /// <summary>
+        /// Gets the name of the discriminator property.
+        /// </summary>
         public string PropertyName { get; }
+
+        /// <summary>
+        /// Initializes the attribute with the discriminator property name.
+        /// </summary>
+        /// <param name="propertyName">Name of the property containing the discriminator value.</param>
         public DiscriminatorColumnAttribute(string propertyName)
             => PropertyName = propertyName;
     }

--- a/src/nORM/Mapping/DiscriminatorValueAttribute.cs
+++ b/src/nORM/Mapping/DiscriminatorValueAttribute.cs
@@ -2,10 +2,21 @@ using System;
 
 namespace nORM.Mapping
 {
+    /// <summary>
+    /// Specifies the discriminator value for an entity type in a table-per-hierarchy mapping.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public sealed class DiscriminatorValueAttribute : Attribute
     {
+        /// <summary>
+        /// Gets the discriminator value associated with the entity type.
+        /// </summary>
         public object Value { get; }
+
+        /// <summary>
+        /// Initializes the attribute with the discriminator value.
+        /// </summary>
+        /// <param name="value">Value stored in the discriminator column for this type.</param>
         public DiscriminatorValueAttribute(object value)
             => Value = value;
     }

--- a/src/nORM/Mapping/OwnedAttribute.cs
+++ b/src/nORM/Mapping/OwnedAttribute.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace nORM.Mapping
 {
+    /// <summary>
+    /// Marks a type as being owned by another entity, indicating its lifecycle is dependent on the owner.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class OwnedAttribute : Attribute
     {

--- a/src/nORM/Mapping/TableMapping.cs
+++ b/src/nORM/Mapping/TableMapping.cs
@@ -15,24 +15,62 @@ using System.Linq.Expressions;
 
 namespace nORM.Mapping
 {
+    /// <summary>
+    /// Describes how a CLR type maps to a database table including column and relationship metadata.
+    /// </summary>
     public sealed class TableMapping
     {
+        /// <summary>Gets the CLR type represented by this mapping.</summary>
         public readonly Type Type;
+
+        /// <summary>Gets the escaped table name used in SQL statements.</summary>
         public string EscTable;
+
+        /// <summary>Gets all mapped columns.</summary>
         public readonly Column[] Columns;
+
+        /// <summary>Gets a lookup of columns by property name.</summary>
         public readonly Dictionary<string, Column> ColumnsByName;
+
+        /// <summary>Gets the columns that form the primary key.</summary>
         public readonly Column[] KeyColumns;
+
+        /// <summary>Gets the timestamp column used for concurrency, if any.</summary>
         public readonly Column? TimestampColumn;
+
+        /// <summary>Gets the tenant discriminator column, if multi-tenancy is enabled.</summary>
         public readonly Column? TenantColumn;
+
+        /// <summary>Gets the set of columns included in insert statements.</summary>
         public readonly Column[] InsertColumns;
+
+        /// <summary>Gets the set of columns included in update statements.</summary>
         public readonly Column[] UpdateColumns;
+
+        /// <summary>Gets the unescaped table name.</summary>
         public string TableName { get; }
+
+        /// <summary>Gets the relationships to dependent entities.</summary>
         public readonly Dictionary<string, Relation> Relations = new();
+
+        /// <summary>Gets the database provider associated with this mapping.</summary>
         public readonly DatabaseProvider Provider;
+
+        /// <summary>Gets the discriminator column used for TPH inheritance, if any.</summary>
         public readonly Column? DiscriminatorColumn = null;
+
+        /// <summary>Gets mappings for derived types in TPH inheritance scenarios.</summary>
         public readonly Dictionary<object, TableMapping> TphMappings = new();
+
         private readonly IEntityTypeConfiguration? _fluentConfig;
 
+        /// <summary>
+        /// Creates a new <see cref="TableMapping"/> for the specified type and provider.
+        /// </summary>
+        /// <param name="t">CLR type being mapped.</param>
+        /// <param name="p">Database provider used for identifier escaping.</param>
+        /// <param name="ctx">Context used to resolve related mappings.</param>
+        /// <param name="fluentConfig">Optional configuration overrides.</param>
         public TableMapping(Type t, DatabaseProvider p, DbContext ctx, IEntityTypeConfiguration? fluentConfig)
         {
             Type = t;

--- a/src/nORM/Mapping/TableSplitAttribute.cs
+++ b/src/nORM/Mapping/TableSplitAttribute.cs
@@ -2,11 +2,21 @@ using System;
 
 namespace nORM.Mapping
 {
+    /// <summary>
+    /// Indicates that an entity shares its table with another principal entity (table splitting).
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public sealed class TableSplitAttribute : Attribute
     {
+        /// <summary>
+        /// Gets the principal entity type with which the table is shared.
+        /// </summary>
         public Type PrincipalType { get; }
 
+        /// <summary>
+        /// Initializes the attribute with the principal entity type.
+        /// </summary>
+        /// <param name="principalType">Type of the principal entity.</param>
         public TableSplitAttribute(Type principalType)
         {
             PrincipalType = principalType;


### PR DESCRIPTION
## Summary
- document connection manager construction and caching provider operations
- add detailed XML docs for core exception and validation helpers
- explain table mapping fields and interception result semantics

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build` *(fails: CS0246 type or namespace not found in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c2586d48f0832cb21ea08c06444c81