### PR TITLE
Optimize identifier validation

### DIFF
--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using System.Transactions;
-using System.Text.RegularExpressions;
 using System.Text;
 using nORM.Configuration;
 using nORM.Execution;
@@ -370,7 +369,17 @@ namespace nORM.Core
                 return false;
 
             // Allow standard identifiers: alphanumeric, underscore, dot
-            if (Regex.IsMatch(name, @"^[A-Za-z0-9_\.]+$"))
+            var isAlphanumericIdentifier = true;
+            foreach (var c in name.AsSpan())
+            {
+                if (!char.IsLetterOrDigit(c) && c != '_' && c != '.')
+                {
+                    isAlphanumericIdentifier = false;
+                    break;
+                }
+            }
+
+            if (isAlphanumericIdentifier)
                 return true;
 
             // Allow delimited identifiers with brackets (SQL Server): [My Table]


### PR DESCRIPTION
## Summary
- replace regex-based identifier validation with manual character scan to reduce overhead
- remove unused regex dependency from DbContext

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fee2c22a8832c96765f4c65d9c648)