### PR TITLE
Fix cache key test fingerprint

### DIFF
--- a/tests/CacheKeyTests.cs
+++ b/tests/CacheKeyTests.cs
@@ -44,7 +44,7 @@ public class CacheKeyTests
             CommandTimeout: TimeSpan.FromSeconds(30),
             IsCacheable: true,
             CacheExpiration: null,
-            Fingerprint: 0);
+            Fingerprint: default);
     }
 
     private static string BuildKey(NormQueryProvider provider, QueryPlan plan, IReadOnlyDictionary<string, object> parameters)


### PR DESCRIPTION
## Summary
- fix cache key test construction to use default expression fingerprint instead of integer placeholder

## Testing
- dotnet test *(fails: command not found: dotnet in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303e3b534c832cb6e7fe3cedb5b4ea)