### PR TITLE
Handle null comparisons in count fast path

### DIFF
--- a/src/nORM/Query/NormQueryProvider.cs
+++ b/src/nORM/Query/NormQueryProvider.cs
@@ -790,14 +790,19 @@ namespace nORM.Query
                     return false;
 
                 var paramName = _ctx.Provider.ParamPrefix + "p0";
-                whereClause = $" WHERE {column.EscCol} = {paramName}";
+                if (!ExpressionValueExtractor.TryGetConstantValue(be.Right, out var value))
+                    return false;
 
-                if (populateParameters)
+                if (value is null)
                 {
-                    if (!ExpressionValueExtractor.TryGetConstantValue(be.Right, out var value))
-                        return false;
+                    whereClause = $" WHERE {column.EscCol} IS NULL";
+                }
+                else
+                {
+                    whereClause = $" WHERE {column.EscCol} = {paramName}";
 
-                    parameters[paramName] = value!;
+                    if (populateParameters)
+                        parameters[paramName] = value;
                 }
 
                 return true;


### PR DESCRIPTION
## Summary
- update count fast-path predicate handling to translate null equality comparisons to IS NULL
- avoid binding parameters for null predicates while preserving parameterized comparisons for non-null values

## Testing
- not run (dotnet CLI unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693175b39a74832c8c67f9634a8cc2af)