### PR TITLE
Add runtime-backed string concatenation operator

### DIFF
--- a/Std.ml
+++ b/Std.ml
@@ -1,0 +1,9 @@
+(*
+   Standard string utilities.
+   String concatenation delegates to the runtime-provided __str_concat,
+   which is responsible for allocating an appropriately sized buffer.
+*)
+
+external __str_concat : string -> string -> string = "__str_concat"
+
+let ( + ) (lhs : string) (rhs : string) : string = __str_concat lhs rhs


### PR DESCRIPTION
## Summary
- add Std.ml string concatenation operator that delegates to runtime __str_concat
- note runtime handles buffer allocation for concatenated strings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69328d7eb928832caa85c2ca3013e324)