### PR TITLE
Fix integer overflow in read replica load balancer

### DIFF
--- a/src/nORM/Core/ConnectionManager.cs
+++ b/src/nORM/Core/ConnectionManager.cs
@@ -240,8 +240,9 @@ namespace nORM.Core
         /// <returns>The selected replica node.</returns>
         private DatabaseTopology.DatabaseNode SelectOptimalReadReplica(IReadOnlyList<DatabaseTopology.DatabaseNode> replicas)
         {
-            var index = Interlocked.Increment(ref _readReplicaIndex);
-            return replicas[index % replicas.Count];
+            // FIX: Cast to uint to handle overflow (negative numbers) gracefully
+            var index = (uint)Interlocked.Increment(ref _readReplicaIndex);
+            return replicas[(int)(index % replicas.Count)];
         }
 
         private void RegisterFailure()


### PR DESCRIPTION
The SelectOptimalReadReplica method suffered from a critical integer overflow vulnerability. After ~2 billion read operations, _readReplicaIndex would overflow from int.MaxValue to int.MinValue. Since the modulo operator in C# preserves the sign, this resulted in negative array indices (e.g., int.MinValue % 3 = -2), causing ArgumentOutOfRangeException crashes.

Solution: Cast the incremented value to uint before the modulo operation. This ensures the value is always treated as positive. For example, (uint)int.MinValue becomes 2,147,483,648, and 2,147,483,648 % 3 = 2 (a valid positive index).

This fix prevents production crashes in high-throughput scenarios.