### PR TITLE
Fix DatabaseProvider compilation error in nORM

### DIFF
--- a/src/nORM/Query/JoinBuilder.cs
+++ b/src/nORM/Query/JoinBuilder.cs
@@ -25,7 +25,7 @@ namespace nORM.Query
     /// 2. **No Nested Anonymous Type Support:**
     ///    - Doesn't handle transparent identifiers from multiple Select() chains
     ///    - Example: `query.Select(x => new { x.Id }).Select(y => new { y.Id, Computed = y.Id * 2 })`
-    ///    - Compiler generates `<>h__TransparentIdentifier0` which isn't recognized
+    ///    - Compiler generates `&lt;&gt;h__TransparentIdentifier0` which isn't recognized
     ///
     /// 3. **No Computed/Method Call Handling:**
     ///    - Doesn't parse method calls: `new { Upper = x.Name.ToUpper() }`

--- a/src/nORM/Query/QueryTranslator.ClientEvaluation.cs
+++ b/src/nORM/Query/QueryTranslator.ClientEvaluation.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using nORM.Core;
+using nORM.Providers;
 
 namespace nORM.Query
 {

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -1875,18 +1875,6 @@ namespace nORM.Query
             using var cts = new CancellationTokenSource(timeout);
             return ExpressionUtils.CompileWithFallback(lambda, cts.Token);
         }
-        private sealed class ParameterReplacer : ExpressionVisitor
-        {
-            private readonly ParameterExpression _from;
-            private readonly Expression _to;
-            public ParameterReplacer(ParameterExpression from, Expression to)
-            {
-                _from = from;
-                _to = to;
-            }
-            protected override Expression VisitParameter(ParameterExpression node) =>
-                node == _from ? _to : base.VisitParameter(node);
-        }
         private sealed class ProjectionMemberReplacer : ExpressionVisitor
         {
             protected override Expression VisitMember(MemberExpression node)

--- a/src/nORM/Scaffolding/DynamicEntityTypeGenerator.cs
+++ b/src/nORM/Scaffolding/DynamicEntityTypeGenerator.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.ObjectPool;


### PR DESCRIPTION
- Add missing nORM.Providers namespace import to QueryTranslator.ClientEvaluation.cs
- Remove duplicate ParameterReplacer class definition from QueryTranslator.cs (kept the one in ClientEvaluation partial)
- Fix malformed XML comments in JoinBuilder.cs by escaping angle brackets in TransparentIdentifier reference
- Add missing System.Threading.Tasks import to DynamicEntityTypeGenerator.cs

Resolves CS0246, CS0111, CS0102, and CS1570 compilation errors.