### PR TITLE
Fix compile warnings and syntax issues

### DIFF
--- a/src/nORM/Core/TransactionManager.cs
+++ b/src/nORM/Core/TransactionManager.cs
@@ -66,8 +66,7 @@ namespace nORM.Core
             if (ownsTransaction)
             {
                 await context.EnsureConnectionAsync(ct).ConfigureAwait(false);
-                var connection = context.Connection ?? throw new InvalidOperationException("Database connection is not initiali
-zed.");
+                var connection = context.Connection ?? throw new InvalidOperationException("Database connection is not initialized.");
                 transaction = await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
 
                 // Create a CTS that cancels if the ambient token cancels.


### PR DESCRIPTION
## Summary
- correct the transaction initialization exception message formatting
- reorder dependent query helper parameters to place the cancellation token last and make stitching helper static
- streamline child-fetch SQL construction and collection initializations

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69314b3b1760832c95111f96eaa1cc42)