### PR TITLE
Fix XML documentation comment warnings

### DIFF
--- a/src/nORM/Enterprise/ISaveChangesInterceptor.cs
+++ b/src/nORM/Enterprise/ISaveChangesInterceptor.cs
@@ -8,7 +8,7 @@ using nORM.Core;
 namespace nORM.Enterprise
 {
     /// <summary>
-    /// Provides hooks that run before and after <see cref="DbContext.SaveChangesAsync"/>.
+    /// Provides hooks that run before and after <see cref="DbContext.SaveChangesAsync(System.Threading.CancellationToken)"/>.
     /// Implementations may inspect or modify tracked entities or react to persistence results.
     /// </summary>
     public interface ISaveChangesInterceptor

--- a/src/nORM/Internal/ConcurrentLruCache.cs
+++ b/src/nORM/Internal/ConcurrentLruCache.cs
@@ -245,14 +245,14 @@ namespace nORM.Internal
         /// Represents a cache entry along with its creation time, optional TTL override,
         /// and last accessed timestamp (stored as ticks for Interlocked updates).
         /// </summary>
-        /// <param name="Key">The key associated with the cached value.</param>
-        /// <param name="Value">The cached value.</param>
-        /// <param name="Created">Timestamp indicating when the entry was created.</param>
-        /// <param name="TtlOverride">Optional TTL overriding the cache's default.</param>
-        /// <param name="LastAccessedTicks">
-        /// Mutable field storing last access time as ticks. Updated via Interlocked for lock-free reads.
-        /// PERFORMANCE FIX (TASK 6): This allows updating access time without acquiring write locks.
-        /// </param>
+        /// <remarks>
+        /// <para><strong>Key</strong>: The key associated with the cached value.</para>
+        /// <para><strong>Value</strong>: The cached value.</para>
+        /// <para><strong>Created</strong>: Timestamp indicating when the entry was created.</para>
+        /// <para><strong>TtlOverride</strong>: Optional TTL overriding the cache's default.</para>
+        /// <para><strong>LastAccessedTicks</strong>: Mutable field storing last access time as ticks. Updated via Interlocked for lock-free reads.
+        /// PERFORMANCE FIX (TASK 6): This allows updating access time without acquiring write locks.</para>
+        /// </remarks>
         private sealed class CacheItem
         {
             public TKey Key { get; }

--- a/src/nORM/Query/MaterializerFactory.cs
+++ b/src/nORM/Query/MaterializerFactory.cs
@@ -308,6 +308,7 @@ namespace nORM.Query
         /// <typeparam name="T">The type to materialize.</typeparam>
         /// <param name="mapping">Mapping describing the source table schema.</param>
         /// <param name="projection">Optional projection expression selecting specific members.</param>
+        /// <param name="startOffset">Zero-based column offset to start reading from the data reader.</param>
         /// <returns>A delegate that synchronously materializes objects from a data reader without boxing.</returns>
         public Func<DbDataReader, T> CreateSyncMaterializer<T>(
             TableMapping mapping,
@@ -350,6 +351,7 @@ namespace nORM.Query
         /// <param name="mapping">Mapping describing the source table schema.</param>
         /// <param name="targetType">CLR type to materialize.</param>
         /// <param name="projection">Optional projection expression selecting specific members.</param>
+        /// <param name="startOffset">Zero-based column offset to start reading from the data reader.</param>
         /// <returns>A delegate that synchronously materializes objects from a data reader.</returns>
         public Func<DbDataReader, object> CreateSyncMaterializer(
             TableMapping mapping,
@@ -422,6 +424,7 @@ namespace nORM.Query
         /// <param name="mapping">Mapping describing the source table schema.</param>
         /// <param name="targetType">CLR type to materialize.</param>
         /// <param name="projection">Optional projection expression selecting specific members.</param>
+        /// <param name="startOffset">Zero-based column offset to start reading from the data reader.</param>
         /// <returns>A delegate that asynchronously materializes objects from a data reader.</returns>
         public Func<DbDataReader, CancellationToken, Task<object>> CreateMaterializer(
             TableMapping mapping,
@@ -466,6 +469,7 @@ namespace nORM.Query
         /// <param name="mapping">Mapping describing the table layout.</param>
         /// <param name="targetType">Type of object to materialize.</param>
         /// <param name="projection">Optional projection expression.</param>
+        /// <param name="startOffset">Zero-based column offset to start reading from the data reader.</param>
         /// <returns>A delegate that materializes objects taking the reader schema into account.</returns>
         public Func<DbDataReader, CancellationToken, Task<object>> CreateSchemaAwareMaterializer(
             TableMapping mapping,

--- a/src/nORM/Query/QueryPlan.cs
+++ b/src/nORM/Query/QueryPlan.cs
@@ -49,16 +49,16 @@ namespace nORM.Query
     /// Defines a secondary query for fetching dependent collection data in split query scenarios.
     /// Used to mitigate Cartesian explosion when projecting nested collections.
     /// </summary>
+    /// <param name="TargetMapping">The table to fetch children from.</param>
+    /// <param name="ForeignKeyColumn">The foreign key column on the child table linking to the parent.</param>
+    /// <param name="ParentKeyProperty">The primary key property on the parent object to extract IDs from.</param>
+    /// <param name="TargetCollectionProperty">The collection property on the parent object to populate with children.</param>
+    /// <param name="CollectionElementType">The type of elements in the collection.</param>
     internal sealed record DependentQueryDefinition(
-        /// <summary>The table to fetch children from.</summary>
         TableMapping TargetMapping,
-        /// <summary>The foreign key column on the child table linking to the parent.</summary>
         Column ForeignKeyColumn,
-        /// <summary>The primary key property on the parent object to extract IDs from.</summary>
         PropertyInfo ParentKeyProperty,
-        /// <summary>The collection property on the parent object to populate with children.</summary>
         PropertyInfo TargetCollectionProperty,
-        /// <summary>The type of elements in the collection.</summary>
         Type CollectionElementType
     );
 


### PR DESCRIPTION
## Summary
- replace invalid XML param tags on cache item with remarks to match class fields
- document startOffset parameter across materializer factory methods
- correct record and interface XML comments to avoid compiler warnings

## Testing
- dotnet build --nologo *(fails: command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303c211fa0832cb56933a32408d5aa)