### PR TITLE
Add query plan cache for repeated translations

### DIFF
--- a/src/nORM/Query/QueryPlan.cs
+++ b/src/nORM/Query/QueryPlan.cs
@@ -27,7 +27,7 @@ namespace nORM.Query
         TimeSpan CommandTimeout,
         bool IsCacheable,
         TimeSpan? CacheExpiration,
-        int Fingerprint = 0,
+        ExpressionFingerprint Fingerprint = default,
         int? Take = null
     );
 


### PR DESCRIPTION
## Summary
- add a 128-bit expression fingerprint to key cached query plans
- reuse translated plans through a concurrent LRU cache while rebinding fresh parameters
- track parameter templates during translation to support cache hits without retranslation

## Testing
- `dotnet test` *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f41544618832cb894c0ee2521209c)