### PR TITLE
Fix SQL template cache key collision risk

### DIFF
--- a/tests/FastPathQueryExecutorTests.cs
+++ b/tests/FastPathQueryExecutorTests.cs
@@ -1,6 +1,8 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite;
 using nORM.Core;
@@ -16,6 +18,18 @@ public class FastPathQueryExecutorTests
     {
         public int Id { get; set; }
         public bool IsActive { get; set; }
+    }
+
+    private class Alpha
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private class Beta
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
     }
 
     [Fact]
@@ -69,5 +83,49 @@ public class FastPathQueryExecutorTests
 
         var count = (int)await task.ConfigureAwait(true);
         Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void Sql_templates_are_cached_per_type()
+    {
+        using var cn = new SqliteConnection("Data Source=:memory:");
+        cn.Open();
+        using (var cmd = cn.CreateCommand())
+        {
+            cmd.CommandText =
+                "CREATE TABLE \"Alpha\"(Id INTEGER, Name TEXT);" +
+                "CREATE TABLE \"Beta\"(Id INTEGER, IsEnabled INTEGER);";
+            cmd.ExecuteNonQuery();
+        }
+
+        using var ctx = new DbContext(cn, new SqliteProvider());
+        var cacheField = typeof(FastPathQueryExecutor)
+            .GetField("_sqlTemplateCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cache = Assert.IsType<ConcurrentDictionary<Type, string>>(cacheField.GetValue(null));
+        cache.Clear();
+
+        var alphaTemplate = InvokeGetSqlTemplate(ctx, typeof(Alpha));
+        var betaTemplate = InvokeGetSqlTemplate(ctx, typeof(Beta));
+
+        var alphaMap = ctx.GetMapping(typeof(Alpha));
+        var betaMap = ctx.GetMapping(typeof(Beta));
+        var expectedAlpha = $"SELECT {string.Join(", ", alphaMap.Columns.Select(c => c.EscCol))} FROM {alphaMap.EscTable}";
+        var expectedBeta = $"SELECT {string.Join(", ", betaMap.Columns.Select(c => c.EscCol))} FROM {betaMap.EscTable}";
+
+        Assert.Equal(expectedAlpha, alphaTemplate);
+        Assert.Equal(expectedBeta, betaTemplate);
+
+        Assert.True(cache.TryGetValue(typeof(Alpha), out var cachedAlpha));
+        Assert.True(cache.TryGetValue(typeof(Beta), out var cachedBeta));
+        Assert.Equal(expectedAlpha, cachedAlpha);
+        Assert.Equal(expectedBeta, cachedBeta);
+    }
+
+    private static string InvokeGetSqlTemplate(DbContext ctx, Type type)
+    {
+        var method = typeof(FastPathQueryExecutor)
+            .GetMethod("GetSqlTemplate", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var generic = method.MakeGenericMethod(type);
+        return (string)generic.Invoke(null, new object[] { ctx })!;
     }
 }


### PR DESCRIPTION
## Summary
- use the entity `Type` as the key for the fast-path SQL template cache to avoid hash collisions
- add coverage to ensure SQL templates are cached separately for distinct entity types

## Testing
- dotnet test *(fails: `dotnet` is unavailable in the environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fec0a0190832c963c26cc80469735)