### PR TITLE
Add package README for dotnet-norm tool

### DIFF
--- a/src/dotnet-norm/README.md
+++ b/src/dotnet-norm/README.md
@@ -1,0 +1,23 @@
+# dotnet-norm CLI
+
+`dotnet-norm` provides command-line tooling for the nORM ORM framework. Use it to scaffold, validate, and manage nORM projects from the terminal.
+
+## Features
+- Validate connection strings before applying migrations.
+- Generate boilerplate configuration for nORM projects.
+- Offer helpful diagnostics to keep projects aligned with nORM best practices.
+
+## Getting Started
+Install the tool locally using the .NET CLI:
+
+```bash
+dotnet tool install --global dotnet-norm --version 1.0.0
+```
+
+Then run the tool from your project directory:
+
+```bash
+norm --help
+```
+
+For more information about package readmes and why they matter, see the [NuGet authoring best practices](https://aka.ms/nuget/authoring-best-practices/readme).

--- a/src/dotnet-norm/dotnet-norm.csproj
+++ b/src/dotnet-norm/dotnet-norm.csproj
@@ -12,7 +12,11 @@
     <Authors>Your Name</Authors>
     <Description>CLI tooling for nORM ORM framework</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\nORM.csproj" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta7.25380.108" />


### PR DESCRIPTION
## Summary
- add a package README for the dotnet-norm CLI tool and include it in the NuGet package
- reference the README in the tool’s csproj so package builds include the documentation

## Testing
- `dotnet build src/dotnet-norm/dotnet-norm.csproj` *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303ee12108832c92eb56a822a85497)