### PR TITLE
Fix compiled join projection for compiled join benchmark

### DIFF
--- a/benchmarks/OrmBenchmarks.cs
+++ b/benchmarks/OrmBenchmarks.cs
@@ -123,6 +123,7 @@ namespace nORM.Benchmarks
                 ctx.Query<BenchmarkUser>()
                     .Join(ctx.Query<BenchmarkOrder>(), u => u.Id, o => o.UserId, (u, o) => new { u.Name, o.Amount, o.ProductName })
                     .Where(x => x.Amount > amount)
+                    .Select(x => (object)new { x.Name, x.Amount, x.ProductName })
                     .Take(50));
 
         // ---------- SQLite PRAGMA helpers (applied uniformly once per connection) ----------


### PR DESCRIPTION
## Summary
- cast compiled join projection to object so materialization matches delegate type
- prevent InvalidCastException when executing Query_Join_nORM_Compiled benchmark

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305ca81a28832c9547b96c5391b6cc)