### PR TITLE
Fix list covariance crash in query provider

### DIFF
--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -370,7 +370,15 @@ namespace nORM.Query
                     }
                     else
                     {
-                        result = list;
+                        // FIX: Handle covariance for List<object> (e.g. casting List<AnonymousType> to List<object>)
+                        if (typeof(TResult) == typeof(List<object>) && list is not List<object>)
+                        {
+                            result = ((IEnumerable)list).Cast<object>().ToList();
+                        }
+                        else
+                        {
+                            result = list;
+                        }
                     }
                 }
                 return (TResult)result!;
@@ -439,7 +447,15 @@ namespace nORM.Query
                     }
                     else
                     {
-                        result = list;
+                        // FIX: Handle covariance for List<object> (e.g. casting List<AnonymousType> to List<object>)
+                        if (typeof(TResult) == typeof(List<object>) && list is not List<object>)
+                        {
+                            result = ((IEnumerable)list).Cast<object>().ToList();
+                        }
+                        else
+                        {
+                            result = list;
+                        }
                     }
                 }
                 return (TResult)result!;


### PR DESCRIPTION
Handle covariance for List<object> when casting from strongly-typed lists (e.g., List<AnonymousType> to List<object>). Generic lists are invariant in C#, so direct casts fail with InvalidCastException.

The fix detects when TResult is List<object> but the materialized result is a specific generic list, and performs the conversion using Cast<object>().ToList().

Changes:
- ExecuteInternalAsync: Added covariance check in else block (~line 373)
- ExecuteCompiledInternalAsync: Added same covariance check (~line 450)

This ensures zero overhead for standard strongly-typed queries while fixing the Query_Join_nORM_Compiled benchmark that returns anonymous types as List<object>.