### PR TITLE
Optimize batch slicing for bulk operations

### DIFF
--- a/src/nORM/Providers/BulkOperationProvider.cs
+++ b/src/nORM/Providers/BulkOperationProvider.cs
@@ -39,7 +39,21 @@ namespace nORM.Providers
             {
                 for (int i = 0; i < entityList.Count; i += sizing.OptimalBatchSize)
                 {
-                    var batch = entityList.Skip(i).Take(sizing.OptimalBatchSize).ToList();
+                    var batchCount = Math.Min(sizing.OptimalBatchSize, entityList.Count - i);
+                    List<T> batch;
+
+                    if (entityList is List<T> list)
+                    {
+                        batch = list.GetRange(i, batchCount);
+                    }
+                    else
+                    {
+                        batch = new List<T>(batchCount);
+                        for (var j = 0; j < batchCount; j++)
+                        {
+                            batch.Add(entityList[i + j]);
+                        }
+                    }
                     var batchSw = Stopwatch.StartNew();
                     total += await batchAction(batch, transaction, ct).ConfigureAwait(false);
                     batchSw.Stop();


### PR DESCRIPTION
## Summary
- avoid repeated Skip/Take batching that caused quadratic iteration cost
- slice batches directly using List.GetRange or indexed copy for other IList implementations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fe24183e4832ca86ac5192fb0e6a1)