### PR TITLE
Add GroupBy translation support and grouping-aware predicates

### DIFF
--- a/src/nORM/Query/OptimizedSqlBuilder.cs
+++ b/src/nORM/Query/OptimizedSqlBuilder.cs
@@ -104,6 +104,21 @@ namespace nORM.Query
         }
 
         /// <summary>
+        /// Appends a <c>GROUP BY</c> clause with the supplied columns.
+        /// </summary>
+        /// <param name="columns">The column list for the <c>GROUP BY</c> clause.</param>
+        /// <returns>The current builder instance.</returns>
+        public OptimizedSqlBuilder AppendGroupBy(ReadOnlySpan<char> columns)
+        {
+            if (!columns.IsEmpty)
+            {
+                Append(" GROUP BY ");
+                Append(columns);
+            }
+            return this;
+        }
+
+        /// <summary>
         /// Appends a SQL aggregate function invocation such as <c>COUNT(column)</c>.
         /// </summary>
         /// <param name="function">Name of the aggregate function.</param>


### PR DESCRIPTION
## Summary
- Track grouping keys inside ExpressionToSqlVisitor to translate g.Key and GroupBy result selectors
- Add optimized SQL builder support for GROUP BY clause emission
- Register grouping context for predicates after GroupBy so visitors can emit HAVING-safe SQL

## Testing
- dotnet test *(fails: `dotnet` command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff26a5a68832ca09865ac5b801903)