### PR TITLE
Fix compilation errors in query pipeline

### DIFF
--- a/src/nORM/Internal/ExpressionCompiler.cs
+++ b/src/nORM/Internal/ExpressionCompiler.cs
@@ -14,7 +14,7 @@ namespace nORM.Internal
 {
     internal static class ExpressionCompiler
     {
-        private static readonly ConcurrentDictionary<int, Delegate> _compiledDelegateCache = new();
+        private static readonly ConcurrentDictionary<ExpressionFingerprint, Delegate> _compiledDelegateCache = new();
 
         public static Func<T, TResult> CompileExpression<T, TResult>(Expression<Func<T, TResult>> expr)
         {

--- a/src/nORM/Query/AdaptiveQueryComplexityAnalyzer.cs
+++ b/src/nORM/Query/AdaptiveQueryComplexityAnalyzer.cs
@@ -14,7 +14,7 @@ namespace nORM.Query
     internal sealed class AdaptiveQueryComplexityAnalyzer : IDisposable
     {
         private readonly IMemoryMonitor _memoryMonitor;
-        private static readonly ConcurrentDictionary<int, QueryComplexityInfo> _analysisCache = new();
+        private static readonly ConcurrentDictionary<ExpressionFingerprint, QueryComplexityInfo> _analysisCache = new();
         private const int DefaultEnumerationLimit = 2000;
         private const int MaxCacheSize = 10000;
         public AdaptiveQueryComplexityAnalyzer(IMemoryMonitor memoryMonitor)

--- a/src/nORM/Query/MaterializerFactory.cs
+++ b/src/nORM/Query/MaterializerFactory.cs
@@ -320,7 +320,7 @@ namespace nORM.Query
             var cacheKey = new MaterializerCacheKey(
                 mapping.Type.GetHashCode(),
                 targetType.GetHashCode(),
-                projection != null ? ExpressionFingerprint.Compute(projection) : 0,
+                projection != null ? ExpressionFingerprint.Compute(projection).GetHashCode() : 0,
                 mapping.TableName,
                 startOffset);
 
@@ -363,7 +363,7 @@ namespace nORM.Query
             var cacheKey = new MaterializerCacheKey(
                 mapping.Type.GetHashCode(),
                 targetType.GetHashCode(),
-                projection != null ? ExpressionFingerprint.Compute(projection) : 0,
+                projection != null ? ExpressionFingerprint.Compute(projection).GetHashCode() : 0,
                 mapping.TableName,
                 startOffset);
 
@@ -441,7 +441,7 @@ namespace nORM.Query
             var cacheKey = new MaterializerCacheKey(
                 mapping.Type.GetHashCode(),
                 targetType.GetHashCode(),
-                projection != null ? ExpressionFingerprint.Compute(projection) : 0,
+                projection != null ? ExpressionFingerprint.Compute(projection).GetHashCode() : 0,
                 mapping.TableName,
                 startOffset);
 
@@ -485,7 +485,7 @@ namespace nORM.Query
             var cacheKey = new MaterializerCacheKey(
                 mapping.Type.GetHashCode(),
                 targetType.GetHashCode(),
-                projection != null ? ExpressionFingerprint.Compute(projection) : 0,
+                projection != null ? ExpressionFingerprint.Compute(projection).GetHashCode() : 0,
                 mapping.TableName,
                 startOffset);
 

--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -345,7 +345,7 @@ namespace nORM.Query
                     _ctx.Options.Logger?.LogQuery(plan.Sql, GetParameterDictionary(), sw.Elapsed, scalarResult == null || scalarResult is DBNull ? 0 : 1);
                     if (scalarResult == null || scalarResult is DBNull) return default(TResult)!;
                     // PERFORMANCE FIX: Use ConvertScalarResult to avoid boxing for value types
-                    result = ConvertScalarResult<TResult>(scalarResult);
+                    result = ConvertScalarResult<TResult>(scalarResult)!;
                 }
                 else
                 {
@@ -415,7 +415,7 @@ namespace nORM.Query
                     _ctx.Options.Logger?.LogQuery(plan.Sql, finalParameters, sw.Elapsed, scalarResult == null || scalarResult is DBNull ? 0 : 1);
                     if (scalarResult == null || scalarResult is DBNull) return default!;
                     // PERFORMANCE FIX: Use ConvertScalarResult to avoid boxing for value types
-                    result = ConvertScalarResult<TResult>(scalarResult);
+                    result = ConvertScalarResult<TResult>(scalarResult)!;
                 }
                 else
                 {

--- a/src/nORM/Query/QueryExecutor.cs
+++ b/src/nORM/Query/QueryExecutor.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using nORM.Execution;
 using nORM.Core;
 using nORM.Internal;
 using nORM.Mapping;
@@ -328,7 +329,7 @@ namespace nORM.Query
                         {
                             var list = CreateListFromItems(info.InnerType, currentChildren);
                             // PERFORMANCE: Pass list directly instead of .Cast<object>() which creates unnecessary enumerator
-                            var result = info.ResultSelector(currentOuter, list);
+                            var result = info.ResultSelector(currentOuter, list.Cast<object>());
                             resultList.Add(result);
                             currentChildren = new List<object>();
                         }
@@ -375,7 +376,7 @@ namespace nORM.Query
                 {
                     var list = CreateListFromItems(info.InnerType, currentChildren);
                     // PERFORMANCE: Pass list directly instead of .Cast<object>() which creates unnecessary enumerator
-                    var result = info.ResultSelector(currentOuter, list);
+                    var result = info.ResultSelector(currentOuter, list.Cast<object>());
                     resultList.Add(result);
                 }
 
@@ -454,7 +455,7 @@ namespace nORM.Query
                             {
                                 var list = CreateListFromItems(info.InnerType, currentChildren);
                                 // PERFORMANCE: Pass list directly instead of .Cast<object>() which creates unnecessary enumerator
-                                var result = info.ResultSelector(currentOuter, list);
+                                var result = info.ResultSelector(currentOuter, list.Cast<object>());
                                 resultList.Add(result);
                                 currentChildren = new List<object>();
                             }
@@ -500,7 +501,7 @@ namespace nORM.Query
                     {
                         var list = CreateListFromItems(info.InnerType, currentChildren);
                         // PERFORMANCE: Pass list directly instead of .Cast<object>() which creates unnecessary enumerator
-                        var result = info.ResultSelector(currentOuter, list);
+                        var result = info.ResultSelector(currentOuter, list.Cast<object>());
                         resultList.Add(result);
                     }
 

--- a/src/nORM/Query/QueryTranslator.ClientEvaluation.cs
+++ b/src/nORM/Query/QueryTranslator.ClientEvaluation.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using nORM.Core;
+using nORM.Internal;
 using nORM.Providers;
 
 namespace nORM.Query

--- a/src/nORM/Query/QueryTranslator.MethodTranslators.cs
+++ b/src/nORM/Query/QueryTranslator.MethodTranslators.cs
@@ -4,7 +4,9 @@ using System.Linq.Expressions;
 using System.Text;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
 using nORM.Core;
+using nORM.Internal;
 using nORM.Mapping;
 
 namespace nORM.Query

--- a/src/nORM/Query/QueryTranslator.cs
+++ b/src/nORM/Query/QueryTranslator.cs
@@ -1628,6 +1628,7 @@ namespace nORM.Query
                 builderForKey.Append(groupBySql).Append(" AS GroupKey");
                 selectItems.Add(builderForKey.ToString());
                 PooledStringBuilder.Return(builderForKey);
+                var builder = (System.Text.StringBuilder?)null;
                 // Analyze the result selector body to find aggregates
                 if (resultSelector.Body is NewExpression newExpr)
                 {
@@ -1635,9 +1636,9 @@ namespace nORM.Query
                     {
                         var arg = newExpr.Arguments[i];
                         var memberName = newExpr.Members?[i]?.Name ?? $"Item{i + 1}";
-                        if (arg is MethodCallExpression methodCall)
+                        if (arg is MethodCallExpression aggregateCall)
                         {
-                            var aggregateSql = TranslateGroupAggregateMethod(methodCall, alias);
+                            var aggregateSql = TranslateGroupAggregateMethod(aggregateCall, alias);
                             if (aggregateSql != null)
                             {
                                 builder = PooledStringBuilder.Rent();

--- a/src/nORM/Query/SelectClauseVisitor.cs
+++ b/src/nORM/Query/SelectClauseVisitor.cs
@@ -22,7 +22,6 @@ namespace nORM.Query
             new DefaultObjectPool<StringBuilder>(new StringBuilderPooledObjectPolicy());
         private StringBuilder _sb = null!;
         private readonly List<PropertyInfo> _detectedCollections = new();
-        private bool _isInsideCollectionDetection;
 
         public SelectClauseVisitor(TableMapping mapping, List<string> groupBy, DatabaseProvider provider)
         {


### PR DESCRIPTION
## Summary
- declare shared builders and fix variable naming collisions in group-by projection translation
- align caching keys and helper usages with correct types and namespaces to restore compilation
- update query execution helpers to match delegate signatures and remove unused members

## Testing
- dotnet build *(fails: command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930212df340832cad72d71f3693c180)