### PR TITLE
Fix compilation issues

### DIFF
--- a/src/nORM/Core/ChangeTracker.cs
+++ b/src/nORM/Core/ChangeTracker.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.ComponentModel;
+using Microsoft.Extensions.Logging;
 using nORM.Configuration;
 using nORM.Mapping;
 using RefComparer = System.Collections.Generic.ReferenceEqualityComparer;

--- a/src/nORM/Core/ConnectionManager.cs
+++ b/src/nORM/Core/ConnectionManager.cs
@@ -458,11 +458,12 @@ namespace nORM.Core
                 // RELIABILITY FIX: Use Task.WaitAsync instead of Task.Wait to avoid potential deadlock
                 // Task.Wait() can deadlock in certain SynchronizationContext scenarios (e.g., WPF, WinForms)
                 // WaitAsync with timeout is safer and works correctly in all contexts
-                if (!_healthCheckTask.WaitAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult())
-                {
-                    // Task didn't complete in time, but we've already canceled it.
-                    // The cancellation token will eventually cause it to exit.
-                }
+                _healthCheckTask.WaitAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
+            }
+            catch (TimeoutException)
+            {
+                // Task didn't complete in time, but we've already canceled it.
+                // The cancellation token will eventually cause it to exit.
             }
             catch
             {

--- a/src/nORM/Core/DbContext.cs
+++ b/src/nORM/Core/DbContext.cs
@@ -46,7 +46,7 @@ namespace nORM.Core
         // across all DbContext instances in the application.
         // MEMORY LEAK FIX: Use LRU cache instead of unbounded ConcurrentDictionary to prevent
         // unbounded memory growth as new dynamic types are generated
-        private static readonly ConcurrentLruCache<string, Lazy<Task<Type>>> _dynamicTypeCache = new(capacity: 1000);
+        private static readonly ConcurrentLruCache<string, Lazy<Task<Type>>> _dynamicTypeCache = new(maxSize: 1000);
         private readonly LinkedList<WeakReference<IDisposable>> _disposables = new();
         private readonly object _disposablesLock = new();
         private readonly Timer _cleanupTimer;

--- a/src/nORM/Core/TransactionManager.cs
+++ b/src/nORM/Core/TransactionManager.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace nORM.Core
 {
@@ -65,7 +66,9 @@ namespace nORM.Core
             if (ownsTransaction)
             {
                 await context.EnsureConnectionAsync(ct).ConfigureAwait(false);
-                transaction = await context.Connection.BeginTransactionAsync(ct).ConfigureAwait(false);
+                var connection = context.Connection ?? throw new InvalidOperationException("Database connection is not initiali
+zed.");
+                transaction = await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
 
                 // Create a CTS that cancels if the ambient token cancels.
                 cts = CancellationTokenSource.CreateLinkedTokenSource(ct);

--- a/src/nORM/Query/ExpressionToSqlVisitor.cs
+++ b/src/nORM/Query/ExpressionToSqlVisitor.cs
@@ -722,14 +722,10 @@ namespace nORM.Query
                 // Variable path: escape the value at runtime to prevent SQL injection
                 var escChar = NormValidator.ValidateLikeEscapeChar(visitor._provider.LikeEscapeChar);
                 visitor._sql.Append("CONCAT('%', ");
-                var paramBuilder = new StringBuilder();
-                var tempVisitor = new ExpressionToSqlVisitor(visitor._provider, visitor._parameters, visitor._paramIndex);
-                tempVisitor.Visit(node.Arguments[0]);
-                var escapedSql = visitor._provider.GetLikeEscapeSql(tempVisitor._sql.ToString());
+                var escapedSql = visitor._provider.GetLikeEscapeSql(visitor.GetSql(node.Arguments[0]));
                 visitor._sql.Append(escapedSql);
                 visitor._sql.Append(", '%')");
                 visitor._sql.Append($" ESCAPE '{escChar}'");
-                visitor._paramIndex = tempVisitor._paramIndex;
             }
         }
         private static void HandleStringStartsWith(ExpressionToSqlVisitor visitor, MethodCallExpression node)
@@ -750,13 +746,10 @@ namespace nORM.Query
                 // Variable path: escape the value at runtime to prevent SQL injection
                 var escChar = NormValidator.ValidateLikeEscapeChar(visitor._provider.LikeEscapeChar);
                 visitor._sql.Append("CONCAT(");
-                var tempVisitor = new ExpressionToSqlVisitor(visitor._provider, visitor._parameters, visitor._paramIndex);
-                tempVisitor.Visit(node.Arguments[0]);
-                var escapedSql = visitor._provider.GetLikeEscapeSql(tempVisitor._sql.ToString());
+                var escapedSql = visitor._provider.GetLikeEscapeSql(visitor.GetSql(node.Arguments[0]));
                 visitor._sql.Append(escapedSql);
                 visitor._sql.Append(", '%')");
                 visitor._sql.Append($" ESCAPE '{escChar}'");
-                visitor._paramIndex = tempVisitor._paramIndex;
             }
         }
         private static void HandleStringEndsWith(ExpressionToSqlVisitor visitor, MethodCallExpression node)
@@ -777,13 +770,10 @@ namespace nORM.Query
                 // Variable path: escape the value at runtime to prevent SQL injection
                 var escChar = NormValidator.ValidateLikeEscapeChar(visitor._provider.LikeEscapeChar);
                 visitor._sql.Append("CONCAT('%', ");
-                var tempVisitor = new ExpressionToSqlVisitor(visitor._provider, visitor._parameters, visitor._paramIndex);
-                tempVisitor.Visit(node.Arguments[0]);
-                var escapedSql = visitor._provider.GetLikeEscapeSql(tempVisitor._sql.ToString());
+                var escapedSql = visitor._provider.GetLikeEscapeSql(visitor.GetSql(node.Arguments[0]));
                 visitor._sql.Append(escapedSql);
                 visitor._sql.Append(")");
                 visitor._sql.Append($" ESCAPE '{escChar}'");
-                visitor._paramIndex = tempVisitor._paramIndex;
             }
         }
         // REFACTOR (TASK 16): Removed redundant IMethodTranslator interface and translator classes.

--- a/src/nORM/Query/QueryExecutor.cs
+++ b/src/nORM/Query/QueryExecutor.cs
@@ -16,6 +16,8 @@ using nORM.SourceGeneration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
+#pragma warning disable IDE0130
+
 namespace nORM.Query
 {
     /// <summary>


### PR DESCRIPTION
## Summary
- update expression visitor string translations to reuse existing SQL builder without missing constructor parameters
- guard transaction creation with a validated connection and enable logging extensions
- fix connection manager timeout handling and correct cache initialization parameter

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69314726ba8c832c8ef65e9f06734b8c)